### PR TITLE
Success page update Kinde without SDK

### DIFF
--- a/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
+++ b/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
@@ -60,6 +60,9 @@ Kinde supports all the standard OAuth 2 request parameters as well as a few addi
 
 Kinde also supports the PKCE extension, in which case the `code_challenge` and `code_challenge_method` parameters are also required. This is recommended for mobile apps and single page applications (SPAs).
 
+## Handling successful auth for desktop and mobile apps
+If you offer mobile and desktop apps, as well as access through a browser, you'll need to handle the post-authentication broser state. Rather than leaving a hannging screen, you can show users a success page. To do this, add the `is_use_auth_success_page` parameter to the authorization URL. See the [Request prameters](/developer-tools/about/using-kinde-without-an-sdk/#request-parameters) section below.
+
 ## Handling the callback
 
 As mentioned before when a user authenticates through Kinde, we will redirect them to the endpoint you defined in the previous step. As part of this redirect, Kinde provides an authorization `code` as a query parameter in the url.


### PR DESCRIPTION
A new parameter can be added to the authorization URL, so that browser signins that redirect to desktop or mobile apps, show a sign in success message. This PR includes an update tot he Kinde without an SDK topic.

See swarm card - https://www.notion.so/kinde/Native-auth-flow-success-page-1011d0d77e764251a108e3ef2137cb35?pvs=4

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
