### PR TITLE
Make sure hash links open in the same page

### DIFF
--- a/plugins/rehype-external-links.mjs
+++ b/plugins/rehype-external-links.mjs
@@ -1,18 +1,20 @@
 import {visit} from "unist-util-visit";
 
 export const rehypeExternalLinks = () => {
-    return (tree) => {
-        visit(tree, "element", (node) => {
-            if (node.tagName === "a") {
-                if (
-                  !node.properties.class?.includes("rehype-anchor-link") &&
-                  !node.properties.href?.includes("kinde.com") &&
-                  !node.properties.href?.startsWith("/")
-                ) {
-                  node.properties.target = "_blank";
-                  node.properties.rel = "noopener noreferrer";
-                }
-            }
-        });
-    };
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      if (node.tagName === "a") {
+        if (node.properties.href?.startsWith("#")) return;
+
+        if (
+          !node.properties.class?.includes("rehype-anchor-link") &&
+          !node.properties.href?.includes("kinde.com") &&
+          !node.properties.href?.startsWith("/")
+        ) {
+          node.properties.target = "_blank";
+          node.properties.rel = "noopener noreferrer";
+        }
+      }
+    });
+  };
 };


### PR DESCRIPTION
When hash links are added without the path (e.g. `#test` vs `/path/to/page#test`), the custom `rehype` script to detect external links considers those links to be external. Added check to solve this issue.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

