### PR TITLE
Fix/add code names to description of additional claims

### DIFF
--- a/src/content/docs/build/tokens/token-customization.mdx
+++ b/src/content/docs/build/tokens/token-customization.mdx
@@ -42,7 +42,7 @@ Apart from your own [custom properties](/properties/work-with-properties/propert
 You can:
 - add an organization name to an access token (`org_name`)
 - add roles to an access token (`roles`)
-- add an email to an access token (`email)
+- add an email to an access token (`email`)
 - add an external organization ID to an access token (`external_organization_id`)
 
 ### Add claims to ID tokens

--- a/src/content/docs/build/tokens/token-customization.mdx
+++ b/src/content/docs/build/tokens/token-customization.mdx
@@ -40,15 +40,15 @@ Apart from your own [custom properties](/properties/work-with-properties/propert
 ### Add claims to access tokens
 
 You can:
-- add an organization name to an access token
-- add roles to an access token
-- add an email to an access token
-- add an external organization ID to an access token
+- add an organization name to an access token (`org_name`)
+- add roles to an access token (`roles`)
+- add an email to an access token (`email)
+- add an external organization ID to an access token (`external_organization_id`)
 
 ### Add claims to ID tokens
 
 You can:
-- Add a user's social identity to an ID token
+- Add a user's social identity to an ID token 
 - Add a user's organizations to an ID token
 
 ### Add claims to M2M tokens


### PR DESCRIPTION
Very small change to improve doc search. Included `code` for the data that can be included in additional token claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added specific identifiers for claims in access tokens, enhancing clarity and usability.
		- Updated claims: "organization name" (`org_name`), "roles" (`roles`), "email" (`email`), and "external organization ID" (`external_organization_id`).
	- Clarified the addition of a user's social identity to ID tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->