### PR TITLE
chore/fix ref to exclude M2M

### DIFF
--- a/src/content/docs/properties/work-with-properties/properties-in-tokens.mdx
+++ b/src/content/docs/properties/work-with-properties/properties-in-tokens.mdx
@@ -13,7 +13,7 @@ app_context:
 
 You can select what information to include in a token for each of your applications. Before you can add properties to tokens, they need to be set to ‘public’ in the property settings. See [Add and manage properties](/properties/work-with-properties/manage-properties/).
 
-You can edit **Access tokens** and **ID tokens** for front-end and back-end apps.
+You can edit **Access tokens** and **ID tokens** for front-end and back-end apps. You cannot add properties to tokens for M2M apps. 
 
 ## Add properties to tokens
 

--- a/src/content/docs/properties/work-with-properties/properties-in-tokens.mdx
+++ b/src/content/docs/properties/work-with-properties/properties-in-tokens.mdx
@@ -20,7 +20,7 @@ You can edit **Access tokens** and **ID tokens** for front-end and back-end apps
 1. Open the relevant application. On the **Home** screen or in **Settings > Applications,** select **View details** on your application.
 2. Select **Tokens**.
 3. Scroll to the **Token customization** section.
-4. Select **Customize** on the relevant token type. The **Customize [access/ID/M2M] token** dialog opens.
+4. Select **Customize** on the relevant token type. The **Customize [access/ID] token** dialog opens.
 5. Select the **Properties** you want to add. These will be included in the token.
 6. Select **Save**.
 
@@ -28,6 +28,6 @@ You can edit **Access tokens** and **ID tokens** for front-end and back-end apps
 
 1. Open the relevant application. On the **Home** screen or in **Settings > Applications,** select **View details** on your application.
 2. Select **Tokens**. and scroll to the **Token customization** section.
-3. Select **Customize** on the relevant token type. The **Customize [access/ID/M2M] token** dialog opens.
+3. Select **Customize** on the relevant token type. The **Customize [access/ID] token** dialog opens.
 4. Select or deselect the **Properties** you want to edit or remove.
 5. Select **Save**.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated guidelines on adding properties to tokens, specifying that this functionality is not available for Machine-to-Machine (M2M) applications.
	- Modified dialog references for customizing tokens to exclude M2M options, clarifying that only Access and ID tokens can be customized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->