### PR TITLE
Removed beta branch from actions

### DIFF
--- a/.github/workflows/check-for-duplicate-page-ids.yml
+++ b/.github/workflows/check-for-duplicate-page-ids.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - beta
 
 jobs:
   check-duplicates:

--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - beta
 
 jobs:
   validate-links:


### PR DESCRIPTION
## Description

Removed `beta` branch from gh actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to restrict triggers to the `main` branch only, removing the `beta` branch for pull request events.
	- Adjusted link validation processes to focus solely on the `main` branch during pull requests, potentially impacting link checks in other branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->