### PR TITLE
fix: Make URLs relative and add missing backslash.

### DIFF
--- a/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
+++ b/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
@@ -13,7 +13,7 @@ relatedArticles:
 
 If you have an app or site that supports a mix of business customers and direct customers, this guide shows you how to set up authentication in Kinde to meet both these needs.
 
-For example, say you run a finance business and you have separate sign-ins for accounting business partners and direct customers. Accounting businesses sign in with an enterprise identity, e.g. SAML and direct customers sign in with email and an OTP. 
+For example, say you run a finance business and you have separate sign-ins for accounting business partners and direct customers. Accounting businesses sign in with an enterprise identity, e.g. SAML and direct customers sign in with email and an OTP.
 
 This topic explains how to create a simple, unified experience for both groups.
 
@@ -36,7 +36,7 @@ This simplifies the sign in experience for all your users, including your enterp
 
 ### Example of a unified authentication experience
 
-This is what happens behind the scenes with the auth setup. 
+This is what happens behind the scenes with the auth setup.
 
 ![image.png](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/ff106642-c42f-44cf-4a89-84406a717000/public)
 
@@ -44,35 +44,35 @@ This is what happens behind the scenes with the auth setup.
 
 In this scenario, your direct customers will sign in with email and a one-time-passcode (OTP). To set this up:
 
