### PR TITLE
Fix/Clarify which value to enter in secret field

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -26,6 +26,7 @@ If you are [importing users into Kinde](/manage-users/add-and-edit/import-users
 ## **Before you begin**
 
 - Your app needs to be [registered with the Microsoft identity platform](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- You need the Client ID and Client Secret from the Microsoft app to connect to Kinde. 
 - We recommend you test connections in a non-production environment before activating in a live environment.
 
 ## **Add and configure the connection in Kinde**
@@ -49,7 +50,7 @@ If you are [importing users into Kinde](/manage-users/add-and-edit/import-users
 
 3. Select if you want to treat this connection as a trusted provider. A [trusted provider](/authenticate/about-auth/identity-and-verification/) is one that guarantees the email they issue is verified. We recommend leaving this off for maximum security.
 4. Enter your **Microsoft Azure domain.**
-5. Enter the **Client ID** and **Client secret** as they appear in the MS Azure portal.
+5. Enter the **Client ID** and **Client secret** as they appear in the MS Azure portal. Make sure you use the **Value** of the client secret.
 6. Enter **Home realm domains**. This speeds up the sign in process for users of those domains.
    Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
 7. If you want, select the **Use common endpoint** option. Recommended if you use multi-tenancy.


### PR DESCRIPTION
Small doc fix to clarify that users must copy the 'value' of the client secret into Kinde as the Client secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation to reflect the rebranding from Azure AD to Microsoft Entra ID.
	- Added clarity on prerequisites for connecting Kinde with Microsoft Entra ID.
	- Enhanced instructions for configuring the connection, specifying the use of the client secret's value.
	- Included a warning about matching connection names to prevent user import mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->