### PR TITLE
Fix/ make it very clear about kinde v other scopes

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
+++ b/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
@@ -20,7 +20,7 @@ For example, you need a machine to machine application for connecting to [Kindeâ
 
 ## About scopes and the Kinde Management API
 
-Scopes must be defined in all applications you want to access the Kinde Management API. You can select scopes when you authorize a new application or you can add scopes to an existing application. See the relevant procedure below.
+Scopes must be defined in all applications you want to access the Kinde Management API. You can select scopes when you authorize a new application or you can add scopes to an existing application. We recommend adding as few scopes as you need, to maintain API security. See the relevant procedure below.
 
 ## Step 1: Add a machine to machine application
 

--- a/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
+++ b/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
@@ -1,6 +1,6 @@
 ---
 page_id: 6bf993fc-a195-4836-8eaf-133812be8876
-title: Add a machine to machine application
+title: Add a machine to machine application for API access
 sidebar:
   order: 2
 relatedArticles:

--- a/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
+++ b/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
@@ -18,6 +18,10 @@ Machine to machine applications facilitate token exchange between systems, appli
 
 For example, you need a machine to machine application for connecting to [Kinde’s Management API](https://kinde.com/api/docs/#kinde-management-api). See below for instructions.
 
+## About scopes and the Kinde Management API
+
+Scopes must be defined in all applications you want to access the Kinde Management API. You can select scopes when you authorize a new application or you can add scopes to an existing application. See the relevant procedure below.
+
 ## Step 1: Add a machine to machine application
 
 1. Go to **Settings > Applications.**
@@ -34,6 +38,16 @@ For example, you need a machine to machine application for connecting to [Kinde�
 5. Select the scopes you want to include in the token. For maximum security only enable the minimum scopes you require. 
 6. Select **Save**
 7. Next: [Get an access token for Kinde’s management API](/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api/).
+
+## Change or add scopes to an application accessing the Kinde Management API
+
+Follow this procedure if you already have an application and you experience a scope error or want to add scopes to an application.
+
+1. Go to **Settings > Applications** and select your application.
+2. On the left, select **APIs**.
+3. Select the three dots next to the Kinde management API, then choose **Manage scopes**. 
+4. Select the scopes you want to include in the token. For maximum security only enable the minimum scopes you require. 
+5. Select **Save**
 
 ## How M2M tokens are calculated in Kinde
 

--- a/src/content/docs/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api.mdx
+++ b/src/content/docs/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api.mdx
@@ -25,7 +25,9 @@ You can also watch a video about connecting and testing the API connection on ou
 
 ## Before you begin
 
-You need to have a [machine to machine application](/developer-tools/kinde-api/add-a-m2m-application-for-api-access/) set up and have the domain details, Client ID and Client secret on hand.
+You need to have:
+- a [machine to machine application](/developer-tools/kinde-api/add-a-m2m-application-for-api-access/) with all relevant Kinde API scopes selected.
+- have your application details, Client ID and Client secret on hand.
 
 ## Get the access token (Postman example)
 

--- a/src/content/docs/developer-tools/kinde-api/test-the-connection-to-kindes-api.mdx
+++ b/src/content/docs/developer-tools/kinde-api/test-the-connection-to-kindes-api.mdx
@@ -59,7 +59,7 @@ When you request to receive data back via the API and get an unexpected or `null
 5. Select **Save**.
 For more detailed information, see [Token customization](/build/tokens/token-customization/)
 
-## Review the requested scopes
+## Kinde Management API scope errors
 
 Access to Kinde's Management API is limited by scopes. When you create or update a M2M application, you need to review and select scopes. If you find that some information is not included in a returned token, check the scopes.
 

--- a/src/content/docs/developer-tools/your-apis/custom-api-scopes.mdx
+++ b/src/content/docs/developer-tools/your-apis/custom-api-scopes.mdx
@@ -11,13 +11,19 @@ relatedArticles:
 
 <Aside type="upgrade">
 
-You may need to [upgrade plans](/manage-your-account/profile-and-plan/change-kinde-plan/) to use this feature
+You must be on the [Kinde Plus or scale plan](https://kinde.com/pricing/) to use this feature.
 
 </Aside>
 
-Kinde lets you manage scopes for access to your APIs. Scopes define token permissions used by your APIs, and provide a reliable way to control access to API resources.
+Kinde lets you add custom scopes to help manage others who access to your APIs. Scopes define token permissions used by your APIs, and provide a reliable way to control access to your API resources. 
 
 You need to have [registered your APIs](/developer-tools/your-apis/register-manage-apis/) in Kinde to secure them using scopes.
+
+<Aside>
+
+Note that this topic is NOT about adding custom scopes for the Kinde Management API, it is only related to adding custom scopes to your own APIs. For information about Kinde Management API scopes, see [this topic](/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api/).
+
+</Aside>
 
 ## Benefits of using scopes
 

--- a/src/content/docs/developer-tools/your-apis/custom-api-scopes.mdx
+++ b/src/content/docs/developer-tools/your-apis/custom-api-scopes.mdx
@@ -11,7 +11,7 @@ relatedArticles:
 
 <Aside type="upgrade">
 
-You must be on the [Kinde Plus or scale plan](https://kinde.com/pricing/) to use this feature.
+You must be on the [Kinde Plus or Scale plan](https://kinde.com/pricing/) to use this feature.
 
 </Aside>
 


### PR DESCRIPTION
In response to a report of customer confusion, I made an update to multiple documents to make it very very clear about the difference between custom scopes for your own API and scopes being required for the Kinde Mangement API. I loaded H2 headings to be more searchable and scannable, hopefully getting any future customers headed the right way more quickly. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed sections on managing scopes for machine-to-machine applications in the Kinde Management API documentation.
	- Enhanced clarity on prerequisites for connecting to the Kinde API, emphasizing the need for specific application details.
	- Updated documentation on custom API scopes to clarify access requirements and management functionalities.

- **Documentation**
	- Improved readability and comprehension of existing documentation, focusing on scope errors and custom API management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->