### PR TITLE
Remove ref to verified users in API

### DIFF
--- a/src/content/docs/authenticate/authentication-methods/email-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/email-authentication.mdx
@@ -46,7 +46,7 @@ If a user signs up via a social provider that does not require an email (such as
 
 <Aside>
 
-The exception for the above is if you import users or add users via API and the `email_verified` parameter is `true`.
+The exception for the above is if you import users and the `email_verified` parameter is `true`.
 
 </Aside>
 


### PR DESCRIPTION
Very minor edit to remove reference to `email_verified` parameter settings in API, in an exceptions note.
