### PR TITLE
Fix/all docs referring to non-m2m apps connecting to api

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/express-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/express-sdk.mdx
@@ -154,9 +154,7 @@ app.get("/some-route", verifier, (req, res) => {
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
-To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
+To use the Kinde management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 ## SDK API Reference - setupKinde
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-prev-sdk.mdx
@@ -627,8 +627,6 @@ export const config = {
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 `getServerSideProps` example:

--- a/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
@@ -458,8 +458,6 @@ console.log("access_token", accessToken);
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 ## **SDK API reference**

--- a/src/content/docs/developer-tools/sdks/backend/nuxt-module.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nuxt-module.mdx
@@ -290,8 +290,6 @@ export default defineNuxtConfig({
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 If you need help using Kinde, please contact us at [support@kinde.com](mailto:support@kinde.com) or join the Kinde community on [Discord](https://discord.com/invite/tw5ng5tK6V) or [Slack](https://join.slack.com/t/thekindecommunity/shared_invite/zt-2k5i0aeet-d6Z_2qYphcNCpj0bFa4oCg).

--- a/src/content/docs/developer-tools/sdks/backend/remix-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/remix-sdk.mdx
@@ -273,6 +273,4 @@ export const action = ({request}: ActionFunctionArgs) => {
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)

--- a/src/content/docs/developer-tools/sdks/backend/ruby-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/ruby-sdk.mdx
@@ -438,9 +438,7 @@ KindeSdk.client(session[:kinde_auth]).oauth.get_user
 
 ## Kinde management API
 
-The Kinde Management API can only be accessed by back-end or machine-to-machine applications. Eventually, anything that can be done through the Kinde admin area (and more) can also be done via this API.
-
-To get started, you will need an access token, the Ruby SDK includes a helper to get one.
+To get started, you will need an access token, the Ruby SDK includes a helper to get one. Or see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js/)
 
 ```ruby
 result = KindeSdk.client_credentials_access(

--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -490,8 +490,6 @@ const access_token = await kindeAuthClient.getToken(request as unknown as Sessio
 
 ## Kinde Management API
 
-You need to enable the application’s access to the Kinde Management API. You can do this in Kinde by going to **Settings > APIs > Kinde Management API** and then toggling on your Next.js application under the **Applications** tab.
-
 To use our management API please see [@kinde/management-api-js](https://github.com/kinde-oss/management-api-js)
 
 ## **SDK API reference**


### PR DESCRIPTION
Removed the incorrect instruction for connecting to Kinde's API from the relevant SDKs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified documentation for accessing the Kinde Management API across various SDKs. Users are now directed to the `@kinde/management-api-js` documentation without detailed navigation steps.
	- Added a reference to the GitHub repository for `@kinde/management-api-js` in the Ruby SDK documentation for enhanced resource accessibility.

- **Bug Fixes**
	- Removed potentially confusing instructions regarding enabling access to the Kinde Management API in multiple SDK documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->