### PR TITLE
Update toggle name on disable-sign-up page

### DIFF
--- a/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
+++ b/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
@@ -36,5 +36,5 @@ However, if you allow self sign-up in your business (and have not disabled it as
 1. Go to **Organizations**.
 2. Select the organization you want to disable sign-ups for.
 3. Go to **Policies**.
-4. Switch off the **Allow self-sign up** option.
+4. Switch off the **Allow org members to be auto-added** option.
 5. Select **Save**.


### PR DESCRIPTION
The name of the disable self signup toggle is changed to "Allow org members to be auto-added".
I have updated the name of the toggle in the docs on this.

#### Related issues & labels (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions in the "Disable self sign-up" document to clarify the setting for organization member auto-addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->