### PR TITLE
Fix/new biz passwordless sign in default

### DIFF
--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -21,7 +21,7 @@ Allow your users to sign up or sign in:
 - [by invitation only](/authenticate/custom-configurations/disable-sign-up/)
 - using self-sign-up (default)
 - [with a password](/authenticate/authentication-methods/password-authentication/)
-- [passwordless](/authenticate/authentication-methods/passwordless-authentication/)
+- [passwordless](/authenticate/authentication-methods/passwordless-authentication/) (Applied by default in all new Kinde businesses)
 - with a [phone number](/authenticate/authentication-methods/phone-authentication/)
 - with a range of [social sign in options](/authenticate/social-sign-in/add-social-sign-in/), like Google, Apple, Slack, and more
 - via [enterprise connections](/authenticate/enterprise-connections/about-enterprise-connections/) such as Cloudflare or SAML

--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -34,6 +34,12 @@ If you switch your users from passwordless to password, Kinde will first check i
 
 ### Passwordless
 
+<Aside>
+
+Email + passwordless is switched on for all new Kinde businesses by default
+
+</Aside>
+
 For [passwordless](/authenticate/authentication-methods/passwordless-authentication/) authentication, set up authentication so users can authenticate via email or username using a one time code.
 
 When you activate this option, users will be sent a one-time password (OTP) to confirm their identity when they sign in. This option is more secure than using passwords, which need to be stored and protected by the user.

--- a/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
@@ -11,6 +11,12 @@ relatedArticles:
 
 Passwordless authentication is a type of authentication that does not require end-users to set or maintain passwords for access to an application. Instead, they authenticate using a one-time passcode (OTP).
 
+<Aside>
+
+The email + passwordless method is switched on by default in all new Kinde businesses
+
+</Aside>
+
 ## About one-time passcodes (OTPs)
 
 Kinde does not support magic links as a password alternative, instead, we prefer to use one-time passcodes (OTPs) as they are more secure, and require manual entry as opposed to a single click.

--- a/src/content/docs/get-started/guides/set-up-tasks.mdx
+++ b/src/content/docs/get-started/guides/set-up-tasks.mdx
@@ -33,7 +33,7 @@ Here are common some set up tasks. Depending on your business structure and how 
 
 ## Authentication
 
-- Select and [set up authentication](/authenticate/authentication-methods/set-up-user-authentication/) for your apps
+- Select and [set up authentication](/authenticate/authentication-methods/set-up-user-authentication/) for your apps (Email + passwordless is set up by default in your first app when you add a new business)
 - Enable [social sign up options](/authenticate/social-sign-in/add-social-sign-in/)
 - Set up [multi-factor authentication](/authenticate/multi-factor-auth/enable-multi-factor-authentication/)
 - Add [MS Entra ID](/authenticate/enterprise-connections/azure/) or [SAML](/authenticate/enterprise-connections/custom-saml/) enterprise authentication (if you have enterprise customers)


### PR DESCRIPTION
Added notes to indicate that all new Kinde businesses are set to use email + passwordless by default. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added clarifying notes about default passwordless authentication settings for new Kinde businesses across multiple documents.
- **Documentation**
	- Enhanced setup instructions for Kinde, specifying that "Email + passwordless is set up by default in your first app when you add a new business."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->