### PR TITLE
Feat/merge and sync enterprise identities

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -2,7 +2,7 @@
 page_id: 98f6868a-7871-4ece-ba9c-2a7b21d1b322
 title: MS Entra ID (was Azure AD) enterprise auth
 sidebar:
-  order: 5
+  order: 6
 relatedArticles:
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
   - e100d77b-530b-4327-8216-93c955657e0c

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -2,7 +2,7 @@
 page_id: 04e9e501-0320-40d5-a440-845e637ced7b
 title: Use Cloudflare as a SAML identity provider
 sidebar:
-  order: 9
+  order: 10
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -2,7 +2,7 @@
 page_id: 0dfcab9d-8610-4881-9293-8501bd472041
 title: Custom SAML with Google Workspace
 sidebar:
-  order: 8
+  order: 9
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - e100d77b-530b-4327-8216-93c955657e0c

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -2,7 +2,7 @@
 page_id: 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
 title: Custom authentication with SAML
 sidebar:
-  order: 6
+  order: 7
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c

--- a/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
@@ -1,0 +1,235 @@
+---
+page_id: fbe51780-8c30-4e7d-b294-cfb6660466c6
+title: Mapping and syncing users for enterprise auth
+sidebar:
+  order: 5
+relatedArticles:
+  - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
+  - e100d77b-530b-4327-8216-93c955657e0c
+  - cc242fb3-4b06-4842-97c8-dd58e87308df
+  - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
+---
+
+When you use Kinde to authenticate users via an enterprise connection such as SAML, you also need a way for users to be identified in Kinde so they match the identities stored in your Identity Provider (IdP).
+
+In general, an email address can be used to map users across systems, but because enterprise connection users can have aliases and proxy addresses, there are better ways to keep identities in sync.
+
+Here’s how we recommend mapping user profiles and keeping them synced for enterprise connections.
+
+## Map the Kinde user ID to your product
+
+When users are imported or added to Kinde, a unique user ID is generated. For example, `kp:1876b10742894a0c9M8e725048e7a323`. We recommend you map each user’s Kinde ID back to your product, and use this as the primary auth identifier. This will keep profiles in sync and support a seamless authentication experience.
+
+### Get Kinde user IDs via API
+
+You can access user IDs [via the API](https://kinde.com/api/docs/#list-users) by calling GET `/api/v1/users`. This will return a response with a users array with the following data:
+
+```json
+{
+  "code": "string",
+  "message": "string",
+  "users": [
+    {
+      "id": "string",
+      "provided_id": "string",
+      "email": "string",
+      "username": "string",
+      "last_name": "string",
+      "first_name": "string",
+      "is_suspended": true,
+      "picture": "string",
+      "total_sign_ins": 0,
+      "failed_sign_ins": 0,
+      "last_signed_in": "string",
+      "created_on": "string",
+      "organizations": [
+        "string"
+      ],
+      "identities": [
+        {
+          "type": "string",
+          "identity": "string"
+        }
+      ]
+    }
+  ],
+  "next_token": "string"
+}
+```
+
+Where:
+
+- `id`  is the kinde ID
+- `provided_id`  is the ID you may have provided when you imported your users. This ID can also be useful to match imported users to your local database records.
+
+## Switch on profile sync
+
+As part of your business authentication setup, we recommend switching on user profile sync to keep enterprise and social profiles up to date across providers.
+
+1. Go to **Settings > Policies**.
+2. Switch on **Sync user profiles on sign in**.
+3. Select **Save**.
+
+## Sync users with webhooks
+
+Webhooks are a method of being notified when an event occurs in Kinde, e.g. a user is created. You can [register your own endpoint URLs](/integrate/webhooks/add-manage-webhooks/) in Kinde, and each time the event occurs, data for that event will be sent to your endpoint.
+
+Here’s some examples of webhook events that can be used to keep your users in sync:
+
+- `user.created` - when a user is created in Kinde either via the admin UI or registering
+- `user.updated` - when a user is added to an organization, their roles or permissions change, or when their assigned properties change
+- `user.deleted` - when a user is deleted via the UI or via the API
+
+Here’s an example json schema for user.updated that could be used to sync your data:
+
+```jsx
+{
+            "id": "et_018df239698d29177684be3f5ad1266d",
+            "code": "user.updated",
+            "name": "User updated",
+            "origin": "kinde",
+            "schema": {
+                "$id": "https://kinde.com/user.updated.schema.json",
+                "type": "object",
+                "title": "User Updated Webhook Event",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "pattern": "kp[:_][0-9a-f]{32}",
+                                        "description": "ID of the user"
+                                    },
+                                    "phone": {
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "last_name": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The users updated last name"
+                                    },
+                                    "first_name": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The users updated first name"
+                                    },
+                                    "is_suspended": {
+                                        "type": "boolean",
+                                        "description": "The users updated status"
+                                    },
+                                    "organizations": {
+                                        "type": [
+                                            "array",
+                                            "null"
+                                        ],
+                                        "items": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "string",
+                                                        "pattern": "org[:_][0-9a-f]{11}"
+                                                    },
+                                                    "roles": {
+                                                        "type": [
+                                                            "array",
+                                                            "null"
+                                                        ],
+                                                        "items": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string",
+                                                                        "format": "uuid"
+                                                                    },
+                                                                    "key": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "permissions": {
+                                                        "type": [
+                                                            "array",
+                                                            "null"
+                                                        ],
+                                                        "items": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string",
+                                                                        "format": "uuid"
+                                                                    },
+                                                                    "key": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "is_password_reset_requested": {
+                                        "type": "boolean",
+                                        "description": "The users updated password reset status"
+                                    }
+                                },
+                                "description": "User event data"
+                            }
+                        },
+                        "description": "Webhook event data"
+                    },
+                    "type": {
+                        "constant": "user.updated"
+                    },
+                    "source": {
+                        "enum": [
+                            "api",
+                            "admin"
+                        ],
+                        "description": "Source of the action"
+                    },
+                    "event_id": {
+                        "type": "string",
+                        "pattern": "event_[0-9a-f]{32}",
+                        "description": "ID of the event"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Datetimestamp of the action"
+                    }
+                },
+                "description": "Webhook detail the user updated event"
+            },
+            "version": 1
+        }
+```
+
+You can see a full list of events in the Kinde UI under **Settings > Webhooks**, or by calling the [Kinde management API](https://kinde.com/api/docs/#kinde-management-api-webhooks) which also provides the JSON schema GET `/api/v1/event_types`.
+
+Read more [about webhooks](/integrate/webhooks/about-webhooks/).
+
+
+
+
+
+
+

--- a/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
@@ -42,9 +42,7 @@ You can access user IDs [via the API](https://kinde.com/api/docs/#list-users) by
       "failed_sign_ins": 0,
       "last_signed_in": "string",
       "created_on": "string",
-      "organizations": [
-        "string"
-      ],
+      "organizations": ["string"],
       "identities": [
         {
           "type": "string",
@@ -59,8 +57,8 @@ You can access user IDs [via the API](https://kinde.com/api/docs/#list-users) by
 
 Where:
 
-- `id`  is the kinde ID
-- `provided_id`  is the ID you may have provided when you imported your users. This ID can also be useful to match imported users to your local database records.
+- `id` is the kinde ID
+- `provided_id` is the ID you may have provided when you imported your users. This ID can also be useful to match imported users to your local database records.
 
 ## Switch on profile sync
 
@@ -82,154 +80,126 @@ Here’s some examples of webhook events that can be used to keep your users in 
 
 Here’s an example json schema for user.updated that could be used to sync your data:
 
-```jsx
+```json
 {
-            "id": "et_018df239698d29177684be3f5ad1266d",
-            "code": "user.updated",
-            "name": "User updated",
-            "origin": "kinde",
-            "schema": {
-                "$id": "https://kinde.com/user.updated.schema.json",
-                "type": "object",
-                "title": "User Updated Webhook Event",
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "properties": {
-                            "user": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string",
-                                        "pattern": "kp[:_][0-9a-f]{32}",
-                                        "description": "ID of the user"
-                                    },
-                                    "phone": {
-                                        "type": [
-                                            "null",
-                                            "string"
-                                        ]
-                                    },
-                                    "last_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The users updated last name"
-                                    },
-                                    "first_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The users updated first name"
-                                    },
-                                    "is_suspended": {
-                                        "type": "boolean",
-                                        "description": "The users updated status"
-                                    },
-                                    "organizations": {
-                                        "type": [
-                                            "array",
-                                            "null"
-                                        ],
-                                        "items": [
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "code": {
-                                                        "type": "string",
-                                                        "pattern": "org[:_][0-9a-f]{11}"
-                                                    },
-                                                    "roles": {
-                                                        "type": [
-                                                            "array",
-                                                            "null"
-                                                        ],
-                                                        "items": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "type": "string",
-                                                                        "format": "uuid"
-                                                                    },
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "permissions": {
-                                                        "type": [
-                                                            "array",
-                                                            "null"
-                                                        ],
-                                                        "items": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "type": "string",
-                                                                        "format": "uuid"
-                                                                    },
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "is_password_reset_requested": {
-                                        "type": "boolean",
-                                        "description": "The users updated password reset status"
-                                    }
-                                },
-                                "description": "User event data"
+  "id": "et_018df239698d29177684be3f5ad1266d",
+  "code": "user.updated",
+  "name": "User updated",
+  "origin": "kinde",
+  "schema": {
+    "$id": "https://kinde.com/user.updated.schema.json",
+    "type": "object",
+    "title": "User Updated Webhook Event",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "kp[:_][0-9a-f]{32}",
+                "description": "ID of the user"
+              },
+              "phone": {
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "type": ["string", "null"],
+                "description": "The users updated last name"
+              },
+              "first_name": {
+                "type": ["string", "null"],
+                "description": "The users updated first name"
+              },
+              "is_suspended": {
+                "type": "boolean",
+                "description": "The users updated status"
+              },
+              "organizations": {
+                "type": ["array", "null"],
+                "items": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "pattern": "org[:_][0-9a-f]{11}"
+                      },
+                      "roles": {
+                        "type": ["array", "null"],
+                        "items": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "key": {
+                                "type": "string"
+                              }
                             }
-                        },
-                        "description": "Webhook event data"
-                    },
-                    "type": {
-                        "constant": "user.updated"
-                    },
-                    "source": {
-                        "enum": [
-                            "api",
-                            "admin"
-                        ],
-                        "description": "Source of the action"
-                    },
-                    "event_id": {
-                        "type": "string",
-                        "pattern": "event_[0-9a-f]{32}",
-                        "description": "ID of the event"
-                    },
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Datetimestamp of the action"
+                          }
+                        ]
+                      },
+                      "permissions": {
+                        "type": ["array", "null"],
+                        "items": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "key": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        ]
+                      }
                     }
