### PR TITLE
chore(deps): updated using npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8368,9 +8368,9 @@
       "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
     "node_modules/vite": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.4.tgz",
-      "integrity": "sha512-RHFCkULitycHVTtelJ6jQLd+KSAAzOgEYorV32R2q++M6COBjKJR6BxqClwp5sf0XaBDjVMuJ9wnNfyAJwjMkA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
+      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

Ran `npm audit fix` to resolve a moderate security vulnerability in one of the underlining packages.