### PR TITLE
Fix/emphasise m2 m access to api

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
+++ b/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
@@ -16,7 +16,7 @@ app_context:
 
 Machine to machine applications facilitate token exchange between systems, applications, and services, including micro-services.
 
-For example, you need a machine to machine application for connecting to [Kinde’s Management API](https://kinde.com/api/docs/#kinde-management-api). See below for instructions.
+Only machine to machine (M2M) applications can connect to [Kinde’s Management API](https://kinde.com/api/docs/#kinde-management-api). This topic explains how to set up an M2M application, including managing the scopes that get requested.
 
 ## About scopes and the Kinde Management API
 

--- a/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
+++ b/src/content/docs/developer-tools/kinde-api/add-a-m2m-application-for-api-access.mdx
@@ -20,7 +20,7 @@ Only machine to machine (M2M) applications can connect to [Kinde’s Management 
 
 ## About scopes and the Kinde Management API
 
-Scopes must be defined in all applications you want to access the Kinde Management API. You can select scopes when you authorize a new application or you can add scopes to an existing application. We recommend adding as few scopes as you need, to maintain API security. See the relevant procedure below.
+Scopes must be defined in all M2M applications you want to access the Kinde Management API. You can select scopes when you authorize a new application or you can add scopes to an existing application. We recommend adding as few scopes as you need, to maintain API security. See the relevant procedure below.
 
 ## Step 1: Add a machine to machine application
 

--- a/src/content/docs/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api.mdx
+++ b/src/content/docs/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api.mdx
@@ -12,7 +12,10 @@ app_context:
     s: applications
 ---
 
-To securely connect to Kinde’s API, you need to obtain an access token.
+To securely connect to Kinde’s API, you need to obtain an access token. You also need to have:
+
+- a [machine to machine application](/developer-tools/kinde-api/add-a-m2m-application-for-api-access/) with all relevant Kinde API scopes selected.
+- have your application details, Client ID and Client secret on hand.
 
 This document describes:
 
@@ -22,12 +25,6 @@ This document describes:
 See our [other SDK frameworks](/developer-tools/about/our-sdks/) for additional guidance.
 
 You can also watch a video about connecting and testing the API connection on our YouTube channel [here](https://www.youtube.com/watch?v=xJCj0IeoB5g).
-
-## Before you begin
-
-You need to have:
-- a [machine to machine application](/developer-tools/kinde-api/add-a-m2m-application-for-api-access/) with all relevant Kinde API scopes selected.
-- have your application details, Client ID and Client secret on hand.
 
 ## Get the access token (Postman example)
 

--- a/src/content/docs/get-started/apis-and-sdks/about-kinde-apis.mdx
+++ b/src/content/docs/get-started/apis-and-sdks/about-kinde-apis.mdx
@@ -3,6 +3,7 @@ page_id: f1ba22b9-b35f-478a-be09-4524d060fe36
 title: About Kinde APIs
 sidebar:
   order: 2
+
 app_context:
   - m: settings
     s: apis
@@ -12,7 +13,7 @@ At Kinde we want to empower founders to build their product their way, and integ
 
 ## Access the Kinde Management API
 
-You can already use our API to integrate Kinde functionality in your app without the admin interface layer. [Check out the API docs](https://kinde.com/api/docs/#kinde-management-api) and watch this space as we expand capability in the coming months.
+You can only access Kinde's API via machine to machine (M2M) applications. Once connected, you can use our API to integrate Kinde functionality in your app without the admin interface layer. [Check out the API docs](https://kinde.com/api/docs/#kinde-management-api).
 
 ## Integrate by registering your own API
 

--- a/src/content/docs/get-started/apis-and-sdks/about-kinde-apis.mdx
+++ b/src/content/docs/get-started/apis-and-sdks/about-kinde-apis.mdx
@@ -3,7 +3,11 @@ page_id: f1ba22b9-b35f-478a-be09-4524d060fe36
 title: About Kinde APIs
 sidebar:
   order: 2
-
+relatedArticles:
+  - 6bf993fc-a195-4836-8eaf-133812be8876
+  - 51899f7f-3436-46e0-9a1b-6ecc3603a0df
+  - 50284476-2442-414c-af20-01ed3ef4ca4e
+  - 601dd8c5-6ee1-474f-ad36-201e65280462
 app_context:
   - m: settings
     s: apis


### PR DESCRIPTION
Update to a few topics to clarify that only M2M apps can access the Kinde Management API. Added some cross references and related topics as well. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified requirements for machine-to-machine (M2M) applications connecting to Kinde’s Management API.
	- Streamlined instructions for obtaining access tokens by consolidating prerequisites.
	- Enhanced connectivity to related topics by adding a new section with additional resources in the "About Kinde APIs" document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->