### PR TITLE
fix: Capitalize Google Workspace correctly and ignore Jwt and Uri

### DIFF
--- a/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
+++ b/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
@@ -13,7 +13,7 @@ relatedArticles:
 
 If you have an app or site that supports a mix of business customers and direct customers, this guide shows you how to set up authentication in Kinde to meet both these needs.
 
-For example, say you run a finance business and you have separate sign-ins for accounting business partners and direct customers. Accounting businesses sign in with an enterprise identity, e.g. SAML and direct customers sign in with email and an OTP. 
+For example, say you run a finance business and you have separate sign-ins for accounting business partners and direct customers. Accounting businesses sign in with an enterprise identity, e.g. SAML and direct customers sign in with email and an OTP.
 
 This topic explains how to create a simple, unified experience for both groups.
 
@@ -36,7 +36,7 @@ This simplifies the sign in experience for all your users, including your enterp
 
 ### Example of a unified authentication experience
 
-This is what happens behind the scenes with the auth setup. 
+This is what happens behind the scenes with the auth setup.
 
 ![image.png](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/ff106642-c42f-44cf-4a89-84406a717000/public)
 
@@ -50,29 +50,29 @@ In this scenario, your direct customers will sign in with email and a one-time-p
 
 ### Step 2: Set up auth for your B2B users
 
-Authentication for business customers can be more complex, with additional security considerations and set up time involved. For example, a partner business may require employees to only access your web app using their business email and for authentication to be centralised with their own identity provider via SAML. 
+Authentication for business customers can be more complex, with additional security considerations and set up time involved. For example, a partner business may require employees to only access your web app using their business email and for authentication to be centralised with their own identity provider via SAML.
 
 Let’s go through the process for setting up 5 SAML enterprise connections for 5 different business customers.
 
 1. [Add 5 separate enterprise connections to Kinde](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/). E.g. EC1, EC2, EC3, and so on.