-                },
-                "description": "Webhook detail the user updated event"
+                  }
+                ]
+              },
+              "is_password_reset_requested": {
+                "type": "boolean",
+                "description": "The users updated password reset status"
+              }
             },
-            "version": 1
-        }
+            "description": "User event data"
+          }
+        },
+        "description": "Webhook event data"
+      },
+      "type": {
+        "constant": "user.updated"
+      },
+      "source": {
+        "enum": ["api", "admin"],
+        "description": "Source of the action"
+      },
+      "event_id": {
+        "type": "string",
+        "pattern": "event_[0-9a-f]{32}",
+        "description": "ID of the event"
+      },
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Datetimestamp of the action"
+      }
+    },
+    "description": "Webhook detail the user updated event"
+  },
+  "version": 1
+}
 ```
 
 You can see a full list of events in the Kinde UI under **Settings > Webhooks**, or by calling the [Kinde management API](https://kinde.com/api/docs/#kinde-management-api-webhooks) which also provides the JSON schema GET `/api/v1/event_types`.
 
 Read more [about webhooks](/integrate/webhooks/about-webhooks/).
-
-
-
-
-
-
-

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -2,7 +2,7 @@
 page_id: 9456239e-0d53-4597-83d2-56ab0c1468d3
 title: Use Okta as a SAML identity provider
 sidebar:
-  order: 10
+  order: 11
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041

--- a/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
@@ -2,7 +2,7 @@
 page_id: d894dd3c-356f-41b0-b510-c35066a2277d
 title: Refresh SAML certificate
 sidebar:
-  order: 7
+  order: 8
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041


### PR DESCRIPTION
New topic describing how we recommend founders map user identities between Kinde and their enterprise auth provider. Touches on provisioning and how to keep identities in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new document on mapping and syncing user identities for enterprise authentication with Kinde.
- **Improvements**
	- Updated sidebar order for multiple documents to enhance navigation and accessibility.
		- Azure connection document moved to position 6.
		- Cloudflare SAML document moved to position 10.
		- Custom SAML with Google Workspace document moved to position 9.
		- Custom SAML document moved to position 7.
		- Okta SAML connection document moved to position 11.
		- Refresh SAML certificate document moved to position 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->