### PR TITLE
feat: Added package manager component for node based sdks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -107,7 +107,10 @@ export default defineConfig({
         "./src/components/SDKSelector.astro",
         "./src/components/YoutubeVideo.astro",
         "./src/components/Aside.astro",
-        "./src/components/FileTree.astro"
+        "./src/components/FileTree.astro",
+        {
+          'starlight-package-managers': ['PackageManagers']
+        }
       ]
     }),
     mdx() // Typically, with Starlight we wouldn't need to add `mdx`, but the `astro-auto-import` was throwing warnings https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.23.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rehype-slug": "^6.0.0",
         "satori": "^0.10.11",
         "satori-html": "^0.3.2",
+        "starlight-package-managers": "^0.6.0",
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
@@ -7626,6 +7627,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/starlight-package-managers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/starlight-package-managers/-/starlight-package-managers-0.6.0.tgz",
+      "integrity": "sha512-2tE0B4ZVEZXZ1LJjcSvVXLfJP8SB2nE+nhiFgSa3fuHUPtnbzmFxLVp7jEKD8jaMXKWPYtlNTy95gJSK9W1sbQ==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.22.0",
+        "astro": ">=4.2.7"
+      }
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rehype-slug": "^6.0.0",
     "satori": "^0.10.11",
     "satori-html": "^0.3.2",
+    "starlight-package-managers": "^0.6.0",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/src/content/docs/developer-tools/sdks/backend/apollo-graphql.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/apollo-graphql.mdx
@@ -34,11 +34,7 @@ You can use our Node.js SDK to secure your endpoints and check that the user is 
 
 ### **Add Kinde Node as a dependency**
 
-```bash
-npm i @kinde-oss/kinde-node
-yarn add @kinde-oss/kinde-node
-pnpm i @kinde-oss/kinde-node
-```
+<PackageManagers pkg="@kinde-oss/kinde-node" />
 
 ### **Environments**
 

