### PR TITLE
fix: remove commented out code

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -398,10 +398,6 @@ starlight-toc > nav > ul > li > a:hover span {
   @apply text-sm;
 }
 
-/* .sl-markdown-content tr p {
-  @apply text-sm;
-} */
-
 .sl-markdown-content tbody tr:nth-child(1n):not(:where(.not-content *)) {
   @apply bg-white dark:bg-black;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Remove commented out code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified CSS by removing unnecessary commented-out code related to text size styles for paragraphs in table rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->