-1. [Enable email + code authentication in your business.](https://docs.kinde.com/authenticate/authentication-methods/passwordless-authentication/)
-2. [Set email + code as the sign in method in your default organization.](https://docs.kinde.com/authenticate/manage-authentication/organization-auth-experience/)
-3. (Optional) [Set an organization policy to allow users to sign up to the default org using an email address](https://docs.kinde.com/build/organizations/allow-user-signup-org/).
+1. [Enable email + code authentication in your business.](/authenticate/authentication-methods/passwordless-authentication/)
+2. [Set email + code as the sign in method in your default organization.](/authenticate/manage-authentication/organization-auth-experience/)
+3. (Optional) [Set an organization policy to allow users to sign up to the default org using an email address](/build/organizations/allow-user-signup-org/).
 
 ### Step 2: Set up auth for your B2B users
 
-Authentication for business customers can be more complex, with additional security considerations and set up time involved. For example, a partner business may require employees to only access your web app using their business email and for authentication to be centralised with their own identity provider via SAML. 
+Authentication for business customers can be more complex, with additional security considerations and set up time involved. For example, a partner business may require employees to only access your web app using their business email and for authentication to be centralised with their own identity provider via SAML.
 
 Let’s go through the process for setting up 5 SAML enterprise connections for 5 different business customers.
 
-1. [Add 5 separate enterprise connections to Kinde](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/). E.g. EC1, EC2, EC3, and so on.
-    1. Configure each connection with the domain information, including email domains in the [home realm discovery](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/#home-realm-discovery) field. You may need to ask the customer’s IT team for this information.
-    2. (Recommended) Switch on the **Create user on sign up** option to [enable JIT provisioning](https://docs.kinde.com/authenticate/enterprise-connections/provision-users-enterprise/). 
-2. [Create 5 organizations](https://docs.kinde.com/build/organizations/add-and-manage-organizations/), one for each business customer (and connection), and select only [the relevant enterprise connection for each organization](https://docs.kinde.com/authenticate/manage-authentication/organization-auth-experience/#set-custom-authentication-for-an-organization). 
-    
-    For example:
-    
-    | For this org… | Switch on this auth connection… |
-    | --- | --- |
-    | Organization 1 | EC1 (domain x home realm) |
-    | Organization 2 | EC2 (domain y home realm) |
-    | Organization 3 | EC3 (domain a home realm) |
-    | Organization 4 | EC4 (domain b home realm) |
-    | Organization 5 | EC5 (domain c home realm) |
+1. [Add 5 separate enterprise connections to Kinde](/authenticate/enterprise-connections/about-enterprise-connections/). E.g. EC1, EC2, EC3, and so on.
+   1. Configure each connection with the domain information, including email domains in the [home realm discovery](/authenticate/enterprise-connections/about-enterprise-connections/#home-realm-discovery) field. You may need to ask the customer’s IT team for this information.
+   2. (Recommended) Switch on the **Create user on sign up** option to [enable JIT provisioning](/authenticate/enterprise-connections/provision-users-enterprise/).
+2. [Create 5 organizations](/build/organizations/add-and-manage-organizations/), one for each business customer (and connection), and select only [the relevant enterprise connection for each organization](/authenticate/manage-authentication/organization-auth-experience/#set-custom-authentication-for-an-organization).
+
+   For example:
+
+   | For this org…  | Switch on this auth connection… |
+   | -------------- | ------------------------------- |
+   | Organization 1 | EC1 (domain x home realm)       |
+   | Organization 2 | EC2 (domain y home realm)       |
+   | Organization 3 | EC3 (domain a home realm)       |
+   | Organization 4 | EC4 (domain b home realm)       |
+   | Organization 5 | EC5 (domain c home realm)       |
 
 3. In each organization:
-    1. Go to **Policies** and add the relevant domain to the **Allowed domains** field.
-    2. Select **Auto-add users from allowed domains**. This activates JIT provisioning for users signing up from this domain.
-    3. Select **Save**.
+   1. Go to **Policies** and add the relevant domain to the **Allowed domains** field.
+   2. Select **Auto-add users from allowed domains**. This activates JIT provisioning for users signing up from this domain.
+   3. Select **Save**.
 
 With home realm discovery and allowed domains set, when a user enters an email that matches the domain name they will be routed through that enterprise connection. There is no need for them to self-select which connection they belong to.
 
@@ -84,10 +84,10 @@ To achieve the above scenario, all the supported sign-in methods need to be swit
 
 ## Optimize your auth flow
 
-This unified model of authentication can be extended to 10’s or 100’s of organizations, all while maintaining the same sign in screen. 
+This unified model of authentication can be extended to 10’s or 100’s of organizations, all while maintaining the same sign in screen.
 
 Other situations you can cater for include:
 
-- [Adding MFA for an organization's users](https://docs.kinde.com/authenticate/multi-factor-auth/mfa-per-org)
-- Adding other [enterprise connections](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/) (e.g. [Google workspace](https://docs.kinde.com/authenticate/enterprise-connections/custom-saml-google-workspace/) or [Microsoft Entra ID](https://docs.kinde.com/authenticate/enterprise-connections/azure/))
-- [Auto-assigning user roles](https://docs.kinde.com/manage-users/roles-and-permissions/default-user-roles/)
+- [Adding MFA for an organization's users](/authenticate/multi-factor-auth/mfa-per-org/)
+- Adding other [enterprise connections](/authenticate/enterprise-connections/about-enterprise-connections/) (e.g. [Google workspace](/authenticate/enterprise-connections/custom-saml-google-workspace/) or [Microsoft Entra ID](/authenticate/enterprise-connections/azure/))
+- [Auto-assigning user roles](/manage-users/roles-and-permissions/default-user-roles/)

--- a/src/content/docs/developer-tools/sdks/backend/dotnet-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/dotnet-sdk.mdx
@@ -17,7 +17,8 @@ head:
 {/* @case-police-ignore Mvc */}
 {/* @case-police-ignore Html */}
 
-Kinde auth can be integrated into your application without the need for an SDK.  Follow the appropriate guide to secure your API or use OpenID Connect to secure your web application:
+Kinde auth can be integrated into your application without the need for an SDK. Follow the appropriate guide to secure your API or use OpenID Connect to secure your web application:
+
 - [Integrate with ASP.NET based APIs](/developer-tools/your-apis/dotnet-based-apis/)
 - [Integrate with ASP.NET using Open ID Connect](/developer-tools/guides/dotnet-open-id-connect/)
 
@@ -27,7 +28,7 @@ The Kinde .NET SDK allows developers to quickly and securely call the Kinde Mana
 
 - Kinde .NET SDK supports .NET 6.0+
 - If you haven’t already got a Kinde account, [register for free here](https://app.kinde.com/register) (no credit card required). Registering gives you a Kinde domain, which you need to get started, e.g. `yourapp.kinde.com`.
-- Create a [machine to machine application for Kinde Management API access](https://docs.kinde.com/developer-tools/kinde-api/add-a-m2m-application-for-api-access/).
+- Create a [machine to machine application for Kinde Management API access](/developer-tools/kinde-api/add-a-m2m-application-for-api-access/).
 
 ## Add packages to your application
 
@@ -50,15 +51,18 @@ This command is intended to be used within the Package Manager Console in Visual
 ## Configure API client
 
 Create and authorize a new client:
+
 ```csharp
 var client = new KindeClient(new ApplicationConfiguration("<your-kinde-domain>", "", ""), new KindeHttpClient());
 await client.Authorize(new ClientCredentialsConfiguration("<your-client-id>", "", "<your-client-secret>", "https://<your-kinde-domain>/api"));
 ```
+
 Replacing `<your-kinde-domain>` with your Kinde domain, `<your-client-id>` and `<your-client-secret>` with your machine to machine app keys.
 
 ## Call management API
 
-The client can be used to call the management API.  For example, listing users:
+The client can be used to call the management API. For example, listing users:
+
 ```csharp
 var usersApi = new UsersApi(client);
 var users = await usersApi.GetUsersAsync();
@@ -67,9 +71,11 @@ foreach (var user in users.Users)
     Console.WriteLine($"Id: {user.Id}, Email: {user.Email}, Name: {user.FirstName} {user.LastName}.");
 }
 ```
+
 Note this requires the `read:users` scope to be added to the API in the machine to machine application in Kinde.
 
 An example of creating an organization then renaming it:
+
 ```csharp
 var orgApi = new OrganizationsApi(client);
 var newOrg = await orgApi.CreateOrganizationAsync(new CreateOrganizationRequest("My new organization"));
@@ -79,6 +85,7 @@ var response = await orgApi.UpdateOrganizationAsync(newOrg.Organization.Code, ne
     Name = "A different name"
 });
 ```
+
 Note this requires the `create:organizations` and `update:organizations` scopes to be added to the API in the machine to machine application in Kinde.
 
 For full details of the available management API functions, see the [Kinde Management API specification](https://kinde.com/api/docs/#kinde-management-api).


### PR DESCRIPTION
- Make URLs relative
- Add missing backslash to link to comply with canonical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and readability of the "Mixed auth set up for B2B and B2C" guide, including updated internal links and enhanced bullet point alignment.
	- Enhanced the .NET SDK documentation with consistent formatting, updated links, and improved clarity in the "Before you begin" and "Call management API" sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->