### PR TITLE
Fix/case usage for usernames

### DIFF
--- a/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
+++ b/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
@@ -103,9 +103,9 @@ Verification is an authentication security measure that checks the person seekin
 
 At Kinde, we don’t treat username identities the same as phone and email identities. If you want users to sign in and authenticate with usernames, they still need to verify themselves (if only once) via email.
 
-## Case sensitivity for usernames and emails
+## Case insensitivity for usernames
 
-Kinde is 'case-blind' when it comes to mixing uppercase and lowercase letters in usernames and emails. If you add the user `CoCo` and then add the user `coco`, Kinde will not distinguish the identities and will merge them. As a practice, we do not recommend using mixed case identifiers.
+Kinde treats usernames as case-insensitive. In other words, we ignore case. We do this because it eliminates the possibility of auth issues and fraud when two usernames are identical in every aspect except the case of one of their letters. We are happy to support users choosing an aesthetically pleasing username combination, like RosyRose or BuilderBob. We just don't also support separate identities for rosYrosE and BUilderbob. 
 
 ## When an identity changes
 

--- a/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
+++ b/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
@@ -103,6 +103,10 @@ Verification is an authentication security measure that checks the person seekin
 
 At Kinde, we don’t treat username identities the same as phone and email identities. If you want users to sign in and authenticate with usernames, they still need to verify themselves (if only once) via email.
 
+## Case sensitivity for usernames and emails
+
+Kinde is 'case-blind' when it comes to mixing uppercase and lowercase letters in usernames and emails. If you add the user `CoCo` and then add the user `coco`, Kinde will not distinguish the identities and will merge them. As a practice, we do not recommend using mixed case identifiers.
+
 ## When an identity changes
 
 For security reasons, you can’t edit a user’s verified identity. But we know it still needs to be possible. People change emails, change names, get new phone numbers, etc.

--- a/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
@@ -25,8 +25,11 @@ There are several ways usernames can be added to a user’s profile:
 - Manually in Kinde
 - Via API
 - Self-created by the user on registration
+- imported with user profiles
 
-Regardless of how a username is added, it must be unique. If a username already exists, an error will be returned.
+Kinde treats usernames as case-insensitive. In other words, we ignore case. We do this because it eliminates the possibility of auth issues and fraud when two usernames are identical in every aspect except the case of one of their letters. We are happy to support users choosing an aesthetically pleasing username combination, like RosyRose or BuilderBob. We just don't also support separate identities for rosYrosE and BUilderbob. 
+
+Regardless of how a username is added, it must be unique (in more than case). If a username already exists, an error will be returned.
 
 ## The sign-up flow
 

--- a/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
@@ -79,6 +79,7 @@ Once an email is verified, we add this email identity for the user. If the auth 
 - Usernames must be unique
 - 2-64 characters, no spaces
 - Can include letters, numbers, -dashes, \_underscores (no special characters)
+- Case is ignored. Jane and jane are treated the same.
 
 ## One password for multiple identities
 

--- a/src/content/docs/manage-users/add-and-edit/add-manage-user-identities.mdx
+++ b/src/content/docs/manage-users/add-and-edit/add-manage-user-identities.mdx
@@ -49,3 +49,7 @@ Make an identity the primary one (`is_primary`) via API: `PATCH /identities/{ide
 ## Update a user identity
 
 You can’t directly edit identities in Kinde. You need to add a new identity and delete the old one to update identity records.
+
+## Case insensitivity for usernames
+
+Kinde treats usernames as case-insensitive. In other words, we ignore case. We do this because it eliminates the possibility of auth issues and fraud when two usernames are identical in every aspect except the case of one of their letters. We are happy to support users choosing an aesthetically pleasing username combination, like RosyRose or BuilderBob. We just don't also support separate identities for rosYrosE and BUilderbob. Before adding users, we recommend checking that all usernames are unique in more than just case.

--- a/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
+++ b/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
@@ -30,9 +30,9 @@ If you’ve got large user sets (over 5MB) or are concerned about file size limi
 
 **Note: Importing users from Azure** Set up the [MS Entra ID connection in Kinde](/authenticate/enterprise-connections/azure/) before you import your users. Then when you import, Kinde will match users to the relevant connection based on their email address.
 
-## Case sensitivity for usernames and emails
+## Case insensitivity for usernames
 
-Kinde is 'case-blind' when it comes to the mixed use of uppercase and lowercase letters in usernames and emails. If you try to import two separte users called `CoCo` and `coco`, Kinde will not distinguish the identities and will merge them. We recommend checking that all usernames are fully unique (not just caase unique) before importing. 
+Kinde treats usernames as case-insensitive. In other words, we ignore case. We do this because it eliminates the possibility of auth issues and fraud when two usernames are identical in every aspect except the case of one of their letters. We are happy to support users choosing an aesthetically pleasing username combination, like RosyRose or BuilderBob. We just don't also support separate identities for rosYrosE and BUilderbob. Before importing users, we recommend checking that all usernames are unique in more than just case.
 
 ## Prepare JSON data (Auth0 imports)
 

--- a/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
+++ b/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
@@ -30,6 +30,10 @@ If you’ve got large user sets (over 5MB) or are concerned about file size limi
 
 **Note: Importing users from Azure** Set up the [MS Entra ID connection in Kinde](/authenticate/enterprise-connections/azure/) before you import your users. Then when you import, Kinde will match users to the relevant connection based on their email address.
 
+## Case sensitivity for usernames and emails
+
+Kinde is 'case-blind' when it comes to the mixed use of uppercase and lowercase letters in usernames and emails. If you try to import two separte users called `CoCo` and `coco`, Kinde will not distinguish the identities and will merge them. We recommend checking that all usernames are fully unique (not just caase unique) before importing. 
+
 ## Prepare JSON data (Auth0 imports)
 
 When you export user details from Auth0:


### PR DESCRIPTION
Added a note to relevant topics explaining that we ignore case, e.g. treat BOB and bob the same, when it comes to usernames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added documentation clarifying that usernames are case-insensitive, preventing authentication issues and fraud.
	- Enhanced explanations regarding username uniqueness requirements across various documentation sections.
- **Documentation**
	- Introduced new sections in multiple documents to emphasize the treatment of usernames in the Kinde authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->