### PR TITLE
fix: make package manager component tabwrapper overflow hidden

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -454,6 +454,10 @@ starlight-tabs[data-sync-key="starlight-package-managers-pkg"] {
   @apply pt-3;
 }
 
+starlight-tabs[data-sync-key="starlight-package-managers-pkg"] .tablist-wrapper {
+  @apply overflow-y-hidden;
+}
+
 starlight-tabs[data-sync-key="starlight-package-managers-pkg"] ul[role="tablist"] {
   @apply border-b-[1px] border-b-kinde-grey-100 dark:border-b-kinde-grey-800;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Fixes the vertical scrolling for the tablist wrapper in the  `PackageManagers` component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved visual layout of the tab list by preventing vertical scrollbars through enhanced styling.
  
- **Bug Fixes**
	- Resolved issues with content overflow in the `starlight-tabs` component, ensuring a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->