-    1. Configure each connection with the domain information, including email domains in the [home realm discovery](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/#home-realm-discovery) field. You may need to ask the customer’s IT team for this information.
-    2. (Recommended) Switch on the **Create user on sign up** option to [enable JIT provisioning](https://docs.kinde.com/authenticate/enterprise-connections/provision-users-enterprise/). 
-2. [Create 5 organizations](https://docs.kinde.com/build/organizations/add-and-manage-organizations/), one for each business customer (and connection), and select only [the relevant enterprise connection for each organization](https://docs.kinde.com/authenticate/manage-authentication/organization-auth-experience/#set-custom-authentication-for-an-organization). 
-    
-    For example:
-    
-    | For this org… | Switch on this auth connection… |
-    | --- | --- |
-    | Organization 1 | EC1 (domain x home realm) |
-    | Organization 2 | EC2 (domain y home realm) |
-    | Organization 3 | EC3 (domain a home realm) |
-    | Organization 4 | EC4 (domain b home realm) |
-    | Organization 5 | EC5 (domain c home realm) |
+   1. Configure each connection with the domain information, including email domains in the [home realm discovery](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/#home-realm-discovery) field. You may need to ask the customer’s IT team for this information.
+   2. (Recommended) Switch on the **Create user on sign up** option to [enable JIT provisioning](https://docs.kinde.com/authenticate/enterprise-connections/provision-users-enterprise/).
+2. [Create 5 organizations](https://docs.kinde.com/build/organizations/add-and-manage-organizations/), one for each business customer (and connection), and select only [the relevant enterprise connection for each organization](https://docs.kinde.com/authenticate/manage-authentication/organization-auth-experience/#set-custom-authentication-for-an-organization).
+
+   For example:
+
+   | For this org…  | Switch on this auth connection… |
+   | -------------- | ------------------------------- |
+   | Organization 1 | EC1 (domain x home realm)       |
+   | Organization 2 | EC2 (domain y home realm)       |
+   | Organization 3 | EC3 (domain a home realm)       |
+   | Organization 4 | EC4 (domain b home realm)       |
+   | Organization 5 | EC5 (domain c home realm)       |
 
 3. In each organization:
-    1. Go to **Policies** and add the relevant domain to the **Allowed domains** field.
-    2. Select **Auto-add users from allowed domains**. This activates JIT provisioning for users signing up from this domain.
-    3. Select **Save**.
+   1. Go to **Policies** and add the relevant domain to the **Allowed domains** field.
+   2. Select **Auto-add users from allowed domains**. This activates JIT provisioning for users signing up from this domain.
+   3. Select **Save**.
 
 With home realm discovery and allowed domains set, when a user enters an email that matches the domain name they will be routed through that enterprise connection. There is no need for them to self-select which connection they belong to.
 
@@ -84,10 +84,10 @@ To achieve the above scenario, all the supported sign-in methods need to be swit
 
 ## Optimize your auth flow
 
-This unified model of authentication can be extended to 10’s or 100’s of organizations, all while maintaining the same sign in screen. 
+This unified model of authentication can be extended to 10’s or 100’s of organizations, all while maintaining the same sign in screen.
 
 Other situations you can cater for include:
 
 - [Adding MFA for an organization's users](https://docs.kinde.com/authenticate/multi-factor-auth/mfa-per-org)
-- Adding other [enterprise connections](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/) (e.g. [Google workspace](https://docs.kinde.com/authenticate/enterprise-connections/custom-saml-google-workspace/) or [Microsoft Entra ID](https://docs.kinde.com/authenticate/enterprise-connections/azure/))
+- Adding other [enterprise connections](https://docs.kinde.com/authenticate/enterprise-connections/about-enterprise-connections/) (e.g. [Google Workspace](https://docs.kinde.com/authenticate/enterprise-connections/custom-saml-google-workspace/) or [Microsoft Entra ID](https://docs.kinde.com/authenticate/enterprise-connections/azure/))
 - [Auto-assigning user roles](https://docs.kinde.com/manage-users/roles-and-permissions/default-user-roles/)

--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -19,7 +19,7 @@ Kinde supports a number of enterprise connection types, including:
 
 - [Custom SAML](/authenticate/enterprise-connections/custom-saml/)
 - [Microsoft Entra ID](/authenticate/enterprise-connections/azure/) (was Azure AD) WS Federated or Open ID
-- [Google workspace](/authenticate/enterprise-connections/custom-saml-google-workspace/) (via SAML)
+- [Google Workspace](/authenticate/enterprise-connections/custom-saml-google-workspace/) (via SAML)
 - [Okta](/authenticate/enterprise-connections/okta-saml-connection/) (via SAML)
 - [Cloudflare](/authenticate/enterprise-connections/cloudflare-saml/) (via SAML)
 
@@ -31,7 +31,7 @@ The number of enterprise connections you can have depends on your [Kinde plan](h
 
 ## Provisioning for enterprise connections
 
-Kinde offer a number of provisioning options for enterprise connections, including **just in time (JIT)** provisioning and **pre-provisioning** options. 
+Kinde offer a number of provisioning options for enterprise connections, including **just in time (JIT)** provisioning and **pre-provisioning** options.
 
 See [Provisioning users with enterprise connections](/authenticate/enterprise-connections/provision-users-enterprise/)
 
@@ -45,11 +45,11 @@ When users sign up via an enterprise connection with single-sign-on (SSO), they 
 
 ### The sign in button on the auth page
 
-When you set up an enterprise connection in Kinde, the SSO button on the authentication page gets linked to the IdP by default, similar to how you see a Google or Facebook sign-in option. 
+When you set up an enterprise connection in Kinde, the SSO button on the authentication page gets linked to the IdP by default, similar to how you see a Google or Facebook sign-in option.
 
 This is fine if you only have one connection, but is not ideal if you have multiple connections and you don’t want to show multiple SSO buttons to all users.
 
-To avoid this, you can use home realm discovery (below). 
+To avoid this, you can use home realm discovery (below).
 
 ### Home realm discovery
 

--- a/src/content/docs/developer-tools/your-apis/dotnet-based-apis.mdx
+++ b/src/content/docs/developer-tools/your-apis/dotnet-based-apis.mdx
@@ -8,7 +8,8 @@ relatedArticles:
   - 02d02820-92da-4721-9a91-222c9b095869
 ---
 
-
+{/* @case-police-ignore Uri */}
+{/* @case-police-ignore Jwt */}
 
 This article walks through configuring an ASP.NET application to accept and validate an access token from Kinde.
 
@@ -19,40 +20,40 @@ A complete sample project can be found in the .NET [starter kit](https://github.
 ## Configure your project
 
 1. Install the package that handles tokens.
-    
-    ```bash
-    dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
-    ```
+
+   ```bash
+   dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
+   ```
 
 2. Configure application services (typically `Program.cs`) to use the package.
-    
-    ```csharp
-    builder.Services
-        .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
-        {
-          // These two lines map the Kinde user ID to Identity.Name (optional).
-          options.MapInboundClaims = false;
-          options.TokenValidationParameters.NameClaimType = "sub";
-        });
-    ```
 
-3. Configure `appsettings.json` for your Kinde application. Replace `<your-domain>` with your Kinde domain and `<your-audience>` with the audience associated with your API in Kinde. 
-    
-    ```json
-      "Authentication": {
-        "Schemes": {
-          "Bearer": {
-            "Authority": "https://<your-domain>.kinde.com",
-            "ValidAudiences": [
-              "<your-audience>"
-            ]
-          }
-        }
-      }
-    ```
+   ```csharp
+   builder.Services
+       .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+       .AddJwtBearer(options =>
+       {
+         // These two lines map the Kinde user ID to Identity.Name (optional).
+         options.MapInboundClaims = false;
+         options.TokenValidationParameters.NameClaimType = "sub";
+       });
+   ```
 
-.NET authentication requires an audience. If you don’t already have an audience defined, you will need to do this by [registering your API](/developer-tools/your-apis/register-manage-apis/). 
+3. Configure `appsettings.json` for your Kinde application. Replace `<your-domain>` with your Kinde domain and `<your-audience>` with the audience associated with your API in Kinde.
+
+   ```json
+     "Authentication": {
+       "Schemes": {
+         "Bearer": {
+           "Authority": "https://<your-domain>.kinde.com",
+           "ValidAudiences": [
+             "<your-audience>"
+           ]
+         }
+       }
+     }
+   ```
+
+.NET authentication requires an audience. If you don’t already have an audience defined, you will need to do this by [registering your API](/developer-tools/your-apis/register-manage-apis/).
 
 ## Manage authorization with policies
 
@@ -73,12 +74,12 @@ builder.Services
     });
 ```
 
-[Set up permissions](/manage-users/roles-and-permissions/user-permissions/) in Kinde. 
+[Set up permissions](/manage-users/roles-and-permissions/user-permissions/) in Kinde.
 
 ### Via role claims
 
 1. [Set up Roles](/manage-users/roles-and-permissions/user-permissions/) in Kinde.
-2. Add roles to the access token via custom claims, see the [token customization](/build/tokens/token-customization/) procedure. 
+2. Add roles to the access token via custom claims, see the [token customization](/build/tokens/token-customization/) procedure.
 3. Create a policy for a particular role, for example:
 
 ```csharp
@@ -96,7 +97,7 @@ Note roles defined in Kinde do not map to roles as defined in ASP.NET, so the re
 
 ## Secure controller-based APIs
 
-To protect routes, add the `[Authorize]` attribute (from the `Microsoft.AspNetCore.Authorization` package) to any controllers or actions required. 
+To protect routes, add the `[Authorize]` attribute (from the `Microsoft.AspNetCore.Authorization` package) to any controllers or actions required.
 
 For example, allow access only to users that satisfy the policy defined in the previous section:
 
@@ -123,62 +124,62 @@ See the ASP.NET Core documentation for more details about [securing minimal APIs
 
 ## Swagger UI
 
-Swagger UI provides an easy way to test APIs while in development.  
+Swagger UI provides an easy way to test APIs while in development.
 
-For secured APIs, an access token is sent from your front end application with each request.  Swagger UI can be configured to initiate auth and populate the token for you.
+For secured APIs, an access token is sent from your front end application with each request. Swagger UI can be configured to initiate auth and populate the token for you.
 
 1. Configure Swagger with the details of Kinde’s OpenID Connect configuration:
-    
-    ```csharp
-    builder.Services.AddSwaggerGen(options =>
-    {
-      var authority = builder.Configuration["Authentication:Schemes:Bearer:Authority"];
-      options.AddSecurityDefinition(
-        "oidc",
-        new OpenApiSecurityScheme
-        {
-          Type = SecuritySchemeType.OpenIdConnect,
-          OpenIdConnectUrl = new Uri(authority + "/.well-known/openid-configuration")
-        }
-      );
-    
-      options.AddSecurityRequirement(
-        new OpenApiSecurityRequirement
-        {
-          {
-            new OpenApiSecurityScheme
-            {
-              Reference = new OpenApiReference
-                { Type = ReferenceType.SecurityScheme, Id = "oidc" },
-            },
-            new string[] { }
-          }
-        }
-      );
-    });
-    ```
-    
+
+   ```csharp
+   builder.Services.AddSwaggerGen(options =>
+   {
+     var authority = builder.Configuration["Authentication:Schemes:Bearer:Authority"];
+     options.AddSecurityDefinition(
+       "oidc",
+       new OpenApiSecurityScheme
+       {
+         Type = SecuritySchemeType.OpenIdConnect,
+         OpenIdConnectUrl = new Uri(authority + "/.well-known/openid-configuration")
+       }
+     );
+
+     options.AddSecurityRequirement(
+       new OpenApiSecurityRequirement
+       {
+         {
+           new OpenApiSecurityScheme
+           {
+             Reference = new OpenApiReference
+               { Type = ReferenceType.SecurityScheme, Id = "oidc" },
+           },
+           new string[] { }
+         }
+       }
+     );
+   });
+   ```
+
 2. Configure Swagger UI to pre-populate the relevant parameters:
-    
-    ```csharp
-    app.UseSwaggerUI(c =>
-    {
-      c.OAuthClientId("<frontend-app-client-id>");
-      c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>
-        { { "audience", builder.Configuration["Authentication:Schemes:Bearer:ValidAudiences:0"] ?? "" } });
-      c.OAuthUsePkce();
-    });
-    ```
-    
+
+   ```csharp
+   app.UseSwaggerUI(c =>
+   {
+     c.OAuthClientId("<frontend-app-client-id>");
+     c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>
+       { { "audience", builder.Configuration["Authentication:Schemes:Bearer:ValidAudiences:0"] ?? "" } });
+     c.OAuthUsePkce();
+   });
+   ```
+
 3. Swap `<frontend-app-client-id>` with your front end application’s client ID shown in Kinde.
 4. Add the callback URL to your front end application’s [allowed callbacks](/get-started/connect/callback-urls/) so that the Swagger UI initiates auth and returns to Swagger UI after auth.
-    
-    For local development, the callback will look like the following, though the port may differ:
-    
-    ```csharp
-    https://localhost:7179/swagger/oauth2-redirect.html
-    ```
-    
+
+   For local development, the callback will look like the following, though the port may differ:
+
+   ```csharp
+   https://localhost:7179/swagger/oauth2-redirect.html
+   ```
+
 5. Once this is set up, use the `Authorize` button to initiate auth. On return, API requests should be automatically populated with the access token. Note for front end applications, implicit flow is not supported, only PKCE is supported.
 
 ## Troubleshooting
@@ -186,9 +187,9 @@ For secured APIs, an access token is sent from your front end application with e
 When mismatched versions of dependent libraries are resolved, requests to the API may fail with HTTP 401 and a token validation error. It will look something like this:
 
 ```csharp
-Bearer error="invalid_token",error_description="The signature key was not found" 
+Bearer error="invalid_token",error_description="The signature key was not found"
 ```
 
-For example, if version 7.4.0 or later of `System.IdentityModel.Tokens.Jwt` is installed with a version of `Microsoft.AspNetCore.Authentication.JwtBearer`  that is dependent on an earlier version of `Microsoft.IdentityModel.Protocols.OpenIdConnect`.
+For example, if version 7.4.0 or later of `System.IdentityModel.Tokens.Jwt` is installed with a version of `Microsoft.AspNetCore.Authentication.JwtBearer` that is dependent on an earlier version of `Microsoft.IdentityModel.Protocols.OpenIdConnect`.
 
 To fix, you would update the version of `Microsoft.IdentityModel.Protocols.OpenIdConnect` to match your version of `System.IdentityModel.Tokens.Jwt`. E.g. ensure they are both 7.4.0.

--- a/src/content/docs/integrate/connected-apps/google-drive-connected-app.mdx
+++ b/src/content/docs/integrate/connected-apps/google-drive-connected-app.mdx
@@ -29,7 +29,7 @@ This is Step 2 of the [Kinde Connected apps setup](/integrate/connected-apps/add
 You need to configure consent to update scopes before creating the OAuth client ID.
 
 1. Select **Configure Consent Screen**.
-2. Select the **User type**: Internal or External. This will usually be **Internal** for Google workspaces.
+2. Select the **User type**: Internal or External. This will usually be **Internal** for Google Workspaces.
 3. Select **Create**. You’ll be prompted to follow the app registration process.
 
 <img


### PR DESCRIPTION
- Fix `Google Workspace` to have a capital "W"
- Add ignore comments for `Jwt` and `Uri` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and structure of the mixed B2B and B2C authentication guide, with expanded sections and visual aids.
	- Improved formatting and consistency in the enterprise connections document.
	- Refined the .NET-based APIs integration guide for better readability and standardized formatting.
	- Updated the Google Drive connected app documentation for consistency in terminology and formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->