### PR TITLE
Fix/Clarify how to change login to register

### DIFF
--- a/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
+++ b/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
@@ -35,7 +35,7 @@ See [Custom sign-up and sign-in pages](/authenticate/custom-configurations/custo
 You can allow all users to register and sign from the same authentication screen, without forcing them to create an account first. 
 To do this:
 
-1. Update your app to redirect all authentication through the registration flow.
+1. Update your app to redirect all authentication through the registration flow. To do this, change the `<LoginLink>` for the sign in button, to use `<RegisterLink>` instead.
 2. Switch off the requirement to ask for first name and last name on registration (see section below).
 3. Go to **Settings > Applications > View details** on your application. Scroll to the **Authentication experience** section. 
 4. Switch off the **Show 'Already have an account? Sign in' on registration page** option.

--- a/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
+++ b/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
@@ -35,7 +35,7 @@ See [Custom sign-up and sign-in pages](/authenticate/custom-configurations/custo
 You can allow all users to register and sign from the same authentication screen, without forcing them to create an account first. 
 To do this:
 
-1. Update your app to redirect all authentication through the registration flow. To do this, change the `<LoginLink>` for the sign in button, to use `<RegisterLink>` instead.
+1. Update your app to redirect all authentication through the registration flow. To do this, change the link for the `sign in` button to go to the `register` button on the authentication screen. In Next.js, for example, you would change `<LoginLink>` to use `<RegisterLink>` instead.
 2. Switch off the requirement to ask for first name and last name on registration (see section below).
 3. Go to **Settings > Applications > View details** on your application. Scroll to the **Authentication experience** section. 
 4. Switch off the **Show 'Already have an account? Sign in' on registration page** option.


### PR DESCRIPTION
Minor update to the first step of the seamless sign up procedure to clarify how to redirect to the registration flow using `<RegisterLink>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for configuring the authentication experience, clarifying the steps for users to register and sign in from the same screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->