### PR TITLE
Fix/update info on enterprise identities

### DIFF
--- a/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
+++ b/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
@@ -41,6 +41,8 @@ If a user signs up with a trusted social provider that provides us a verified em
 
 An enterprise identity is created when a user signs up via an enterprise connection, or when they sign in via a trusted provider who supplies a verified email that matches an existing email identity.
 
+Note that a user's identity information is sourced with the identity provider and is managed via the identity provider, not in Kinde.
+
 ## Trusting emails from providers
 
 ### Trusted emails

--- a/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
+++ b/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
@@ -41,7 +41,7 @@ If a user signs up with a trusted social provider that provides us a verified em
 
 An enterprise identity is created when a user signs up via an enterprise connection, or when they sign in via a trusted provider who supplies a verified email that matches an existing email identity.
 
-Note that a user's identity information is sourced with the identity provider and is managed via the identity provider, not in Kinde.
+Users with enterprise identities in Kinde can't also have other identity types in Kinde. E.g. a user can have an email identity and a social identity. But if a user has an enterprise identity, they cannot have other identities. In this case, identity information is sourced with the identity provider and is managed via the identity provider, not in Kinde.
 
 ## Trusting emails from providers
 

--- a/src/content/docs/manage-users/add-and-edit/add-manage-user-identities.mdx
+++ b/src/content/docs/manage-users/add-and-edit/add-manage-user-identities.mdx
@@ -14,6 +14,12 @@ This topic explains how to add profile identities manually in Kinde - you might 
 
 You can also add identities via [the Kinde Management API](https://kinde.com/api/docs/#kinde-management-api). You might do it this way for bulk processes.
 
+<Aside>
+
+Users with enterprise identities in Kinde can't also have other identity types in Kinde. E.g. a user can have an email identity and a social identity. But if a user has an enterprise identity, they cannot have other identities.
+
+</Aside>
+
 ## Add an identity
 
 1. In Kinde, go to **Users**.


### PR DESCRIPTION
Updated to clarify that enterprise user identities are standalone and cannot also have social or email identities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added clarification on enterprise identities, specifying that users with enterprise identities cannot have other identity types (e.g., email or social).
	- Enhanced documentation on identity management processes, including restrictions and implications for users with enterprise identities.
  
- **Documentation**
	- Updated sections on identity credentials and verification processes to reinforce security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->