### PR TITLE
fix: added backslash so URLs are canonical

### DIFF
--- a/src/content/docs/developer-tools/about/our-sdks.mdx
+++ b/src/content/docs/developer-tools/about/our-sdks.mdx
@@ -29,7 +29,7 @@ Make sure that your tech stack’s versions are compatible with the SDK you want
 ## **Back end**
 
 - [Elixir SDK](/developer-tools/sdks/backend/elixir-sdk/)
-- [ExpressJS SDK](/developer-tools/sdks/backend/express-sdk/)
+- [Express.js SDK](/developer-tools/sdks/backend/express-sdk/)
 - [.NET SDK](/developer-tools/sdks/backend/dotnet-sdk/)
 - [Java SDK](/developer-tools/sdks/backend/java-sdk/)
 - [Next.js App Router SDK](/developer-tools/sdks/backend/nextjs-sdk/)

--- a/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nodejs-sdk.mdx
@@ -10,17 +10,17 @@ head:
       content: "https://kinde.com/assets/images/open-graph/DOCS-SSI-SDK_NodeJS.png"
 ---
 
-Kinde has a number of SDKs tailored to frameworks run on Node.js.  Refer to the SDK for your framework:
+Kinde has a number of SDKs tailored to frameworks run on Node.js. Refer to the SDK for your framework:
 
- * [Apollo Server](/developer-tools/sdks/backend/apollo-graphql)
- * [Express](/developer-tools/sdks/backend/express-sdk)
- * [Express + GraphQL](/developer-tools/sdks/backend/node-express-graphql)
- * [Next.js App Router](/developer-tools/sdks/backend/nextjs-sdk)
- * [Next.js Pages Router](/developer-tools/sdks/backend/nextjs-prev-sdk)
- * [Nuxt](/developer-tools/sdks/backend/nuxt-module)
- * [Remix](/developer-tools/sdks/backend/remix-sdk)
- * [SvelteKit](/developer-tools/sdks/backend/sveltekit-sdk)
+- [Apollo Server](/developer-tools/sdks/backend/apollo-graphql/)
+- [Express](/developer-tools/sdks/backend/express-sdk/)
+- [Express + GraphQL](/developer-tools/sdks/backend/node-express-graphql/)
+- [Next.js App Router](/developer-tools/sdks/backend/nextjs-sdk/)
+- [Next.js Pages Router](/developer-tools/sdks/backend/nextjs-prev-sdk/)
+- [Nuxt](/developer-tools/sdks/backend/nuxt-module/)
+- [Remix](/developer-tools/sdks/backend/remix-sdk/)
+- [SvelteKit](/developer-tools/sdks/backend/sveltekit-sdk/)
 
-For all other frameworks, the [TypeScript SDK](/developer-tools/sdks/backend/typescript-sdk) can be used to integrate with Kinde.
+For all other frameworks, the [TypeScript SDK](/developer-tools/sdks/backend/typescript-sdk/) can be used to integrate with Kinde.
 
 If you need help connecting to Kinde, please contact us at [support@kinde.com](mailto:support@kinde.com).


### PR DESCRIPTION
- Make internal URLs follow canonical. (with backslashes)
- Update `ExpressJS` to `Express.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the name of the "ExpressJS SDK" to "Express.js SDK" for consistency.
	- Added trailing slashes to various SDK URLs in the Node.js SDK documentation for improved link accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->