### PR TITLE
fix: update styles for Aside and FileTree

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -26,7 +26,9 @@ customHeaders:
           'sha256-VTPkflC5B5I/pI+/Q1cnJXif3W+asZRxhYQMwcr5c+0='
           'sha256-z/4EgkrJk25Kl8I32jIE2nzzxwYPdzJ3rWRiQXrBsAs='
           'sha256-rB9PWqOIDhTIEbtgV8wtIrUUMA+3cgqJjmr3TY9YCmM='
-          'sha256-Vii9e1JkzzWVI6DO0DGPlt+/UCyIQiJCZx6wVEuRWr0=' 'self'
+          'sha256-Vii9e1JkzzWVI6DO0DGPlt+/UCyIQiJCZx6wVEuRWr0='
+          'sha256-szfLSGiNWrV5m1Nr+g2tzKVstrJxYDPK80xA6gn8sT0='
+          'sha256-w+FQAT20sk+2ucj42Wx5kr5y8ZAHpGZ+K/rfwCpAbLk=' 'self'
           widgets.kinde.com kinde.com
       - key: Strict-Transport-Security
         value: max-age=31536000; includeSubDomains; preload

--- a/src/components/Aside.astro
+++ b/src/components/Aside.astro
@@ -78,19 +78,39 @@ const {type = "info", title} = Astro.props;
     @apply bg-kinde-purple-100 dark:bg-kinde-purple-500/40 text-kinde-purple-500 dark:text-kinde-purple-100;
   }
 
+  .c-aside :global(code) {
+    @apply px-[.4em] py-[.2em] text-sm rounded;
+  }
+
   .c-aside--info :global(code) {
-    @apply bg-kinde-blue-900/5 text-kinde-blue-900 border-none;
+    @apply bg-kinde-blue-900/5 text-kinde-blue-900;
+  }
+
+  :global([data-theme="dark"] .c-aside--info code) {
+    @apply bg-kinde-blue-900/60 text-white;
   }
 
   .c-aside--warning :global(code) {
-    @apply bg-kinde-amber-900/5 text-kinde-amber-900 border-none;
+    @apply bg-kinde-amber-900/5 text-kinde-amber-900;
+  }
+
+  :global([data-theme="dark"] .c-aside--warning code) {
+    @apply bg-kinde-amber-900/40 text-white;
   }
 
   .c-aside--danger :global(code) {
-    @apply bg-kinde-red-900/5 text-kinde-red-900 border-none;
+    @apply bg-kinde-red-900/5 text-kinde-red-900;
   }
 
-  :global(.c-aside--upgrade code) {
-    @apply bg-kinde-purple-500/5 text-kinde-purple-500 border-none dark:bg-kinde-purple-100;
+  :global([data-theme="dark"] .c-aside--danger code) {
+    @apply bg-kinde-red-900/60 text-white;
+  }
+
+  .c-aside--upgrade :global(code) {
+    @apply bg-kinde-purple-500/5 text-kinde-purple-500  dark:bg-kinde-purple-100;
+  }
+
+  :global([data-theme="dark"] .c-aside--upgrade code) {
+    @apply bg-kinde-purple-500/40 text-white;
   }
 </style>

--- a/src/components/FileTree.astro
+++ b/src/components/FileTree.astro
@@ -1,19 +1,37 @@
 ---
-import { FileTree as AstroFileTree } from "@astrojs/starlight/components";
+import {FileTree as AstroFileTree} from "@astrojs/starlight/components";
 ---
 
-<div class="not-content file-tree">
+<div class="c-file-tree not-content">
   <AstroFileTree>
     <slot />
   </AstroFileTree>
 </div>
 
 <style>
-  :global(.file-tree starlight-file-tree) {
-    @apply bg-kinde-grey-50 border-kinde-grey-200 rounded-2xl;
+  :global(.c-file-tree starlight-file-tree) {
+    @apply bg-kinde-grey-50 border-none rounded-lg;
   }
 
-  :global(.file-tree starlight-file-tree .tree-entry .highlight) {
+  :global([data-theme="dark"] .c-file-tree starlight-file-tree) {
+    @apply bg-kinde-grey-900 rounded-lg border-none;
+  }
+
+  :global(.c-file-tree starlight-file-tree .directory > details > summary:hover),
+  :global(.c-file-tree starlight-file-tree .directory > details > summary:hover svg) {
+    @apply text-black fill-black;
+  }
+
+  :global(
+      [data-theme="dark"] .c-file-tree starlight-file-tree .directory > details > summary:hover
+    ),
+  :global(
+      [data-theme="dark"] .c-file-tree starlight-file-tree .directory > details > summary:hover svg
+    ) {
+    @apply text-white fill-white;
+  }
+
+  :global(.c-file-tree starlight-file-tree .tree-entry .highlight) {
     @apply bg-kinde-grey-900;
   }
 </style>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -231,19 +231,11 @@ p {
 }
 
 .sl-markdown-content code:not(:where(.not-content *)) {
-  @apply bg-kinde-grey-50 dark:bg-kinde-grey-800;
+  @apply px-[.4em] py-[.2em] text-sm bg-kinde-grey-50 rounded border-kinde-grey-100 dark:border-kinde-grey-700 dark:bg-kinde-grey-800 border-[1px];
 }
 
-.sl-markdown-content p code {
-  @apply px-[.4em] py-[.2em] text-sm rounded border-kinde-grey-100 dark:border-kinde-grey-700 dark:bg-kinde-grey-800 border-[1px];
-}
-
-.sl-markdown-content blockquote code {
-  @apply bg-kinde-grey-100 border-kinde-grey-200 dark:bg-kinde-grey-800 dark:border-kinde-grey-700;
-}
-
-:is(:where([data-theme="dark"]) .sl-markdown-content code:not(:where(.not-content *))) {
-  @apply px-[.4em] py-[.2em] text-sm rounded border-kinde-grey-100 dark:border-kinde-grey-700 dark:bg-kinde-grey-800 border-[1px];
+.sl-markdown-content .c-aside.not-content code {
+  /* @apply bg-inherit; */
 }
 
 .sl-markdown-content .expressive-code * {


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)
<!-- Please describe the change you are proposing, and why -->

Update styles for `FileTree` and `Aside` components, especially for dark mode.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced security by adding new SHA256 hash values to the configuration for improved protection.
  
- **Style**
  - Updated styling for the `.c-aside` component to improve visual presentation of code snippets across themes.
  - Refined the file tree component's design with a new class name and improved hover states for better user experience.
  - Streamlined CSS for code elements within markdown content for a more consistent and visually appealing display.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->