--- a/src/content/docs/developer-tools/sdks/backend/express-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/express-sdk.mdx
@@ -20,11 +20,7 @@ You can view Kinde’s [Express JS docs](https://github.com/kinde-oss/kinde-nod
 
 ### Add Kinde ExpressJS SDK as a dependency
 
-```bash
-npm i @kinde-oss/kinde-node-express
-yarn add @kinde-oss/kinde-node-express
-pnpm i @kinde-oss/kinde-node-express
-```
+<PackageManagers pkg="@kinde-oss/kinde-node-express" />
 
 ### Integrate with your app
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdk.mdx
@@ -35,11 +35,7 @@ The easiest way to get started is to use the [Next.js starter kit](https://githu
 
 ## **Install for existing project**
 
-```bash
-npm i @kinde-oss/kinde-auth-nextjs
-yarn add @kinde-oss/kinde-auth-nextjs
-pnpm i @kinde-oss/kinde-auth-nextjs
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-nextjs" />
 
 ## **Set callback URLs**
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdkv1.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdkv1.mdx
@@ -23,11 +23,7 @@ Whilst technically this SDK is compatible with Next.js 13, it isn’t optimal. I
 
 ## **Installation**
 
-```shell
-npm i @kinde-oss/kinde-auth-nextjs@1
-yarn add @kinde-oss/kinde-auth-nextjs@1
-pnpm i @kinde-oss/kinde-auth-nextjs@1
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-nextjs@1" />
 
 ## **Set callback URLs**
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
@@ -30,11 +30,7 @@ The easiest way to get started is to use the [Next.js starter kit](https://githu
 
 ## **Install for an existing project**
 
-```bash
-npm i @kinde-oss/kinde-auth-nextjs
-yarn add @kinde-oss/kinde-auth-nextjs
-pnpm i @kinde-oss/kinde-auth-nextjs
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-nextjs" />
 
 ## **Set callback URLs**
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdkv1.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdkv1.mdx
@@ -28,11 +28,7 @@ You can also view the [Next.js docs](https://github.com/kinde-oss/kinde-auth-ne
 
 ## **Installation**
 
-```shell
-npm i @kinde-oss/kinde-auth-nextjs@1
-yarn add @kinde-oss/kinde-auth-nextjs@1
-pnpm i @kinde-oss/kinde-auth-nextjs@1
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-nextjs@1" />
 
 ## **Set callback URLs**
 

--- a/src/content/docs/developer-tools/sdks/backend/node-express-graphql.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/node-express-graphql.mdx
@@ -31,11 +31,7 @@ If you don’t yet have a front end setup, please set this up first following th
 
 ### **Add Kinde Node as a dependency**
 
-```bash
-npm i @kinde-oss/kinde-node
-yarn add @kinde-oss/kinde-node
-pnpm i @kinde-oss/kinde-node
-```
+<PackageManagers pkg="@kinde-oss/kinde-node" />
 
 ### **Integrate with your app**
 

--- a/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
@@ -21,11 +21,7 @@ You can view the [NodeJS docs](https://github.com/kinde-oss/kinde-nodejs-sdk) a
 
 ## Install
 
-```bash
-npm i @kinde-oss/kinde-nodejs-sdk --save
-yarn add @kinde-oss/kinde-nodejs-sdk --save
-pnpm i @kinde-oss/kinde-nodejs-sdk --save
-```
+<PackageManagers pkg="@kinde-oss/kinde-nodejs-sdk" />
 
 ## Configure Kinde
 

--- a/src/content/docs/developer-tools/sdks/backend/remix-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/remix-sdk.mdx
@@ -20,11 +20,7 @@ The Remix SDK works with back end applications. Create one in Kinde. See [Add an
 
 ## Install the Kinde Remix SDK into your Remix project
 
-```shell
-npm i @kinde-oss/kinde-remix-sdk
-yarn add @kinde-oss/kinde-remix-sdk
-pnpm i @kinde-oss/kinde-remix-sdk
-```
+<PackageManagers pkg="@kinde-oss/kinde-remix-sdk" />
 
 ## **Set callback URLs**
 

--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -28,11 +28,7 @@ If you haven’t already got a Kinde account, [register for free here](https://
 
 ## Install
 
-```bash
-npm i @kinde-oss/kinde-auth-sveltekit
-yarn add @kinde-oss/kinde-auth-sveltekit
-pnpm i @kinde-oss/kinde-auth-sveltekit
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-sveltekit" />
 
 ## Configure Kinde
 

--- a/src/content/docs/developer-tools/sdks/backend/typescript-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/typescript-sdk.mdx
@@ -26,11 +26,7 @@ If you haven’t already got a Kinde account, [register for free here](https://
 
 ## Install
 
-```bash
-npm i @kinde-oss/kinde-typescript-sdk
-yarn add @kinde-oss/kinde-typescript-sdk
-pnpm i @kinde-oss/kinde-typescript-sdk
-```
+<PackageManagers pkg="@kinde-oss/kinde-typescript-sdk" />
 
 ## Configure Kinde
 

--- a/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
@@ -37,11 +37,7 @@ As part of your development process, we highly recommend you create a developme
 
 ### Installation
 
-```shell
-npm i @kinde-oss/kinde-auth-pkce-js
-yarn add @kinde-oss/kinde-auth-pkce-js
-pnpm i @kinde-oss/kinde-auth-pkce-js
-```
+<PackageManagers pkg="@kinde-oss/kinde-auth-pkce-js" />
 
 ### **Integrate with your app**
 

--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -24,11 +24,7 @@ If you haven’t already got a Kinde account, [register for free here](https://
 
 ### Installation
 
-```bash
-npm i @kinde-oss/kinde-auth-react
-yarn add @kinde-oss/kinde-auth-react
-pnpm i @kinde-oss/kinde-auth-react
-```
+<PackageManagers pkg=" @kinde-oss/kinde-auth-react" />
 
 ## **Integrate with your app**
 

--- a/src/content/docs/developer-tools/sdks/native/expo-react-native.mdx
+++ b/src/content/docs/developer-tools/sdks/native/expo-react-native.mdx
@@ -22,7 +22,7 @@ Use this document for Expo and React Native.
 
 To use just React Native, see [React Native SDK](/developer-tools/sdks/native/react-native-sdk/). You can also view the [React Native docs](https://github.com/kinde-oss/kinde-react-native-sdk-0-7x) and [React Native starter kit](https://github.com/kinde-oss/kinde-react-native-sdk-0-7x) in GitHub.
 
-We are working on creating an updated Expo package (it is being tested) and we will add a link here when it's ready. 
+We are working on creating an updated Expo package (it is being tested) and we will add a link here when it's ready.
 
 ## Register for Kinde
 
@@ -36,11 +36,7 @@ Follow [the installation instructions for your chosen OS](https://reactnative.d
 
 ## **Installation with Expo Managed Workflow**
 
-```shell
-npm i @kinde-oss/react-native-sdk-0-7x
-yarn add @kinde-oss/react-native-sdk-0-7x
-pnpm i @kinde-oss/react-native-sdk-0-7x
-```
+<PackageManagers pkg="@kinde-oss/react-native-sdk-0-7x" />
 
 ## **Installation with Bare React Native**
 
@@ -48,19 +44,14 @@ pnpm i @kinde-oss/react-native-sdk-0-7x
 
 1. The SDK can be installed using your package manager or `expo` cli
 
-   ```shell
-   # npm
-   npm i @kinde-oss/react-native-sdk-0-7x
-   # yarn
-   yarn add @kinde-oss/react-native-sdk-0-7x
-   # pnpm
-   pnpm i @kinde-oss/react-native-sdk-0-7x
+   <PackageManagers pkg="@kinde-oss/react-native-sdk-0-7x" title="With package managers" />
 
-   # With Expo CLI
+   ```shell title="With Expo CLI"
    expo install @kinde-oss/react-native-sdk-0-7x
-   # With Expo CLI (npx)
-   npx expo install @kinde-oss/react-native-sdk-0-7x
+   ```
 
+   ```shell title="With Expo CLI (npx)"
+   npx expo install @kinde-oss/react-native-sdk-0-7x
    ```
 
 2. Configure the deep link support for your app

--- a/src/content/docs/developer-tools/sdks/native/react-native-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/native/react-native-sdk.mdx
@@ -58,11 +58,7 @@ Fundamentally, both SDK versions have equivalent functionality, so there should 
 
 ## **Installation**
 
-```shell
-npm i @kinde-oss/react-native-sdk-0-7x
-yarn add @kinde-oss/react-native-sdk-0-7x
-pnpm i @kinde-oss/react-native-sdk-0-7x
-```
+<PackageManagers pkg="@kinde-oss/react-native-sdk-0-7x" />
 
 ### **Android**
 

--- a/src/content/docs/integrate/webhooks/webhooks-nextjs.mdx
+++ b/src/content/docs/integrate/webhooks/webhooks-nextjs.mdx
@@ -42,14 +42,7 @@ Kinde sends webhooks as JWT’s to make them both easy and secure. In this examp
 
 2. Install the dependencies.
 
-   ```bash
-   #npm
-   npm i jwks-rsa jsonwebtoken
-   #yarn
-   yarn add jwks-rsa jsonwebtoken
-   #pnpm
-   pnpm i jwks-rsa jsonwebtoken
-   ```
+   <PackageManagers pkg="jwks-rsa jsonwebtoken" />
 
 3. Update your file as follows:
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -453,3 +453,29 @@ ol + ol li aside,
 ol + ol li blockquote {
   margin-inline-start: 20px;
 }
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] {
+  @apply pt-3;
+}
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] ul[role="tablist"] {
+  @apply border-b-[1px] border-b-kinde-grey-100 dark:border-b-kinde-grey-800;
+}
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] a[role="tab"] {
+  @apply text-sm text-kinde-grey-600 dark:text-kinde-grey-200 py-2 border-b-kinde-grey-100 dark:border-b-kinde-grey-800;
+}
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] a[role="tab"] svg {
+  @apply opacity-55;
+}
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] a[role="tab"][aria-selected="true"] {
+  @apply font-medium text-black dark:text-white opacity-100 border-black border-b-[1px] dark:border-white;
+}
+
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"]
+  a[role="tab"][aria-selected="true"]
+  svg {
+  @apply opacity-100;
+}


### PR DESCRIPTION
Add a package manager component so users can switch between `npm`, `yarn` and `pnpm` code snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for package managers in the configuration to enhance package management capabilities.
	- Introduced a `<PackageManagers>` component for installation instructions across various SDK documentation, simplifying the user experience.

- **Documentation**
	- Streamlined installation instructions by replacing command-line examples with a reusable component for multiple SDKs, enhancing readability and maintainability.

- **Style**
	- Updated styles for the `starlight-tabs` component to improve visual presentation and ensure consistency across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->