### PR TITLE
Updated 'Username + code' copy in Passwordless authentication doc

### DIFF
--- a/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
@@ -30,7 +30,7 @@ A OTP can be issued via email or phone, depending how you have set up authentica
    1. Select which applications will use this authentication method.
    2. Select **Save**.
 
-5. If you select the **Username+code** tile:
+5. If you select the **Username + code** tile:
 
    1. Select which applications will use this authentication method.
    2. Select **Save**.


### PR DESCRIPTION
# Explain your changes

Updated the copy in https://docs.kinde.com/authenticate/authentication-methods/passwordless-authentication/#set-up-passwordless-authentication so that it says 'username + code' (with spaces)

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
