### PR TITLE
fix: add trailing slash to internal link

### DIFF
--- a/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
+++ b/src/content/docs/get-started/learn-about-kinde/kinde-product-security.mdx
@@ -20,7 +20,7 @@ Native bot detection is on the roadmap, which will allow customers to bring thei
 
 To protect against bot driven volumetric attacks, we use AWS WAF to block traffic that matches OWASP threat rules, known malicious IP addresses, and AWS managed rules. 
 
-Alternatively, customers can implement bot detection and CAPTCHA if your DNS is hosted via Cloudflare. Kinde's hosted pages, with a custom domain, can be proxied through Cloudflare to incorporate their advanced web attack protection features, including bot detection and Cloudflare's Turnstile (Cloudflare's equivalent to CAPTCHA). Please see [Proxy your Kinde auth pages through Cloudflare](/authenticate/custom-configurations/proxy-your-kinde-auth-pages-through-cloudflare) for more information.
+Alternatively, customers can implement bot detection and CAPTCHA if your DNS is hosted via Cloudflare. Kinde's hosted pages, with a custom domain, can be proxied through Cloudflare to incorporate their advanced web attack protection features, including bot detection and Cloudflare's Turnstile (Cloudflare's equivalent to CAPTCHA). Please see [Proxy your Kinde auth pages through Cloudflare](/authenticate/custom-configurations/proxy-your-kinde-auth-pages-through-cloudflare/) for more information.
 
 ## Credential stuffing protection
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Add missing trailing slash to conform with canonical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated a hyperlink in the Kinde product security documentation for improved accuracy in directing users to information about proxying authentication pages through Cloudflare.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->