### PR TITLE
Tweaks to custom domain pages

### DIFF
--- a/src/content/docs/build/domains/organization-custom-domain.mdx
+++ b/src/content/docs/build/domains/organization-custom-domain.mdx
@@ -53,9 +53,15 @@ Instructions will vary depending on your domain provider. Here’s the general p
     
     Once successfully provisioned, your custom domain will then be used for this organization. You will also receive email confirmation.
 
+<Aside type="warning">
+
+The challenge DNS record needs to remain in place after verification in order for us to renew your SSL certificate on an ongoing basis.
+
+</Aside>
+
 ## Step 4: Update provider social auth apps and codebase
 
-If the organization's users will use social authentication to sign in, update the provider apps such as Google or GitHub to include the custom domain callback (e.g. `account.mydomain.com/login/callback`) as an authorized redirect URI. How you do this will be different for each provider you use. 
+If the organization's users will use social authentication to sign in, update the provider apps such as Google or GitHub to include the custom domain callback (e.g. `account.example.com/login/callback`) as an authorized redirect URI. How you do this will be different for each provider you use. 
 
 Remember to also update your application's codebase to reference the custom domain.
 
@@ -70,13 +76,13 @@ It's important to include a subdomain for the procedure to work, e.g. `account.
 
 When you create the DNS records be sure to match the format and details provided in Kinde. 
 
-For example, if your custom domain is `account.mydomain.com`, then:
+For example, if your custom domain is `account.example.com`, then:
 
 Host = `account`
 
 Record type = `CNAME`
 
-Value = `account.mydomain.com`
+Value = `account.example.com`
 
 TTL = Leave as default
 
@@ -84,11 +90,11 @@ Routing policy = Leave as default
 
 ### Using multi-level subdomains
 
-If you are using a multi-level subdomain, like `multi.subdomain.domain.com`, how you set up DNS records will depend on how your zones are set up. 
+If you are using a multi-level subdomain, like `multi.subdomain.example.com`, how you set up DNS records will depend on how your zones are set up.
 
 The details provided in the admin console assumes the domain entered is adding a single level to your DNS zone, but if you are adding more than one level you’ll need to create others.
 
-So if your business is `blue.black.red.com`, you need to created a DNS entry for the custom domain `blue.back.red`, as well as an `_acme-challenge.blue.black.red` domain.
+So if your business is `multi.subdomain.example.com` and your zone is `example.com`, you need to create a DNS entry for `multi.subdomain`, as well as for `_acme-challenge.multi.subdomain`.
 
 ## Remove a custom domain for an organization
 

--- a/src/content/docs/build/domains/pointing-your-domain.mdx
+++ b/src/content/docs/build/domains/pointing-your-domain.mdx
@@ -13,7 +13,7 @@ app_context:
     s: custom_domain
 ---
 
-By default, Kinde issues a Kinde subdomain when you first register. But for your production environment you can use your own custom domain instead of Kinde’s as your URL. For example, `account.mydomain.com` instead of `mydomain.kinde.com`.
+By default, Kinde issues a Kinde subdomain when you first register. But for your production environment you can use your own custom domain instead of Kinde’s as your URL. For example, `account.example.com` instead of `mydomain.kinde.com`.
 
 There are a few reasons you may wish to do this.
 
@@ -29,7 +29,7 @@ Even if you use custom domains, you need to use your Kinde domain for Kinde Mana
 
 ## Before you begin
 
-- Name your custom domain. It needs to include a subdomain for this procedure to work. Common subdomain names include `account` , `id` , or `auth`, e.g. `account.mydomain.com`.
+- Name your custom domain. It needs to include a subdomain for this procedure to work. Common subdomain names include `account` , `id` , or `auth`, e.g. `account.example.com`.
 - Make sure your application is configured to use the exact custom domain. This includes updating the environment variables and any relevant configuration files. For example, the KINDE_ISSUER_URL needs to be updated to the custom domain.
 - Ensure that the callback and logout redirect URLs in your Kinde settings are updated with the custom domain. This can be done in the Kinde dashboard under Settings > Applications > [your app] > View details.
 
