### PR TITLE
Fix: Org sign up refs and allow reg refs

### DIFF
--- a/src/content/docs/build/organizations/allow-user-signup-org.mdx
+++ b/src/content/docs/build/organizations/allow-user-signup-org.mdx
@@ -52,7 +52,7 @@ Users must belong to an organization to be assigned roles and permissions
 
 </Aside>
 
-1. Go to **Settings > Environment > Policies**.
+1. Go to **Organizations** and open the default organization.
 2. Scroll down and switch off the **Sign users up to the default organization if one can’t be detected** option.
 3. Select **Save**.
 
@@ -63,6 +63,12 @@ You can disable user self-sign up altogether. You might do this if you want to a
 1. Go to **Settings > Environment > Policies**.
 2. Switch off the **Allow users to sign up** option.
 3. Select **Save**. This setting applies to all apps in your business.
+
+<Aside type="warning">
+
+Leave this on if you plan to use [JIT provisioning for enterprise connections](/authenticate/enterprise-connections/provision-users-enterprise/).
+
+</Aside>
 
 ## Sign in experience for users in multiple organizations
 


### PR DESCRIPTION
Correction to the instructions for switching off sign ups to the default organization. Added a note to say JIT provisioning requires the general 'Allow sign up' switch to be on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user guidance for organization settings and user sign-up processes.
	- Added a warning regarding the importance of enabling the **Allow users to sign up** option for Just-In-Time (JIT) provisioning. 

- **Documentation**
	- Revised instructions for managing user sign-up policies to improve clarity and streamline access to settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->