### PR TITLE
fix: update code language in jwt block

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/access-token-for-api.mdx
+++ b/src/content/docs/developer-tools/kinde-api/access-token-for-api.mdx
@@ -286,7 +286,7 @@ Make sure to replace `<your_subdomain>`, `<your_m2m_client_id>` and `<your_m2m_c
 
 The response will contain a signed JWT containing claims including the scopes the token is allowed to access and the expiry time. Here is an example token:
 
-```jwt
+```json
 
 {
   "aud": [
@@ -300,7 +300,7 @@ The response will contain a signed JWT containing claims including the scopes th
   "iat": 1729725640,
   "iss": "https://example.kinde.com",
   "jti": "6f091ebe-44ba-4afc-bd2f-05fcccafc89e",
-  "scope": "read:users update:users",
+  "scope": "read:users update:users"
 }
 
 ```


### PR DESCRIPTION
Update the code language from `jwt` to `json` for the code block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and structure of the Kinde Management API access token guide.
	- Enhanced clarity with a JSON code block for JWT response examples.
	- Standardized examples across multiple programming languages.
	- Clarified instructions for using access tokens in API requests.
	- Added emphasis on replacing placeholders with actual values.
	- Introduced a new section for the Kinde Management API JS SDK and a Postman setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->