@@ -39,7 +39,7 @@ Note that the verification process can take anywhere from 5 minutes to a few hou
 
 1. Go to **Settings > Environment > Custom domain**.
 2. Select **Add custom domain**
-3. In the dialog, enter your custom domain. Be sure to include the subdomain, for example `account.mydomain.com`.
+3. In the dialog, enter your custom domain. Be sure to include the subdomain, for example `account.example.com`.
 4. Select **Save**. DNS details appear. You need to add these to your domain provider site.
 
 ## Add CNAME DNS records
@@ -63,6 +63,12 @@ Your domain will then be used instead of Kinde’s. You will also receive an ema
 
 If you encounter any errors, such as the verification taking too long, re-check the DNS records you created on your provider site, to ensure the details are correct.
 
+<Aside type="warning">
+
+The challenge DNS record needs to remain in place after verification in order for us to renew your SSL certificate on an ongoing basis.
+
+</Aside>
+
 ## Update your code
 
 - Update your code to use the custom domain.
@@ -82,11 +88,11 @@ When you use social connections to authenticate users, you need to add the callb
 />
 
 If you haven't set this up, follow these instructions for the [relevant social provider](/authenticate/social-sign-in/add-social-sign-in/).
-If you already have social auth set up, make sure you add the custom domain callback (e.g. `account.mydomain.com/login/callback` as an authorized redirect URI in the provider app.
+If you already have social auth set up, make sure you add the custom domain callback (e.g. `account.example.com/login/callback` as an authorized redirect URI in the provider app.
 
 ## Domains and auth end points
 
-Auth endpoints are available for both custom domains and your Kinde subdomain. You can get tokens from either end point, but they are not interchangeable. For example, if you get an ID and access token from `account.mydomain.com`, it cannot be used with `mydomain.kinde.com`.
+Auth endpoints are available for both custom domains and your Kinde subdomain. You can get tokens from either end point, but they are not interchangeable. For example, if you get an ID and access token from `account.example.com`, it cannot be used with `mydomain.kinde.com`.
 
 ## Local domain
 
@@ -96,13 +102,13 @@ Currently, Kinde only supports `*.localhost` for non-https traffic.
 
 When you create the DNS records for linking your own domain to Kinde, be sure to match the format you have used above.
 
-For example, if your custom domain is `account.mydomain.com`, then:
+For example, if your custom domain is `account.example.com`, then:
 
 Host = `account`
 
 Record type = `CNAME`
 
-Value = `account.mydomain.com`
+Value = `account.example.com`
 
 TTL = Leave as default
 
@@ -110,11 +116,11 @@ Routing policy = Leave as default
 
 ## Using multi-level subdomains
 
-If you are using a multi-level subdomain, like `multi.subdomain.domain.com`, how you set up DNS records will depend on how your zones are set up.
+If you are using a multi-level subdomain, like `multi.subdomain.example.com`, how you set up DNS records will depend on how your zones are set up.
 
 The details provided in the admin console assumes the domain entered is adding a single level to your DNS zone, but if you are adding more than one level you’ll need to create others.
 
-So if your business is `blue.black.red.com`, you need to created a DNS entry for the custom domain `blue.back.red`, as well as an `_acme-challenge.blue.black.red` domain.
+So if your business is `multi.subdomain.example.com` and your zone is `example.com`, you need to create a DNS entry for `multi.subdomain`, as well as for `_acme-challenge.multi.subdomain`.
 
 <img
   src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/ee01b968-bea8-4082-7680-cde0522fbf00/public"


### PR DESCRIPTION
#### Description (required)

- Tweaked the multi level subdomain text to be a bit more accurate
- Added a warning note that DNS records need to remain in place as we see lots of customers later removing them
- Changed domains referenced to `example.com` as that is what that domain is for according to various specs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for setting up custom domains, enhancing clarity on SSL certificate management.
	- Standardized examples by replacing `mydomain.com` with `example.com` to avoid confusion.
	- Added a warning about retaining the challenge DNS record post-verification for SSL renewal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->