### PR TITLE
Updating documentation to split between company and product security

### DIFF
--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -40,10 +40,6 @@ This is similar to how Google manages authentication for `calendar.google.com`, 
 
 See also, [Manage authentication across applications](/authenticate/manage-authentication/user-auth-applications/).
 
-## Password security
-
-If your business is set up so users sign in with passwords, you can be assured that Kinde uses a hashing algorithm and never stores passwords as text. Specifically, we use Blowfish for hashing, both in transit and at rest.
-
 ## Rate limiting if third party keys not entered
 
 When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/) or enterprise sign in like [SAML](/authenticate/enterprise-connections/custom-saml/), ensure you have added the third party Client ID and Client Secret (Keys) to the configuration screens in your live environment. If you don’t enter these details, Kinde will fallback to use our own credentials as proxy and this will cause rate limiting. This is okay for local development environments, but not for live production environments.

--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -26,8 +26,6 @@ The password needs to be at least 8 characters and popular passwords are blocked
 
 Users will be prompted to verify their email address when they first sign up, using a one time code.
 
-Kinde uses a secure hashing algorithm and never stores passwords as text. Specifically, we use Blowfish for hashing, both in transit and at rest.
-
 <Aside type="warning">
 
 If you switch your users from passwordless to password, Kinde will first check if a password exists for the user when they next sign in. If a password doesn't exist, we verify the email address and ask user to set the password. The next time they sign in, they will use the email + password. Note that they enter their password on a different screen to their email.

--- a/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
+++ b/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
@@ -55,9 +55,9 @@ If your business is set up so users sign in with passwords, you can be assured t
 
 Kinde has implemented an application level rate limit and throttle. This helps protect our shared infrastructure and our customers from excessive network traffic that could lead to an outage. Our rate limits are tuned based on the type of traffic, such as API, admin pages, or general auth usage, and will limit the number of connections from an IP in a short space of time. This generally covers all interactions for our service.
 
-## Device fingerprinting prevents session highjacking
+## Device fingerprinting prevents session hijacking
 
