### PR TITLE
fix: link text on .NET SDK docs

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/dotnet-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/dotnet-sdk.mdx
@@ -16,7 +16,7 @@ head:
 
 The Kinde .NET SDK allows developers to quickly and securely integrate a new or an existing .NET application to the Kinde platform. The Kinde SDK is available from the Nuget package repository at [https://www.nuget.org/packages/Kinde.SDK](https://www.nuget.org/packages/Kinde.SDK)
 
-You can also view the [.NET docs](https://github.com/kinde-oss/kinde-dotnet-sdk) and [.NET starter kit](https://github.com/kinde-starter-kits/dotnet-starter-kit) in GitHub.
+You can also view the [.NET SDK](https://github.com/kinde-oss/kinde-dotnet-sdk) and [.NET starter kit](https://github.com/kinde-starter-kits/dotnet-starter-kit) in GitHub.
 
 ## Before you begin
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

The `.NET docs` link on the .NET SDK page links to the SDK, so updating the text to `.NET SDK`.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the terminology in the Kinde .NET SDK documentation for improved clarity by specifying "the .NET SDK" instead of "the .NET docs."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->