### PR TITLE
feat: add security and privacy label automatically to `/trust-center/` articles

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
 sdk:
   - changed-files:
       - any-glob-to-any-file: "src/content/docs/developer-tools/sdks/**/*"
+"security and privacy":
+  - changed-files:
+      - any-glob-to-any-file: "src/content/docs/trust-center/**/*"


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Add a `security and privacy` label automatically to pull requests when a file under `/trust-center/` is added/updated/deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "security and privacy" section in the labeler configuration to enhance tracking of relevant documentation changes.
  
- **Improvements**
	- Improved organization and management of documentation updates related to security and privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->