### PR TITLE
Fix/Remove to connect app to API

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
@@ -1385,8 +1385,6 @@ const handleRefresh = async () => {
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 Server Component example:


### PR DESCRIPTION
Removed the text that refers to connecting your frontend app to Kinde API, this is not possible anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed a specific instruction for enabling access to the Kinde Management API in the Next.js setup documentation, streamlining the setup process for users. 
	- Maintained guidance on using the management API library with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->