### PR TITLE
Add success page param to no SDK docs

### DIFF
--- a/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
+++ b/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
@@ -181,6 +181,14 @@ Type: `boolean`
 
 Required: No
 
+### `has_success_page`
+
+Show a success page at end of auth flow, this is useful when the callback URL is not a web page
+
+Type: `boolean`
+
+Required: No
+
 ### `lang`
 
 For selecting the UI language.


### PR DESCRIPTION
#### Description (required)

Adding documentation detailing the `has_success_page` property of the auth flow

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `has_success_page`, to enhance the authentication flow by allowing users to display a success page after authentication. This option improves user experience, particularly when the callback URL does not lead to a web page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->