### PR TITLE
Add missing curly bracket to API example node doc

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/api-example-node.mdx
+++ b/src/content/docs/developer-tools/kinde-api/api-example-node.mdx
@@ -58,6 +58,7 @@ If you don’t use Postman or other similar tools to test your connections, here
      console.log({data});
     } catch (err) {
      console.error(err);
+    }
    }
    ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Added a missing curly bracket to the code example #3 in the https://docs.kinde.com/developer-tools/kinde-api/api-example-node/ doc