-Kinde implements a method of device fingerprinting during the authentication flow to block the transfer of sessions between different browsers or devices that could lead to [session highjacking](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
+Kinde implements a method of device fingerprinting during the authentication flow to block the transfer of sessions between different browsers or devices that could lead to [session hijacking](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
 
 ## Enforcement of TLS version and ciphers
 

--- a/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
+++ b/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
@@ -8,11 +8,23 @@ relatedArticles:
   - 162a0888-6b7f-439e-9ba2-7b2c491fc95b
 ---
 
-Here’s some of the practices, standards, and methods we use to keep your data, and user’s data secure.
+Here’s some of the practices, standards, and methods we use to keep your data, and user’s data secure. 
 
 ## Auth pages require known origins in the callback URL
 
 To help prevent [XSS attacks](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html), all authentication pages require a [callback URL](/get-started/connect/callback-urls/) to be set in Kinde. Authentication does not work correctly without them. Our application will check the callback URLs and parse out the domain for an origin check.
+
+## Bot detection
+
+Native bot detection is on the roadmap, which will allow customers to bring their own Cloudflare integration key to apply bot detection and protections directly to their Kinde hosted auth pages. This will allow customers to adjust the level of protection based on their own risk profile. Please see our [roadmap](https://updates.kinde.com/board) for updates.
+
+To protect against bot driven volumetric attacks, we use AWS WAF to block traffic that matches OWASP threat rules, known malicious IP addresses, and AWS managed rules. 
+
+Alternatively, customers can implement bot detection and CAPTCHA if your DNS is hosted via Cloudflare. Kinde's hosted pages, with a custom domain, can be proxied through Cloudflare to incorporate their advanced web attack protection features, including bot detection and Cloudflare's Turnstile (Cloudflare's equivalent to CAPTCHA). Please see [Proxy your Kinde auth pages through Cloudflare](/authenticate/custom-configurations/proxy-your-kinde-auth-pages-through-cloudflare) for more information.
+
+## Credential stuffing protection
+
+Kinde protects from credential stuffing attacks with a combination of techniques. To protect against volumetric attacks, we use AWS WAF to block traffic that matches OWASP threat rules and also use our own application throttling. To protect against password brute forcing, we will automatically lock out accounts after 5 consecutive failed attempts of the password or passwordless code (OTP, password, or multi-factor authentication) for a short period of time. Admins can manually unlock accounts if necessary. Bot detection (see previous section) can be used to provide additional protection.
 
 ## CSRF protections via `state` parameter
 
@@ -35,13 +47,13 @@ Kinde provides a baseline password protection policy for any customer who wants 
 
 Note that Kinde recommends, where possible, not using passwords for authentication and instead using [passwordless](/authenticate/about-auth/authentication-methods/#passwordless) or [social](/authenticate/social-sign-in/add-social-sign-in/) integrations. If using passwords for authentication, we recommend adding [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) as an option for users.
 
-## Outage mitigation via rate limits and throttles
+## Denial of service mitigation via rate limits and throttles
 
 Kinde has implemented an application level rate limit and throttle. This helps protect our shared infrastructure and our customers from excessive network traffic that could lead to an outage. Our rate limits are tuned based on the type of traffic, such as API, admin pages, or general auth usage, and will limit the number of connections from an IP in a short space of time. This generally covers all interactions for our service.
 
-## Fingerprinting prevents session highjacking
+## Device fingerprinting prevents session highjacking
 
-Kinde implements a method of fingerprinting during the authentication flow to block the transfer of sessions between different browsers that could lead to [session highjacking](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
+Kinde implements a method of device fingerprinting during the authentication flow to block the transfer of sessions between different browsers or devices that could lead to [session highjacking](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
 
 ## Enforcement of TLS version and ciphers
 
@@ -66,6 +78,6 @@ Kinde uses various techniques to help prevent the execution of unknown third par
 
 Kinde’s server rendered application encodes output by default, which prevents most opportunities to inject HTML. The Content Security Policy configured across our webpages prevents the execution of inline and third party scripts.
 
-## We have a WAF
+## Blocking malicious traffic with our WAF
 
-Kinde was implemented a web access firewall ([WAF](https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.html#web-application-firewall)) across all of our public-facing websites and API endpoints. This blocks known malicious traffic patterns and high threat IP addresses.
+Kinde has implemented a web application firewall ([WAF](https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.html#web-application-firewall)) across all of our public-facing websites and API endpoints. We use AWS WAF to block traffic that matches OWASP threat rules, known malicious IP addresses, and AWS managed rules. 

--- a/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
+++ b/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
@@ -47,6 +47,10 @@ Kinde provides a baseline password protection policy for any customer who wants 
 
 Note that Kinde recommends, where possible, not using passwords for authentication and instead using [passwordless](/authenticate/about-auth/authentication-methods/#passwordless) or [social](/authenticate/social-sign-in/add-social-sign-in/) integrations. If using passwords for authentication, we recommend adding [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) as an option for users.
 
+## Password security
+
+If your business is set up so users sign in with passwords, you can be assured that Kinde uses a hashing algorithm and never stores passwords as text. Specifically, we use bcrypt for hashing of passwords in our database.
+
 ## Denial of service mitigation via rate limits and throttles
 
 Kinde has implemented an application level rate limit and throttle. This helps protect our shared infrastructure and our customers from excessive network traffic that could lead to an outage. Our rate limits are tuned based on the type of traffic, such as API, admin pages, or general auth usage, and will limit the number of connections from an IP in a short space of time. This generally covers all interactions for our service.

--- a/src/content/docs/trust-center/security/security-at-kinde.mdx
+++ b/src/content/docs/trust-center/security/security-at-kinde.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 relatedArticles:
   - 836bfb61-5d32-4110-b33c-c43764f05162
+  - 54d44f6d-3942-4e10-9299-df61b2817b9f
 ---
 
 Kinde takes security threats very seriously as the integrity, confidentiality, and availability of our systems potentially impact our customers. If you have detected a security threat or vulnerability against Kinde systems or personnel, please reach out to your account manager or to the security mailing group at [security@kinde.com](mailto:security@kinde.com).

--- a/src/content/docs/trust-center/security/security-at-kinde.mdx
+++ b/src/content/docs/trust-center/security/security-at-kinde.mdx
@@ -63,7 +63,3 @@ All Kinde source code is managed by a company managed source code repository. So
 Production services are deployed through a CICD pipeline using container technology. Server builds are done at least once a week and replace the existing servers. The build process will use the latest patched container host and container image to reduce the risk of vulnerabilities due to unpatched software.
 
 All container images are scanned at build using AWS Inspector for dependencies and third party library vulnerabilities. External production URLs and any public facing cloud IP addresses are scanned weekly for vulnerabilities by Intruder. All vulnerability reports are triaged, analysed, and assigned to the engineering team for remediation based on vulnerability management SLAs.
-
-## Changes to this document
-
-Last updated 12 June, 2024.

--- a/src/content/docs/trust-center/security/security-at-kinde.mdx
+++ b/src/content/docs/trust-center/security/security-at-kinde.mdx
@@ -10,25 +10,13 @@ relatedArticles:
 
 Kinde takes security threats very seriously as the integrity, confidentiality, and availability of our systems potentially impact our customers. If you have detected a security threat or vulnerability against Kinde systems or personnel, please reach out to your account manager or to the security mailing group at [security@kinde.com](mailto:security@kinde.com).
 
-## **Availability**
+## Availability
 
 Kinde production services are designed to be resistant to failure with multiple front-end servers and replicated back-end databases. Our main production databases are provisioned, but we use serverless for some supporting roles.
 
 All services are setup in AWS and are configured to use multiple availability zones for redundancy. Please refer to the [Kinde status page](https://status.kinde.com/) for uptime metrics.
 
-## Bot detection
-
-Native bot detection is on the roadmap, which will allow customers to bring their own Cloudflare integration key to apply bot detection and protections directly to their Kinde hosted auth pages. This will allow customers to adjust the level of protection based on their own risk profile. Please see our [roadmap](https://updates.kinde.com/board) for updates.
-
-Alternatively, customers can implement bot detection and CAPTCHA if your DNS is hosted via Cloudflare. Kinde's hosted pages, with a custom domain, can be proxied through Cloudflare to incorporate advanced web attack protection features, including bot detection and Cloudflare's Turnstile (Cloudflare's equivalent to CAPTCHA).
-
-## Brute force protection
-
-Kinde protects from brute force attacks with a combination of techniques. To protect against volumetric attacks, we use AWS WAF to block traffic that matches OWASP threat rules and also use our own application throttling. To protect against password brute forcing, we will automatically lock out accounts after 5 consecutive failed attempts of the passwordless code (OTP, password, or multi-factor authentication code for a short period of time. Admins can manually unlock accounts if necessary.
-
-Suspicious IPs performing large scale scanning and probing will automatically blocked for a short amount of time based on configured rate limits. Kinde has rate limit thresholds for "buckets" of traffic such as API or token events, which can be tuned with help from our support team.
-
-## **Business continuity and disaster recovery**
+## Business continuity and disaster recovery
 
 Kinde has documented and tested both our business continuity plan and disaster recovery plan. These are updated and refreshed at least annually to ensure that technical events such as a database failover or business impacting events such as a communications tool outage are understood with redundancy plans in place.
 
@@ -36,7 +24,7 @@ Kinde has documented and tested both our business continuity plan and disaster r
 
 Kinde holds a certificate of registration for ISO 27001:2022 and has a SOC 2 attestation. Please refer to our [Compliance certifications](/trust-center/privacy-and-compliance/compliance/) page for more information.
 
-## **Data residency**
+## Data residency
 
 Data is stored in the region you selected during sign up of our product. Currently the available regions are Sydney, Australia; Dublin, Ireland; Oregon, USA; and London, UK. The only data replicated between regions is backend metadata to facilitate the operation of the production services. Otherwise, all user data is not replicated between the regions and will remain in it’s original region.
 
@@ -44,38 +32,38 @@ Data is stored in the region you selected during sign up of our product. Current
 
 Kinde uses a layered approach to protect it’s customers from denial of service attacks to the authentication pages and API, such as protections provided by AWS Shield, rate limiting rules with AWS WAF, and application based throttling.
 
-## **Encryption for data at rest**
+## Encryption for data at rest
 
 All customer data at rest is encrypted in the Kinde production databases using the industry standard AES256 encryption algorithm. Encryption is facilitated by AWS KMS with access to administer KMS strictly limited to privileged admins.
 
-## **Encryption for data in transit**
+## Encryption for data in transit
 
 All network traffic to Kinde production services uses TLS 1.2 or greater with a limited set of modern secure ciphers enforced. Security headers are applied to all production endpoints where possible.
 
-## **Identity management**
+## Identity management
 
 Internal identity is generally managed through the company’s single sign-on (SSO) platform provided by Google Workspace. All systems are connected to the company SSO platform where supported. Multi-factor authentication is enforced for all users and audit logs are enabled and monitored for systems connected to the company SSO. For systems that do not support SSO, employees are required to use the company provided password manager to generate and manage secure credentials as well as enable MFA for added protection.
 
 Access to systems is based on the employee’s job role with the least privileges assigned. Privileged access to any system is strictly limited based on the employee’s job role and accounts are individual to that user only.
 
-## **Penetration testing**
+## Penetration testing
 
 Kinde has completed a network and web application penetration test conducted by [Strike](https://strike.sh/), which was scoped for anything and everything related to Kinde. The test included common OWASP techniques and specifically targeted workflows such as privilege escalations, authentication bypasses, and cloud security. We intend to perform these at least annually.
 
-## **Security awareness**
+## Security awareness
 
 All employees take part in a security onboarding session during their first week that covers topics such as acceptable use, phishing, data privacy, identity, endpoint protection, data classification, and incident response.
 
-## **Software development lifecycle**
+## Software development lifecycle
 
 All Kinde source code is managed by a company managed source code repository. Source code is scanned using a suite of open source tools, which will alert on insecure coding that could lead to vulnerabilities. Access to the source code repository is restricted based on job role with the identity linked to the company single sign-on platform. Merges to source code require a peer review. Pull requests to the master branch are performed by senior engineers.
 
-## **Vulnerability management**
+## Vulnerability management
 
 Production services are deployed through a CICD pipeline using container technology. Server builds are done at least once a week and replace the existing servers. The build process will use the latest patched container host and container image to reduce the risk of vulnerabilities due to unpatched software.
 
 All container images are scanned at build using AWS Inspector for dependencies and third party library vulnerabilities. External production URLs and any public facing cloud IP addresses are scanned weekly for vulnerabilities by Intruder. All vulnerability reports are triaged, analysed, and assigned to the engineering team for remediation based on vulnerability management SLAs.
 
-## **Changes to this document**
+## Changes to this document
 
 Last updated 12 June, 2024.


### PR DESCRIPTION
#### Description

This pull request will do a better job of splitting the company security protections that are usually called our for in third party vendors surveys and the product security protections that are asked about during technical requirements gathering.  I've also removed references of the password hashing from a few places and centralised it into the product security page.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation Updates**
	- Removed specific details about password security and hashing algorithms from authentication documentation.
	- Added new sections on bot detection and credential stuffing protection, enhancing communication of security practices.
	- Renamed and clarified sections related to denial-of-service mitigation and device fingerprinting for better understanding.
	- Reformatted security documentation for improved readability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->