### PR TITLE
feat: Add API docs (stage 1)

### DIFF
--- a/.github/workflows/check-for-duplicate-page-ids.yml
+++ b/.github/workflows/check-for-duplicate-page-ids.yml
@@ -6,7 +6,7 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-duplicates:

--- a/.github/workflows/check-for-duplicate-page-ids.yml
+++ b/.github/workflows/check-for-duplicate-page-ids.yml
@@ -6,7 +6,7 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-duplicates:

--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -6,7 +6,7 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   validate-links:

--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -6,7 +6,7 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   validate-links:
@@ -25,6 +25,10 @@ jobs:
         run: npm install
 
       - name: Build docs
+        env:
+          PUBLIC_KINDE_MANAGEMENT_API_SPEC_URL: ${{secrets.PUBLIC_KINDE_MANAGEMENT_API_SPEC_URL}}
+          PUBLIC_KINDE_FRONTEND_API_SPEC_URL: ${{secrets.PUBLIC_KINDE_FRONTEND_API_SPEC_URL}}
+          PUBLIC_KINDE_PROXY_URL: ${{secrets.PUBLIC_KINDE_PROXY_URL}}
         run: npm run build
 
       - name: Run link validation script

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# spec files
+public/specs

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -35,7 +35,8 @@ customHeaders:
           'sha256-ksuAFu7Hd775nzkr+SiQFnrrgkdZXsZuPdyVrecDp/4='
           'sha256-wX2yOADeV+NMngflD5uYi3vl50SHC4sfM1EmylVjlX4='
           'sha256-7eCV4jtsr4t4knb3c4FCRPeu7GGZeOUGE3XvWix0XOQ='
-          'sha256-OizSKqsU+f0G4vojbxNt0Lao3kUpTmCLQSv3y6P7qhQ=' 'self'
+          'sha256-OizSKqsU+f0G4vojbxNt0Lao3kUpTmCLQSv3y6P7qhQ='
+          'sha256-ZOND5PirXJ/KGOiJVbRQAIskp9o83/I3ySoXkGfvuec=' 'self'
           widgets.kinde.com kinde.com
       - key: Strict-Transport-Security
         value: max-age=31536000; includeSubDomains; preload
@@ -55,3 +56,7 @@ customHeaders:
     headers:
       - key: Cache-Control
         value: max-age=3600
+  - pattern: /kinde-apis/*
+    headers:
+      - key: Content-Security-Policy
+        value: frame-ancestors 'none'

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "autoprefixer": "^10.4.16",
         "chalk": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
-        "dotenv": "^16.3.1",
+        "dotenv": "^16.4.5",
         "glob": "^10.4.5",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
@@ -3571,15 +3571,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "dev": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "npm run get-api-specs && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "lint": "npx prettier \"src/content/docs/**/*\" --write --ignore-unknown",
-    "postbuild": "node ./scripts/update-csp.js"
+    "postbuild": "node ./scripts/update-csp.js",
+    "get-api-specs": "node ./scripts/fetch-api-specs.js"
   },
   "dependencies": {
     "@astrojs/mdx": "^3.1.9",
@@ -35,7 +36,7 @@
     "autoprefixer": "^10.4.16",
     "chalk": "^5.3.0",
     "cheerio": "^1.0.0-rc.12",
-    "dotenv": "^16.3.1",
+    "dotenv": "^16.4.5",
     "glob": "^10.4.5",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",

--- a/public/specs/kinde-frontend-api-spec.yaml
+++ b/public/specs/kinde-frontend-api-spec.yaml
@@ -1,0 +1,227 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: Kinde Frontend API
+  description: >
+    To access the OAuth endpoint, you will need to use a user token. This can be
+    obtained when your users sign in via the methods you've setup in Kinde (e.g.
+    Google, passwordless, etc). Find this using the getToken command in the
+    relevant SDK.
+  termsOfService: https://docs.kinde.com/trust-center/agreements/terms-of-service/
+  contact:
+    name: Kinde Support Team
+    email: support@kinde.com
+    url: https://docs.kinde.com
+servers:
+  - url: https://{subdomain}.kinde.com
+    variables:
+      subdomain:
+        default: your_kinde_subdomain
+        description: The subdomain generated for your business on Kinde.
+tags:
+  - name: OAuth
+    x-displayName: OAuth
+paths:
+  /oauth2/v2/user_profile:
+    get:
+      tags:
+        - OAuth
+      operationId: getUserProfileV2
+      summary: Get user profile
+      description: >
+        This endpoint returns a user's ID, names, profile picture URL and email
+        of the currently logged in user.
+      responses:
+        '200':
+          description: Details of logged in user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user_profile_v2'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /oauth2/introspect:
+    post:
+      tags:
+        - OAuth
+      operationId: tokenIntrospection
+      description: Retrieve information about the provided token.
+      summary: Get token details
+      requestBody:
+        description: Token details.
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: The token to be introspected.
+                  type: string
+                token_type:
+                  type: string
+                  description: The provided token's type.
+      responses:
+        '200':
+          description: Details of the token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/token_introspect'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/token_introspect'
+        '401':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/token_error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/token_error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /oauth2/revoke:
+    post:
+      tags:
+        - OAuth
+      operationId: tokenRevocation
+      description: Revoke a previously issued token.
+      summary: Revoke token
+      requestBody:
+        description: Details of the token to be revoked.
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: The token to be revoked.
+                  type: string
+                client_id:
+                  type: string
+                  description: The identifier for your client.
+                client_secret:
+                  type: string
+                  description: The secret associated with your client.
+      responses:
+        '200':
+          description: Token successfully revoked.
+        '401':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/token_error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/token_error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+components:
+  schemas:
+    token_introspect:
+      type: object
+      properties:
+        active:
+          type: boolean
+          description: Indicates the status of the token.
+        aud:
+          type: array
+          description: Array of intended token recipients.
+          items:
+            type: string
+        client_id:
+          type: string
+          description: Identifier for the requesting client.
+        exp:
+          type: string
+          description: Token expiration timestamp.
+        iat:
+          type: string
+          description: Token issuance timestamp.
+    token_error_response:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error.
+        error_description:
+          type: string
+          description: The error description.
+    user_profile_v2:
+      type: object
+      properties:
+        sub:
+          type: string
+          description: Unique ID of the user in Kinde.
+          example: kp_c3143a4b50ad43c88e541d9077681782
+        provided_id:
+          type: string
+          description: >-
+            Value of the user's ID in a third-party system when the user is
+            imported into Kinde.
+          example: some_external_id
+          nullable: true
+        name:
+          type: string
+          description: User's first and last name separated by a space.
+          example: John Snow
+        given_name:
+          type: string
+          description: User's first name.
+          example: John
+        family_name:
+          type: string
+          description: User's last name.
+          example: Snow
+        updated_at:
+          type: integer
+          description: Date the user was last updated at (In Unix time).
+          example: 1612345678
+        email:
+          type: string
+          description: User's email address if available.
+          example: john.snow@example.com
+        email_verified:
+          type: boolean
+          description: Whether the user's email address has been verified.
+          example: true
+        picture:
+          type: string
+          description: URL that point's to the user's picture or avatar
+          example: https://example.com/john_snow.jpg
+          nullable: true
+        preferred_username:
+          type: string
+          description: User's preferred username.
+          example: john_snow
+          nullable: true
+        id:
+          type: string
+          description: Unique ID of the user in Kinde
+          example: kp_c3143a4b50ad43c88e541d9077681782
+  securitySchemes:
+    kindeBearerAuth:
+      description: >
+        To access the OAuth endpoint, you will need to use a user token. This
+        can be obtained when your users sign in via the methods you've setup in
+        Kinde (e.g. Google, passwordless, etc). Find this using the getToken
+        command in the relevant SDK.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/public/specs/kinde-management-api-spec.yaml
+++ b/public/specs/kinde-management-api-spec.yaml
@@ -1,0 +1,7920 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: Kinde Management API
+  description: >
+
+    Provides endpoints to manage your Kinde Businesses.
+
+
+    ## Intro
+
+
+    ## Prerequisites
+
+
+    1. [Create and authorize a machine-to-machine (M2M) application for
+    accessing the Kinde Management
+    API](https://docs.kinde.com/developer-tools/kinde-api/connect-to-kinde-api/).
+
+
+    2. [Get access
+    tokens](https://docs.kinde.com/developer-tools/kinde-api/access-token-for-api/#get-access-tokens)
+  termsOfService: https://docs.kinde.com/trust-center/agreements/terms-of-service/
+  contact:
+    name: Kinde Support Team
+    email: support@kinde.com
+    url: https://docs.kinde.com
+servers:
+  - url: https://{subdomain}.kinde.com
+    variables:
+      subdomain:
+        default: your_kinde_subdomain
+        description: The subdomain generated for your business on Kinde.
+tags:
+  - name: APIs
+    x-displayName: APIs
+  - name: Applications
+    x-displayName: Applications
+  - name: Business
+    x-displayName: Business
+  - name: Industries
+    x-displayName: Industries
+  - name: Timezones
+    x-displayName: Timezones
+  - name: Callbacks
+    x-displayName: Callbacks
+  - name: Connected Apps
+    x-displayName: Connected Apps
+  - name: Connections
+    x-displayName: Connections
+  - name: Environments
+    x-displayName: Environments
+  - name: Environment variables
+    x-displayName: Environment variables
+  - name: Feature Flags
+    x-displayName: Feature Flags
+  - name: Identities
+    x-displayName: Identities
+  - name: Organizations
+    x-displayName: Organizations
+  - name: Permissions
+    x-displayName: Permissions
+  - name: Properties
+    x-displayName: Properties
+  - name: Property Categories
+    x-displayName: Property Categories
+  - name: Roles
+    x-displayName: Roles
+  - name: Subscribers
+    x-displayName: Subscribers
+  - name: Users
+    x-displayName: Users
+  - name: Webhooks
+    x-displayName: Webhooks
+paths:
+  /api/v1/apis:
+    get:
+      tags:
+        - APIs
+      operationId: getAPIs
+      summary: Get APIs
+      description: |
+        Returns a list of your APIs. The APIs are returned sorted by name.
+
+        <div>
+          <code>read:apis</code>
+        </div>
+      responses:
+        '200':
+          description: A list of APIs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_apis_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - APIs
+      operationId: addAPIs
+      summary: Create API
+      description: >
+        Register a new API. For more information read [Register and manage
+        APIs](https://docs.kinde.com/developer-tools/your-apis/register-manage-apis/).
+
+
+        <div>
+          <code>create:apis</code>
+        </div>
+      externalDocs:
+        url: https://docs.kinde.com/developer-tools/your-apis/register-manage-apis
+        description: Register and manage APIs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the API. (1-64 characters).
+                  example: Example API
+                audience:
+                  type: string
+                  description: >-
+                    A unique identifier for the API - commonly the URL. This
+                    value will be used as the `audience` parameter in
+                    authorization claims. (1-64 characters)
+                  example: https://api.example.com
+              required:
+                - name
+                - audience
+      responses:
+        '200':
+          description: APIs successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_apis_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}:
+    parameters:
+      - $ref: '#/components/parameters/api_id'
+    get:
+      tags:
+        - APIs
+      operationId: getAPI
+      summary: Get API
+      description: |
+        Retrieve API details by ID.
+
+        <div>
+          <code>read:apis</code>
+        </div>
+      responses:
+        '200':
+          description: API successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - APIs
+      operationId: deleteAPI
+      summary: Delete API
+      description: |
+        Delete an API you previously created.
+
+        <div>
+          <code>delete:apis</code>
+        </div>
+      responses:
+        '200':
+          description: API successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}/applications:
+    parameters:
+      - $ref: '#/components/parameters/api_id'
+    patch:
+      tags:
+        - APIs
+      operationId: updateAPIApplications
+      summary: Authorize API applications
+      description: |
+        Authorize applications to be allowed to request access tokens for an API
+
+        <div>
+          <code>update:apis</code>
+        </div>
+      requestBody:
+        description: The applications you want to authorize.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - applications
+              properties:
+                applications:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - id
+                    properties:
+                      id:
+                        description: The application's Client ID.
+                        type: string
+                        example: d2db282d6214242b3b145c123f0c123
+                      operation:
+                        description: >-
+                          Optional operation, set to 'delete' to revoke
+                          authorization for the application. If not set, the
+                          application will be authorized.
+                        type: string
+                        example: delete
+      responses:
+        '200':
+          description: Authorized applications updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/authorize_app_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications:
+    get:
+      tags:
+        - Applications
+      operationId: getApplications
+      summary: Get applications
+      description: |
+        Get a list of applications / clients.
+
+        <div>
+          <code>read:applications</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A successful response with a list of applications or an empty list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_applications_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Applications
+      operationId: createApplication
+      summary: Create application
+      description: |
+        Create a new client.
+
+        <div>
+          <code>create:applications</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The application's name.
+                  type: string
+                  example: React Native app
+                type:
+                  description: >-
+                    The application's type. Use `reg` for regular server
+                    rendered applications, `spa` for single-page applications,
+                    and `m2m` for machine-to-machine applications.
+                  type: string
+                  enum:
+                    - reg
+                    - spa
+                    - m2m
+              required:
+                - name
+                - type
+      responses:
+        '201':
+          description: Application successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_application_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}:
+    get:
+      tags:
+        - Applications
+      operationId: getApplication
+      summary: Get application
+      description: |
+        Gets an application given the application's ID.
+
+        <div>
+          <code>read:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Application successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_application_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Applications
+      operationId: updateApplication
+      summary: Update Application
+      description: >
+        Updates a client's settings. For more information, read [Applications in
+        Kinde](https://docs.kinde.com/build/applications/about-applications)
+
+
+        <div>
+          <code>update:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Application details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The application's name.
+                  type: string
+                language_key:
+                  description: The application's language key.
+                  type: string
+                logout_uris:
+                  description: The application's logout uris.
+                  type: array
+                  items:
+                    type: string
+                redirect_uris:
+                  description: The application's redirect uris.
+                  type: array
+                  items:
+                    type: string
+                login_uri:
+                  description: The default login route for resolving session issues.
+                  type: string
+                homepage_uri:
+                  description: The homepage link to your application.
+                  type: string
+      responses:
+        '200':
+          description: Application successfully updated.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Applications
+      operationId: deleteApplication
+      summary: Delete application
+      description: |
+        Delete a client / application.
+
+        <div>
+          <code>delete:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Application successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/connections:
+    get:
+      tags:
+        - Applications
+      operationId: GetApplicationConnections
+      description: |
+        Gets all connections for an application.
+
+        <div>
+          <code>read:application_connections</code>
+        </div>
+      summary: Get connections
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Application connections successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/connections/{connection_id}:
+    post:
+      tags:
+        - Applications
+      operationId: EnableConnection
+      summary: Enable connection
+      description: |
+        Enable an auth connection for an application.
+
+        <div>
+          <code>create:application_connections</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection successfully enabled.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Applications
+      operationId: RemoveConnection
+      summary: Remove connection
+      description: |
+        Turn off an auth connection for an application
+
+        <div>
+          <code>delete:application_connections</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/properties:
+    parameters:
+      - $ref: '#/components/parameters/application_id'
+    get:
+      tags:
+        - Applications
+      operationId: getApplicationPropertyValues
+      summary: Get property values
+      description: |
+        Gets properties for an application by client ID.
+
+        <div>
+          <code>read:application_properties</code>
+        </div>
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/properties/{property_key}:
+    parameters:
+      - $ref: '#/components/parameters/application_id'
+      - $ref: '#/components/parameters/property_key'
+    put:
+      tags:
+        - Applications
+      operationId: updateApplicationsProperty
+      summary: Update property
+      description: |
+        Update application property value.
+
+        <div>
+          <code>update:application_properties</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  oneOf:
+                    - type: string
+                    - type: boolean
+                  description: The new value for the propery
+                  example: Some new value
+              required:
+                - value
+      responses:
+        '200':
+          description: Property successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/business:
+    get:
+      tags:
+        - Business
+      operationId: getBusiness
+      summary: Get business
+      description: |
+        Get your business details.
+
+        <div>
+          <code>read:businesses</code>
+        </div>
+      responses:
+        '200':
+          description: Your business details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_business_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Business
+      operationId: updateBusiness
+      summary: Update business
+      description: |
+        Update your business details.
+
+        <div>
+          <code>update:businesses</code>
+        </div>
+      requestBody:
+        description: The business details to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                business_name:
+                  type: string
+                  description: The name of the business.
+                  example: Tailsforce Ltd
+                  nullable: true
+                email:
+                  type: string
+                  description: The email address of the business.
+                  example: sally@example.com
+                  nullable: true
+                industry_key:
+                  type: string
+                  description: >-
+                    The key of the industry of your business. Can be retrieved
+                    from the /industries endpoint.
+                  example: construction
+                  nullable: true
+                is_click_wrap:
+                  description: Whether the business is using clickwrap agreements.
+                  type: boolean
+                  example: false
+                  nullable: true
+                is_show_kinde_branding:
+                  description: >-
+                    Whether the business is showing Kinde branding. Requires a
+                    paid plan.
+                  type: boolean
+                  example: true
+                  nullable: true
+                kinde_perk_code:
+                  description: The Kinde perk code for the business.
+                  type: string
+                  nullable: true
+                phone:
+                  description: The phone number of the business.
+                  type: string
+                  example: 123-456-7890
+                  nullable: true
+                privacy_url:
+                  description: The URL to the business's privacy policy.
+                  type: string
+                  example: https://example.com/privacy
+                  nullable: true
+                terms_url:
+                  description: The URL to the business's terms of service.
+                  type: string
+                  example: https://example.com/terms
+                  nullable: true
+                timezone_key:
+                  description: >-
+                    The key of the timezone of your business. Can be retrieved
+                    from the /timezones endpoint.
+                  type: string
+                  example: los_angeles_pacific_standard_time
+                  nullable: true
+      responses:
+        '200':
+          description: Business successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/industries:
+    get:
+      tags:
+        - Industries
+      operationId: getIndustries
+      summary: Get industries
+      description: |
+        Get a list of industries and associated industry keys.
+
+        <div>
+          <code>read:industries</code>
+        </div>
+      responses:
+        '200':
+          description: A list of industries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_industries_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/timezones:
+    get:
+      tags:
+        - Timezones
+      operationId: getTimezones
+      summary: Get timezones
+      description: |
+        Get a list of timezones and associated timezone keys.
+
+        <div>
+          <code>read:timezones</code>
+        </div>
+      responses:
+        '200':
+          description: A list of timezones.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_timezones_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{app_id}/auth_redirect_urls:
+    get:
+      tags:
+        - Callbacks
+      operationId: getCallbackURLs
+      description: |
+        Returns an application's redirect callback URLs.
+
+        <div>
+          <code>read:applications_redirect_uris</code>
+        </div>
+      summary: List Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Callback URLs successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/redirect_callback_urls'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/redirect_callback_urls'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Callbacks
+      operationId: addRedirectCallbackURLs
+      description: |
+        Add additional redirect callback URLs.
+
+        <div>
+          <code>create:applications_redirect_uris</code>
+        </div>
+      summary: Add Redirect Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of callback urls.
+      responses:
+        '200':
+          description: Callbacks successfully updated
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Callbacks
+      operationId: replaceRedirectCallbackURLs
+      description: |
+        Replace all redirect callback URLs.
+
+        <div>
+          <code>update:applications_redirect_uris</code>
+        </div>
+      summary: Replace Redirect Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of callback urls.
+      responses:
+        '200':
+          description: Callbacks successfully updated
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Callbacks
+      operationId: deleteCallbackURLs
+      description: |
+        Delete callback URLs.
+
+        <div>
+          <code>delete:applications_redirect_uris</code>
+        </div>
+      summary: Delete Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+        - name: urls
+          in: query
+          description: Urls to delete, comma separated and url encoded.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Callback URLs successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{app_id}/auth_logout_urls:
+    get:
+      tags:
+        - Callbacks
+      operationId: getLogoutURLs
+      description: |
+        Returns an application's logout redirect URLs.
+
+        <div>
+          <code>read:application_logout_uris</code>
+        </div>
+      summary: List logout URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Logout URLs successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/logout_redirect_urls'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Callbacks
+      operationId: addLogoutRedirectURLs
+      description: |
+        Add additional logout redirect URLs.
+
+        <div>
+          <code>create:application_logout_uris</code>
+        </div>
+      summary: Add logout redirect URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of logout urls.
+      responses:
+        '200':
+          description: Logout URLs successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Callbacks
+      operationId: replaceLogoutRedirectURLs
+      description: |
+        Replace all logout redirect URLs.
+
+        <div>
+          <code>update:application_logout_uris</code>
+        </div>
+      summary: Replace logout redirect URls
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of logout urls.
+      responses:
+        '200':
+          description: Logout URLs successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Callbacks
+      operationId: deleteLogoutURLs
+      description: |
+        Delete logout URLs.
+
+        <div>
+          <code>delete:application_logout_uris</code>
+        </div>
+      summary: Delete Logout URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+        - name: urls
+          in: query
+          description: Urls to delete, comma separated and url encoded.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Logout URLs successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/auth_url:
+    get:
+      tags:
+        - Connected Apps
+      operationId: GetConnectedAppAuthUrl
+      description: >
+        Get a URL that authenticates and authorizes a user to a third-party
+        connected app.
+
+
+        <div>
+          <code>read:connected_apps</code>
+        </div>
+      summary: Get Connected App URL
+      parameters:
+        - name: key_code_ref
+          in: query
+          description: >-
+            The unique key code reference of the connected app to authenticate
+            against.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: user_id
+          in: query
+          description: >-
+            The id of the user that needs to authenticate to the third-party
+            connected app.
+          schema:
+            type: string
+            nullable: false
+          required: false
+        - name: org_code
+          in: query
+          description: >-
+            The code of the Kinde organization that needs to authenticate to the
+            third-party connected app.
+          schema:
+            type: string
+            nullable: false
+          required: false
+        - name: override_callback_url
+          in: query
+          description: >-
+            A URL that overrides the default callback URL setup in your
+            connected app configuration
+          schema:
+            type: string
+            nullable: false
+          required: false
+      responses:
+        '200':
+          description: >-
+            A URL that can be used to authenticate and a session id to identify
+            this authentication session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connected_apps_auth_url'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/connected_apps_auth_url'
+        '400':
+          description: Error retrieving connected app auth url.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '404':
+          description: Error retrieving connected app auth url.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/token:
+    get:
+      tags:
+        - Connected Apps
+      operationId: GetConnectedAppToken
+      description: >
+        Get an access token that can be used to call the third-party provider
+        linked to the connected app.
+
+
+        <div>
+          <code>read:connected_apps</code>
+        </div>
+      summary: Get Connected App Token
+      parameters:
+        - name: session_id
+          in: query
+          description: The unique sesssion id representing the login session of a user.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: >-
+            An access token that can be used to query a third-party provider, as
+            well as the token's expiry time.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connected_apps_access_token'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/connected_apps_access_token'
+        '400':
+          description: The session id provided points to an invalid session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/revoke:
+    post:
+      tags:
+        - Connected Apps
+      operationId: RevokeConnectedAppToken
+      description: |
+        Revoke the tokens linked to the connected app session.
+
+        <div>
+          <code>create:connected_apps</code>
+        </div>
+      summary: Revoke Connected App Token
+      parameters:
+        - name: session_id
+          in: query
+          description: The unique sesssion id representing the login session of a user.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: >-
+            An access token that can be used to query a third-party provider, as
+            well as the token's expiry time.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '405':
+          description: Invalid HTTP method used.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connections:
+    get:
+      tags:
+        - Connections
+      operationId: GetConnections
+      description: |
+        Returns a list of Connections
+
+        <div>
+          <code>read:connections</code>
+        </div>
+      summary: List Connections
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the connection to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the connection to end before.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Connections successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Connections
+      operationId: CreateConnection
+      description: |
+        Create Connection.
+
+        <div>
+          <code>create:connections</code>
+        </div>
+      summary: Create Connection
+      requestBody:
+        description: Connection details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The internal name of the connection.
+                  type: string
+                  nullable: false
+                display_name:
+                  description: The public facing name of the connection.
+                  type: string
+                  nullable: false
+                strategy:
+                  description: The identity provider identifier for the connection.
+                  type: string
+                  enum:
+                    - oauth2:apple
+                    - oauth2:azure_ad
+                    - oauth2:bitbucket
+                    - oauth2:discord
+                    - oauth2:facebook
+                    - oauth2:github
+                    - oauth2:gitlab
+                    - oauth2:google
+                    - oauth2:linkedin
+                    - oauth2:microsoft
+                    - oauth2:patreon
+                    - oauth2:slack
+                    - oauth2:stripe
+                    - oauth2:twitch
+                    - oauth2:twitter
+                    - oauth2:xero
+                    - saml:custom
+                    - wsfed:azure_ad
+                  nullable: false
+                enabled_applications:
+                  description: >-
+                    Client IDs of applications in which this connection is to be
+                    enabled.
+                  type: array
+                  items:
+                    type: string
+                options:
+                  description: The connection's options (varies by strategy).
+                  type: object
+              required:
+                - name
+                - display_name
+                - strategy
+      responses:
+        '201':
+          description: Connection successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_connection_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_connection_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connections/{connection_id}:
+    get:
+      tags:
+        - Connections
+      operationId: GetConnection
+      description: |
+        Get Connection.
+
+        <div>
+          <code>read:connections</code>
+        </div>
+      summary: Get Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The unique identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connection'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/connection'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Connections
+      operationId: UpdateConnection
+      description: |
+        Update Connection.
+
+        <div>
+          <code>update:connections</code>
+        </div>
+      summary: Update Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The unique identifier for the connection.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the connection to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The internal name of the connection.
+                  type: string
+                  nullable: false
+                display_name:
+                  description: The public facing name of the connection.
+                  type: string
+                  nullable: false
+                enabled_applications:
+                  description: >-
+                    Client IDs of applications in which this connection is to be
+                    enabled.
+                  type: array
+                  items:
+                    type: string
+                options:
+                  description: The connection's options (varies by strategy).
+                  type: object
+      responses:
+        '200':
+          description: Connection successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Connections
+      operationId: deleteConnection
+      description: |
+        Delete connection.
+
+        <div>
+          <code>delete:connections</code>
+        </div>
+      summary: Delete Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/feature_flags:
+    delete:
+      tags:
+        - Environments
+      operationId: DeleteEnvironementFeatureFlagOverrides
+      description: |
+        Delete all environment feature flag overrides.
+
+        <div>
+          <code>delete:environment_feature_flags</code>
+        </div>
+      summary: Delete Environment Feature Flag Overrides
+      responses:
+        '200':
+          description: Feature flag overrides deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    get:
+      tags:
+        - Environments
+      operationId: GetEnvironementFeatureFlags
+      description: |
+        Get environment feature flags.
+
+        <div>
+          <code>read:environment_feature_flags</code>
+        </div>
+      summary: List Environment Feature Flags
+      responses:
+        '200':
+          description: Feature flags retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_feature_flags_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_environment_feature_flags_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/feature_flags/{feature_flag_key}:
+    delete:
+      tags:
+        - Environments
+      operationId: DeleteEnvironementFeatureFlagOverride
+      description: |
+        Delete environment feature flag override.
+
+        <div>
+          <code>delete:environment_feature_flags</code>
+        </div>
+      summary: Delete Environment Feature Flag Override
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Environments
+      operationId: UpdateEnvironementFeatureFlagOverride
+      description: |
+        Update environment feature flag override.
+
+        <div>
+          <code>update:environment_feature_flags</code>
+        </div>
+      summary: Update Environment Feature Flag Override
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Flag details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  description: The flag override value.
+                  type: string
+                  nullable: false
+              required:
+                - value
+      responses:
+        '200':
+          description: Feature flag override successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment_variables:
+    get:
+      tags:
+        - Environment variables
+      operationId: getEnvironmentVariables
+      summary: Get environment variables
+      description: >
+        Get environment variables. This feature is in beta and admin UI is not
+        yet available.
+
+
+        <div>
+          <code>read:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: >-
+            A successful response with a list of environment variables or an
+            empty list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_variables_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Environment variables
+      operationId: createEnvironmentVariable
+      summary: Create environment variable
+      description: >
+        Create a new environment variable. This feature is in beta and admin UI
+        is not yet available.
+
+
+        <div>
+          <code>create:environment_variables</code>
+        </div>
+      requestBody:
+        description: The environment variable details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: The name of the environment variable (max 128 characters).
+                  example: MY_API_KEY
+                value:
+                  type: string
+                  description: >-
+                    The value of the new environment variable (max 2048
+                    characters).
+                  example: some-secret-value
+                is_secret:
+                  type: boolean
+                  description: >-
+                    Whether the environment variable is sensitive. Secrets are
+                    not-readable by you or your team after creation.
+                  example: false
+              required:
+                - key
+                - value
+      responses:
+        '201':
+          description: Environment variable successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment_variables/{variable_id}:
+    parameters:
+      - $ref: '#/components/parameters/variable_id'
+    get:
+      tags:
+        - Environment variables
+      operationId: getEnvironmentVariable
+      summary: Get environment variable
+      description: >
+        Retrieve environment variable details by ID. This feature is in beta and
+        admin UI is not yet available.
+
+
+        <div>
+          <code>read:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: Environment variable successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Environment variables
+      operationId: updateEnvironmentVariable
+      summary: Update environment variable
+      description: >
+        Update an environment variable you previously created. This feature is
+        in beta and admin UI is not yet available.
+
+
+        <div>
+          <code>update:environment_variables</code>
+        </div>
+      requestBody:
+        description: The new details for the environment variable
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: The key to update.
+                  example: MY_API_KEY
+                value:
+                  type: string
+                  description: The new value for the environment variable.
+                  example: new-secret-value
+                is_secret:
+                  type: boolean
+                  description: >-
+                    Whether the environment variable is sensitive. Secret
+                    variables are not-readable by you or your team after
+                    creation.
+      responses:
+        '200':
+          description: Environment variable successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Environment variables
+      operationId: deleteEnvironmentVariable
+      summary: Delete environment variable
+      description: >
+        Delete an environment variable you previously created. This feature is
+        in beta and admin UI is not yet available.
+
+
+        <div>
+          <code>delete:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: Environment variable successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/feature_flags:
+    post:
+      tags:
+        - Feature Flags
+      operationId: CreateFeatureFlag
+      description: |
+        Create feature flag.
+
+        <div>
+          <code>create:feature_flags</code>
+        </div>
+      summary: Create Feature Flag
+      requestBody:
+        description: Flag details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the flag.
+                  type: string
+                  nullable: false
+                description:
+                  description: Description of the flag purpose.
+                  type: string
+                  nullable: false
+                key:
+                  description: The flag identifier to use in code.
+                  type: string
+                  nullable: false
+                type:
+                  description: The variable type.
+                  type: string
+                  enum:
+                    - str
+                    - int
+                    - bool
+                  nullable: false
+                allow_override_level:
+                  description: Allow the flag to be overridden at a different level.
+                  type: string
+                  enum:
+                    - env
+                    - org
+                    - usr
+                  nullable: false
+                default_value:
+                  description: >-
+                    Default value for the flag used by environments and
+                    organizations.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - key
+                - type
+                - default_value
+      responses:
+        '201':
+          description: Feature flag successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/feature_flags/{feature_flag_key}:
+    delete:
+      tags:
+        - Feature Flags
+      operationId: DeleteFeatureFlag
+      description: |
+        Delete feature flag
+
+        <div>
+          <code>delete:feature_flags</code>
+        </div>
+      summary: Delete Feature Flag
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Feature Flags
+      operationId: UpdateFeatureFlag
+      description: |
+        Update feature flag.
+
+        <div>
+          <code>update:feature_flags</code>
+        </div>
+      summary: Replace Feature Flag
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The key identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: query
+          description: The name of the flag.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: description
+          in: query
+          description: Description of the flag purpose.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: type
+          in: query
+          description: The variable type
+          schema:
+            type: string
+            enum:
+              - str
+              - int
+              - bool
+            nullable: false
+          required: true
+        - name: allow_override_level
+          in: query
+          description: Allow the flag to be overridden at a different level.
+          schema:
+            type: string
+            enum:
+              - env
+              - org
+            nullable: false
+          required: true
+        - name: default_value
+          in: query
+          description: Default value for the flag used by environments and organizations.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: Feature flag successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/identities/{identity_id}:
+    get:
+      tags:
+        - Identities
+      operationId: GetIdentity
+      description: |
+        Returns an identity by ID
+
+        <div>
+          <code>read:identities</code>
+        </div>
+      summary: Get identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Identity successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/identity'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identity'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Identities
+      operationId: UpdateIdentity
+      description: |
+        Update identity by ID.
+
+        <div>
+          <code>update:identities</code>
+        </div>
+      summary: Update identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the identity to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                is_primary:
+                  description: Whether the identity is the primary for it's type
+                  type: boolean
+                  nullable: false
+      responses:
+        '200':
+          description: Identity successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Identities
+      operationId: DeleteIdentity
+      description: |
+        Delete identity by ID.
+
+        <div>
+          <code>delete:identities</code>
+        </div>
+      summary: Delete identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Identity successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization:
+    get:
+      tags:
+        - Organizations
+      operationId: getOrganization
+      summary: Get organization
+      description: |
+        Retrieve organization details by code.
+
+        <div>
+          <code>read:organizations</code>
+        </div>
+      parameters:
+        - in: query
+          name: code
+          description: The organization's code.
+          schema:
+            type: string
+            example: org_1ccfb819462
+      responses:
+        '200':
+          description: Organization successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: createOrganization
+      summary: Create organization
+      description: >
+        Create a new organization. To learn more read about [multi tenancy using
+        organizations](https://docs.kinde.com/build/organizations/multi-tenancy-using-organizations/)
+
+
+        <div>
+          <code>create:organizations</code>
+        </div>
+      requestBody:
+        description: Organization details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  description: The organization's name.
+                  type: string
+                  example: Acme Corp
+                feature_flags:
+                  type: object
+                  description: The organization's feature flag settings.
+                  additionalProperties:
+                    type: string
+                    enum:
+                      - str
+                      - int
+                      - bool
+                    description: Value of the feature flag.
+                external_id:
+                  description: >-
+                    The organization's external identifier - commonly used when
+                    migrating from or mapping to other systems.
+                  type: string
+                  example: some1234
+                background_color:
+                  description: The organization's brand settings - background color.
+                  type: string
+                button_color:
+                  description: The organization's brand settings - button color.
+                  type: string
+                button_text_color:
+                  description: The organization's brand settings - button text color.
+                  type: string
+                link_color:
+                  description: The organization's brand settings - link color.
+                  type: string
+                background_color_dark:
+                  description: >-
+                    The organization's brand settings - dark mode background
+                    color.
+                  type: string
+                button_color_dark:
+                  description: The organization's brand settings - dark mode button color.
+                  type: string
+                button_text_color_dark:
+                  description: >-
+                    The organization's brand settings - dark mode button text
+                    color.
+                  type: string
+                link_color_dark:
+                  description: The organization's brand settings - dark mode link color.
+                  type: string
+                theme_code:
+                  description: >-
+                    The organization's brand settings - theme/mode 'light' |
+                    'dark' | 'user_preference'.
+                  type: string
+                handle:
+                  description: >-
+                    A unique handle for the organization - can be used for
+                    dynamic callback urls.
+                  type: string
+                  example: acme_corp
+                is_allow_registrations:
+                  description: >-
+                    If users become members of this organization when the org
+                    code is supplied during authentication.
+                  type: boolean
+                  example: true
+                is_custom_auth_connections_enabled:
+                  description: Enable custom auth connections for this organization.
+                  type: boolean
+      responses:
+        '200':
+          description: Organization successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_organization_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations:
+    get:
+      tags:
+        - Organizations
+      operationId: getOrganizations
+      summary: Get organizations
+      description: |
+        Get a list of organizations.
+
+        <div>
+          <code>read:organizations</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Organizations successfully retreived.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organizations_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization/{org_code}:
+    patch:
+      tags:
+        - Organizations
+      operationId: updateOrganization
+      description: |
+        Update an organization.
+
+        <div>
+          <code>update:organizations</code>
+        </div>
+      summary: Update Organization
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_1ccfb819462
+      requestBody:
+        description: Organization details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The organization's name.
+                  type: string
+                  example: Acme Corp
+                external_id:
+                  description: The organization's ID.
+                  type: string
+                  example: some1234
+                background_color:
+                  description: The organization's brand settings - background color.
+                  type: string
+                  example: '#fff'
+                button_color:
+                  description: The organization's brand settings - button color.
+                  type: string
+                  example: '#fff'
+                button_text_color:
+                  description: The organization's brand settings - button text color.
+                  type: string
+                  example: '#fff'
+                link_color:
+                  description: The organization's brand settings - link color.
+                  type: string
+                  example: '#fff'
+                background_color_dark:
+                  description: >-
+                    The organization's brand settings - dark mode background
+                    color.
+                  type: string
+                  example: '#000'
+                button_color_dark:
+                  description: The organization's brand settings - dark mode button color.
+                  type: string
+                  example: '#000'
+                button_text_color_dark:
+                  description: >-
+                    The organization's brand settings - dark mode button text
+                    color.
+                  type: string
+                  example: '#000'
+                link_color_dark:
+                  description: The organization's brand settings - dark mode link color.
+                  type: string
+                  example: '#000'
+                theme_code:
+                  description: The organization's brand settings - theme/mode.
+                  type: string
+                  enum:
+                    - light
+                    - dark
+                    - user_preference
+                  example: light
+                handle:
+                  description: The organization's handle.
+                  type: string
+                  example: acme_corp
+                is_allow_registrations:
+                  deprecated: true
+                  description: Deprecated - Use 'is_auto_membership_enabled' instead.
+                  type: boolean
+                is_custom_auth_connections_enabled:
+                  description: Enable custom auth connections for this organization.
+                  type: boolean
+                  example: true
+                is_auto_join_domain_list:
+                  description: Users can sign up to this organization.
+                  type: boolean
+                  example: true
+                allowed_domains:
+                  description: Domains allowed for self-sign up to this environment.
+                  type: array
+                  example:
+                    - https://acme.kinde.com
+                    - https://acme.com
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Organization successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: deleteOrganization
+      description: |
+        Delete an organization.
+
+        <div>
+          <code>delete:organizations</code>
+        </div>
+      summary: Delete Organization
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Organization successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users:
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUsers
+      summary: Get organization users
+      description: |
+        Get user details for all members of an organization.
+
+        <div>
+          <code>read:organization_users</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            example: org_1ccfb819462
+            type: string
+            nullable: false
+        - name: permissions
+          in: query
+          description: Filter by user permissions comma separated (where all match)
+          schema:
+            type: string
+        - name: roles
+          in: query
+          description: Filter by user roles comma separated (where all match)
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            A successful response with a list of organization users or an empty
+            list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: AddOrganizationUsers
+      description: |
+        Add existing users to an organization.
+
+        <div>
+          <code>create:organization_users</code>
+        </div>
+      summary: Add Organization Users
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: Users to be added to the organization.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The users id.
+                        type: string
+                      roles:
+                        description: Role keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                      permissions:
+                        description: Permission keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+      responses:
+        '200':
+          description: Users successfully added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add_organization_users_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/add_organization_users_response'
+        '204':
+          description: No users added.
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationUsers
+      description: |
+        Update users that belong to an organization.
+
+        <div>
+          <code>update:organization_users</code>
+        </div>
+      summary: Update Organization Users
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: Users to add, update or remove from the organization.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The users id.
+                        type: string
+                      operation:
+                        description: >-
+                          Optional operation, set to 'delete' to remove the user
+                          from the organization.
+                        type: string
+                      roles:
+                        description: Role keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                      permissions:
+                        description: Permission keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+      responses:
+        '200':
+          description: Users successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_organization_users_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/update_organization_users_response'
+        '400':
+          description: Error updating organization user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/roles:
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUserRoles
+      description: |
+        Get roles for an organization user.
+
+        <div>
+          <code>read:organization_user_roles</code>
+        </div>
+      summary: List Organization User Roles
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: A successful response with a list of user roles.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_roles_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_roles_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: CreateOrganizationUserRole
+      description: |
+        Add role to an organization user.
+
+        <div>
+          <code>create:organization_user_roles</code>
+        </div>
+      summary: Add Organization User Role
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Role details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role_id:
+                  description: The role id.
+                  type: string
+      responses:
+        '200':
+          description: Role successfully added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/roles/{role_id}:
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationUserRole
+      description: |
+        Delete role for an organization user.
+
+        <div>
+          <code>delete:organization_user_roles</code>
+        </div>
+      summary: Delete Organization User Role
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: role_id
+          in: path
+          description: The role id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/permissions:
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUserPermissions
+      description: |
+        Get permissions for an organization user.
+
+        <div>
+          <code>read:organization_user_permissions</code>
+        </div>
+      summary: List Organization User Permissions
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "roles".
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A successful response with a list of user permissions.
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/get_organizations_user_permissions_response
+            application/json; charset=utf-8:
+              schema:
+                $ref: >-
+                  #/components/schemas/get_organizations_user_permissions_response
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: CreateOrganizationUserPermission
+      description: |
+        Add permission to an organization user.
+
+        <div>
+          <code>create:organization_user_permissions</code>
+        </div>
+      summary: Add Organization User Permission
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Permission details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                permission_id:
+                  description: The permission id.
+                  type: string
+      responses:
+        '200':
+          description: User permission successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/permissions/{permission_id}:
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationUserPermission
+      description: |
+        Delete permission for an organization user.
+
+        <div>
+          <code>delete:organization_user_permissions</code>
+        </div>
+      summary: Delete Organization User Permission
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: permission_id
+          in: path
+          description: The permission id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}:
+    delete:
+      tags:
+        - Organizations
+      operationId: RemoveOrganizationUser
+      description: |
+        Remove user from an organization.
+
+        <div>
+          <code>delete:organization_users</code>
+        </div>
+      summary: Remove Organization User
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed from organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/feature_flags:
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationFeatureFlags
+      description: |
+        Get all organization feature flags.
+
+        <div>
+          <code>read:organization_feature_flags</code>
+        </div>
+      summary: List Organization Feature Flags
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag overrides successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_feature_flags_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_organization_feature_flags_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationFeatureFlagOverrides
+      description: |
+        Delete all organization feature flag overrides.
+
+        <div>
+          <code>delete:organization_feature_flags</code>
+        </div>
+      summary: Delete Organization Feature Flag Overrides
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag overrides successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/feature_flags/{feature_flag_key}:
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationFeatureFlagOverride
+      description: |
+        Delete organization feature flag override.
+
+        <div>
+          <code>delete:organization_feature_flags</code>
+        </div>
+      summary: Delete Organization Feature Flag Override
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationFeatureFlagOverride
+      description: |
+        Update organization feature flag override.
+
+        <div>
+          <code>update:organization_feature_flags</code>
+        </div>
+      summary: Update Organization Feature Flag Override
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: Override value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/properties/{property_key}:
+    put:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationProperty
+      description: |
+        Update organization property value.
+
+        <div>
+          <code>update:organization_properties</code>
+        </div>
+      summary: Update Organization Property value
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+        - name: property_key
+          in: path
+          description: The identifier for the property
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: The new property value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/properties:
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationPropertyValues
+      description: |
+        Gets properties for an organization by org code.
+
+        <div>
+          <code>read:organization_properties</code>
+        </div>
+      summary: Get Organization Property Values
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationProperties
+      description: |
+        Update organization property values.
+
+        <div>
+          <code>update:organization_properties</code>
+        </div>
+      summary: Update Organization Property values
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Properties to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                properties:
+                  description: Property keys and values
+                  type: object
+                  nullable: false
+              required:
+                - properties
+      responses:
+        '200':
+          description: Properties successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization/{org_code}/handle:
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationHandle
+      description: |
+        Delete organization handle
+
+        <div>
+          <code>delete:organization_handles</code>
+        </div>
+      summary: Delete organization handle
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Handle successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/permissions:
+    get:
+      tags:
+        - Permissions
+      operationId: GetPermissions
+      description: >
+        The returned list can be sorted by permission name or permission ID in
+        ascending or descending order. The number of records to return at a time
+        can also be controlled using the `page_size` query string parameter.
+
+
+        <div>
+          <code>read:permissions</code>
+        </div>
+      summary: List Permissions
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Permissions successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_permissions_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Permissions
+      operationId: CreatePermission
+      description: |
+        Create a new permission.
+
+        <div>
+          <code>create:permissions</code>
+        </div>
+      summary: Create Permission
+      requestBody:
+        description: Permission details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The permission's name.
+                  type: string
+                description:
+                  description: The permission's description.
+                  type: string
+                key:
+                  description: The permission identifier to use in code.
+                  type: string
+      responses:
+        '201':
+          description: Permission successfully created
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/permissions/{permission_id}:
+    patch:
+      tags:
+        - Permissions
+      operationId: UpdatePermissions
+      description: |
+        Update permission
+
+        <div>
+          <code>update:permissions</code>
+        </div>
+      summary: Update Permission
+      parameters:
+        - name: permission_id
+          in: path
+          description: The identifier for the permission.
+          required: true
+          schema:
+            type: integer
+            nullable: false
+      requestBody:
+        description: Permission details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The permission's name.
+                  type: string
+                description:
+                  description: The permission's description.
+                  type: string
+                key:
+                  description: The permission identifier to use in code.
+                  type: string
+      responses:
+        '200':
+          description: Permission successfully updated
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Permissions
+      operationId: DeletePermission
+      description: |
+        Delete permission
+
+        <div>
+          <code>delete:permissions</code>
+        </div>
+      summary: Delete Permission
+      parameters:
+        - name: permission_id
+          in: path
+          description: The identifier for the permission.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: permission successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/properties:
+    get:
+      tags:
+        - Properties
+      operationId: GetProperties
+      description: |
+        Returns a list of properties
+
+        <div>
+          <code>read:properties</code>
+        </div>
+      summary: List properties
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the property to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the property to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: context
+          in: query
+          description: Filter results by user,  organization or application context
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - usr
+              - org
+              - app
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_properties_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_properties_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Properties
+      operationId: CreateProperty
+      description: |
+        Create property.
+
+        <div>
+          <code>create:properties</code>
+        </div>
+      summary: Create Property
+      requestBody:
+        description: Property details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the property.
+                  type: string
+                  nullable: false
+                description:
+                  description: Description of the property purpose.
+                  type: string
+                  nullable: false
+                key:
+                  description: The property identifier to use in code.
+                  type: string
+                  nullable: false
+                type:
+                  description: The property type.
+                  type: string
+                  enum:
+                    - single_line_text
+                    - multi_line_text
+                  nullable: false
+                context:
+                  description: The context that the property applies to.
+                  type: string
+                  enum:
+                    - org
+                    - usr
+                    - app
+                  nullable: false
+                is_private:
+                  description: >-
+                    Whether the property can be included in id and access
+                    tokens.
+                  type: boolean
+                  nullable: false
+                category_id:
+                  description: Which category the property belongs to.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - key
+                - type
+                - context
+                - is_private
+                - category_id
+      responses:
+        '201':
+          description: Property successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_property_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_property_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/properties/{property_id}:
+    put:
+      tags:
+        - Properties
+      operationId: UpdateProperty
+      description: |
+        Update property.
+
+        <div>
+          <code>update:properties</code>
+        </div>
+      summary: Update Property
+      parameters:
+        - name: property_id
+          in: path
+          description: The unique identifier for the property.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the property to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the property.
+                  type: string
+                  nullable: false
+                description:
+                  type: string
+                  description: Description of the property purpose.
+                is_private:
+                  type: boolean
+                  description: >-
+                    Whether the property can be included in id and access
+                    tokens.
+                category_id:
+                  description: Which category the property belongs to.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - is_private
+                - category_id
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Properties
+      operationId: DeleteProperty
+      description: |
+        Delete property.
+
+        <div>
+          <code>delete:properties</code>
+        </div>
+      summary: Delete Property
+      parameters:
+        - name: property_id
+          in: path
+          description: The unique identifier for the property.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/property_categories:
+    get:
+      tags:
+        - Property Categories
+      operationId: GetCategories
+      description: |
+        Returns a list of categories.
+
+        <div>
+          <code>read:property_categories</code>
+        </div>
+      summary: List categories
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the category to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the category to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: context
+          in: query
+          description: Filter the results by User or Organization context
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - usr
+              - org
+      responses:
+        '200':
+          description: Categories successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_categories_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_categories_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Property Categories
+      operationId: CreateCategory
+      description: |
+        Create category.
+
+        <div>
+          <code>create:property_categories</code>
+        </div>
+      summary: Create Category
+      requestBody:
+        description: Category details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the category.
+                  type: string
+                  nullable: false
+                context:
+                  description: The context that the category applies to.
+                  type: string
+                  enum:
+                    - org
+                    - usr
+                    - app
+                  nullable: false
+              required:
+                - name
+                - context
+      responses:
+        '201':
+          description: Category successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_category_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_category_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/property_categories/{category_id}:
+    put:
+      tags:
+        - Property Categories
+      operationId: UpdateCategory
+      description: |
+        Update category.
+
+        <div>
+          <code>update:property_categories</code>
+        </div>
+      summary: Update Category
+      parameters:
+        - name: category_id
+          in: path
+          description: The unique identifier for the category.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the category to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the category.
+                  type: string
+                  nullable: false
+      responses:
+        '200':
+          description: category successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles:
+    get:
+      tags:
+        - Roles
+      operationId: GetRoles
+      description: >
+        The returned list can be sorted by role name or role ID in ascending or
+        descending order. The number of records to return at a time can also be
+        controlled using the `page_size` query string parameter.
+
+
+        <div>
+          <code>read:roles</code>
+        </div>
+      summary: List roles
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Roles successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_roles_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Roles
+      operationId: CreateRole
+      description: |
+        Create role.
+
+        <div>
+          <code>create:roles</code>
+        </div>
+      summary: Create role
+      requestBody:
+        description: Role details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The role's name.
+                  type: string
+                description:
+                  description: The role's description.
+                  type: string
+                key:
+                  description: The role identifier to use in code.
+                  type: string
+                is_default_role:
+                  description: Set role as default for new users.
+                  type: boolean
+      responses:
+        '201':
+          description: Role successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_roles_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}:
+    get:
+      tags:
+        - Roles
+      operationId: GetRole
+      description: |
+        Get a role
+
+        <div>
+          <code>read:roles</code>
+        </div>
+      summary: Get role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Role successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_role_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Roles
+      operationId: UpdateRoles
+      description: |
+        Update a role
+
+        <div>
+          <code>update:roles</code>
+        </div>
+      summary: Update role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          schema:
+            type: string
+          required: true
+      requestBody:
+        description: Role details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The role's name.
+                  type: string
+                description:
+                  description: The role's description.
+                  type: string
+                key:
+                  description: The role identifier to use in code.
+                  type: string
+                is_default_role:
+                  description: Set role as default for new users.
+                  type: boolean
+              required:
+                - name
+                - key
+      responses:
+        '201':
+          description: Role successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Roles
+      operationId: DeleteRole
+      description: |
+        Delete role
+
+        <div>
+          <code>delete:roles</code>
+        </div>
+      summary: Delete role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Role successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/permissions:
+    get:
+      tags:
+        - Roles
+      operationId: GetRolePermissions
+      description: |
+        Get permissions for a role.
+
+        <div>
+          <code>read:role_permissions</code>
+        </div>
+      summary: Get role permissions
+      parameters:
+        - name: role_id
+          in: path
+          description: The role's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A list of permissions for a role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/role_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/role_permissions_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Roles
+      operationId: UpdateRolePermissions
+      description: |
+        Update role permissions.
+
+        <div>
+          <code>update:role_permissions</code>
+        </div>
+      summary: Update role permissions
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                permissions:
+                  description: Permissions to add or remove from the role.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The permission id.
+                        type: string
+                      operation:
+                        description: >-
+                          Optional operation, set to 'delete' to remove the
+                          permission from the role.
+                        type: string
+      responses:
+        '200':
+          description: Permissions successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_role_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/update_role_permissions_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/permissions/{permission_id}:
+    delete:
+      tags:
+        - Roles
+      operationId: RemoveRolePermission
+      description: |
+        Remove a permission from a role.
+
+        <div>
+          <code>delete:role_permissions</code>
+        </div>
+      summary: Remove role permission
+      parameters:
+        - name: role_id
+          in: path
+          description: The role's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: permission_id
+          in: path
+          description: The permission's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Permission successfully removed from role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/subscribers:
+    get:
+      tags:
+        - Subscribers
+      operationId: GetSubscribers
+      description: >
+        The returned list can be sorted by full name or email address
+
+        in ascending or descending order. The number of records to return at a
+        time can also be controlled using the `page_size` query
+
+        string parameter.
+
+
+        <div>
+          <code>read:subscribers</code>
+        </div>
+      summary: List Subscribers
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Subscriber successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_subscribers_response'
+        '403':
+          description: Bad request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Subscribers
+      operationId: CreateSubscriber
+      description: |
+        Create subscriber.
+
+        <div>
+          <code>create:subscribers</code>
+        </div>
+      summary: Create Subscriber
+      parameters:
+        - name: first_name
+          in: query
+          description: Subscriber's first name.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: last_name
+          in: query
+          description: Subscriber's last name.
+          required: true
+          schema:
+            type: string
+            nullable: true
+        - name: email
+          in: query
+          description: The email address of the subscriber.
+          required: true
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '201':
+          description: Subscriber successfully created
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_subscriber_success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/subscribers/{subscriber_id}:
+    get:
+      tags:
+        - Subscribers
+      operationId: GetSubscriber
+      description: |
+        Retrieve a subscriber record.
+
+        <div>
+          <code>read:subscribers</code>
+        </div>
+      summary: Get Subscriber
+      parameters:
+        - name: subscriber_id
+          in: path
+          description: The subscriber's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Subscriber successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_subscriber_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users:
+    get:
+      tags:
+        - Users
+      operationId: getUsers
+      description: >
+        The returned list can be sorted by full name or email address in
+        ascending or descending order. The number of records to return at a time
+        can also be controlled using the `page_size` query string parameter.
+
+
+        <div>
+          <code>read:users</code>
+        </div>
+      summary: Get users
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: user_id
+          in: query
+          description: ID of the user to filter by.
+          schema:
+            type: string
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+        - name: email
+          in: query
+          description: >-
+            Filter the results by email address. The query string should be
+            comma separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: username
+          in: query
+          description: >-
+            Filter the results by username. The query string should be comma
+            separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: expand
+          in: query
+          description: >-
+            Specify additional data to retrieve. Use "organizations" and/or
+            "identities".
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: has_organization
+          in: query
+          description: >-
+            Filter the results by if the user has at least one organization
+            assigned.
+          required: false
+          schema:
+            type: boolean
+            nullable: true
+      responses:
+        '200':
+          description: Users successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/refresh_claims:
+    post:
+      tags:
+        - Users
+      operationId: refreshUserClaims
+      description: |
+        Refreshes the user's claims and invalidates the current cache.
+
+        <div>
+          <code>update:user_refresh_claims</code>
+        </div>
+      summary: Refresh User Claims and Invalidate Cache
+      parameters:
+        - in: path
+          name: user_id
+          schema:
+            type: string
+          required: true
+          description: The id of the user whose claims needs to be updated.
+      responses:
+        '200':
+          description: Claims successfully refreshed.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Bad request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/user:
+    get:
+      tags:
+        - Users
+      operationId: getUserData
+      description: |
+        Retrieve a user record.
+
+        <div>
+          <code>read:users</code>
+        </div>
+      summary: Get user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: expand
+          in: query
+          description: >-
+            Specify additional data to retrieve. Use "organizations" and/or
+            "identities".
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: User successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Users
+      operationId: createUser
+      description: >
+        Creates a user record and optionally zero or more identities for the
+        user. An example identity could be the email
+
+        address of the user.
+
+
+        <div>
+          <code>create:users</code>
+        </div>
+      summary: Create user
+      requestBody:
+        description: The details of the user to create.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile:
+                  description: Basic information required to create a user.
+                  type: object
+                  properties:
+                    given_name:
+                      type: string
+                      description: User's first name.
+                    family_name:
+                      type: string
+                      description: User's last name.
+                    picture:
+                      type: string
+                      description: The user's profile picture.
+                organization_code:
+                  description: >-
+                    The unique code associated with the organization you want
+                    the user to join.
+                  type: string
+                provided_id:
+                  description: An external id to reference the user.
+                  type: string
+                identities:
+                  type: array
+                  description: Array of identities to assign to the created user
+                  items:
+                    type: object
+                    description: The result of the user creation operation.
+                    properties:
+                      type:
+                        type: string
+                        description: >-
+                          The type of identity to create, e.g. email, username,
+                          or phone.
+                        enum:
+                          - email
+                          - phone
+                          - username
+                      details:
+                        type: object
+                        description: Additional details required to create the user.
+                        properties:
+                          email:
+                            type: string
+                            description: The email address of the user.
+                            example: email@email.com
+                          phone:
+                            type: string
+                            description: The phone number of the user.
+                            example: '+61426148233'
+                          phone_country_id:
+                            type: string
+                            description: The country code for the phone number.
+                            example: au
+                          username:
+                            type: string
+                            description: The username of the user.
+                            example: myusername
+                  example:
+                    - type: email
+                      details:
+                        email: email@email.com
+                    - type: phone
+                      details:
+                        phone: '+61426148233'
+                        phone_country_id: au
+                    - type: username
+                      details:
+                        username: myusername
+      responses:
+        '200':
+          description: User successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_user_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Users
+      operationId: updateUser
+      description: |
+        Update a user record.
+
+        <div>
+          <code>update:users</code>
+        </div>
+      summary: Update user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: The user to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                given_name:
+                  type: string
+                  description: User's first name.
+                family_name:
+                  type: string
+                  description: User's last name.
+                picture:
+                  type: string
+                  description: The user's profile picture.
+                is_suspended:
+                  type: boolean
+                  description: Whether the user is currently suspended or not.
+                is_password_reset_requested:
+                  type: boolean
+                  description: Prompt the user to change their password on next sign in.
+                provided_id:
+                  description: An external id to reference the user.
+                  type: string
+      responses:
+        '200':
+          description: User successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_user_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Users
+      operationId: deleteUser
+      description: |
+        Delete a user record.
+
+        <div>
+          <code>delete:users</code>
+        </div>
+      summary: Delete user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: kp_c3143a4b50ad43c88e541d9077681782
+        - name: is_delete_profile
+          in: query
+          description: >-
+            Delete all data and remove the user's profile from all of Kinde,
+            including the subscriber list
+          schema:
+            type: boolean
+            nullable: false
+            example: true
+      responses:
+        '200':
+          description: User successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/feature_flags/{feature_flag_key}:
+    patch:
+      tags:
+        - Users
+      operationId: UpdateUserFeatureFlagOverride
+      description: |
+        Update user feature flag override.
+
+        <div>
+          <code>update:user_feature_flags</code>
+        </div>
+      summary: Update User Feature Flag Override
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: Override value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/properties/{property_key}:
+    put:
+      tags:
+        - Users
+      operationId: UpdateUserProperty
+      description: |
+        Update property value.
+
+        <div>
+          <code>update:user_properties</code>
+        </div>
+      summary: Update Property value
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+        - name: property_key
+          in: path
+          description: The identifier for the property
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: The new property value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/properties:
+    get:
+      tags:
+        - Users
+      operationId: GetUserPropertyValues
+      description: |
+        Gets properties for an user by ID.
+
+        <div>
+          <code>read:user_properties</code>
+        </div>
+      summary: Get property values
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Users
+      operationId: UpdateUserProperties
+      description: |
+        Update property values.
+
+        <div>
+          <code>update:user_properties</code>
+        </div>
+      summary: Update Property values
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Properties to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                properties:
+                  description: Property keys and values
+                  type: object
+                  nullable: false
+              required:
+                - properties
+      responses:
+        '200':
+          description: Properties successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/password:
+    put:
+      tags:
+        - Users
+      operationId: SetUserPassword
+      description: |
+        Set user password.
+
+        <div>
+          <code>update:user_passwords</code>
+        </div>
+      summary: Set User password
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Password details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hashed_password:
+                  description: The hashed password.
+                  type: string
+                hashing_method:
+                  description: >-
+                    The hashing method or algorithm used to encrypt the user’s
+                    password. Default is bcrypt.
+                  type: string
+                  enum:
+                    - bcrypt
+                    - crypt
+                    - md5
+                    - wordpress
+                salt:
+                  type: string
+                  description: >-
+                    Extra characters added to passwords to make them stronger.
+                    Not required for bcrypt.
+                salt_position:
+                  type: string
+                  description: >-
+                    Position of salt in password string. Not required for
+                    bcrypt.
+                  enum:
+                    - prefix
+                    - suffix
+                is_temporary_password:
+                  type: boolean
+                  description: >-
+                    The user will be prompted to set a new password after
+                    entering this one.
+              required:
+                - hashed_password
+      responses:
+        '200':
+          description: User successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/identities:
+    get:
+      tags:
+        - Users
+      operationId: GetUserIdentities
+      description: |
+        Gets a list of identities for an user by ID.
+
+        <div>
+          <code>read:user_identities</code>
+        </div>
+      summary: Get identities
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: starting_after
+          in: query
+          description: The ID of the identity to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the identity to end before.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Identities successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_identities_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_identities_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Users
+      operationId: CreateUserIdentity
+      description: |
+        Creates an identity for a user.
+
+        <div>
+          <code>create:user_identities</code>
+        </div>
+      summary: Create identity
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: The identity details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  type: string
+                  description: The email address, social identity, or username of the user.
+                  example: sally@example.com
+                type:
+                  type: string
+                  description: The identity type
+                  enum:
+                    - email
+                    - username
+                    - phone
+                    - enterprise
+                    - social
+                  example: email
+                phone_country_id:
+                  type: string
+                  description: >-
+                    The country code for the phone number, only required when
+                    identity type is 'phone'.
+                  example: au
+                connection_id:
+                  type: string
+                  description: >-
+                    The social connection ID, only required when identity type
+                    is 'social'.
+                  example: conn_019289347f1193da6c0e4d49b97b4bd2
+      responses:
+        '201':
+          description: Identity successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_identity_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_identity_response'
+        '400':
+          description: Error creating identity.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/events/{event_id}:
+    get:
+      tags:
+        - Webhooks
+      operationId: GetEvent
+      description: |
+        Returns an event
+
+        <div>
+          <code>read:events</code>
+        </div>
+      summary: Get Event
+      parameters:
+        - name: event_id
+          in: path
+          description: The event id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Event successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_event_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_event_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/event_types:
+    get:
+      tags:
+        - Webhooks
+      operationId: GetEventTypes
+      description: |
+        Returns a list event type definitions
+
+        <div>
+          <code>read:event_types</code>
+        </div>
+      summary: List Event Types
+      responses:
+        '200':
+          description: Event types successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_event_types_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_event_types_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/webhooks/{webhook_id}:
+    delete:
+      tags:
+        - Webhooks
+      operationId: DeleteWebHook
+      description: |
+        Delete webhook
+
+        <div>
+          <code>delete:webhooks</code>
+        </div>
+      summary: Delete Webhook
+      parameters:
+        - name: webhook_id
+          in: path
+          description: The webhook id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Webhook successfully deleted.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/delete_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/webhooks:
+    get:
+      tags:
+        - Webhooks
+      operationId: GetWebHooks
+      description: |
+        List webhooks
+
+        <div>
+          <code>read:webhooks</code>
+        </div>
+      summary: List Webhooks
+      responses:
+        '200':
+          description: Webhook list successfully returned.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_webhooks_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_webhooks_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Webhooks
+      operationId: CreateWebHook
+      description: |
+        Create a webhook
+
+        <div>
+          <code>create:webhooks</code>
+        </div>
+      summary: Create a Webhook
+      requestBody:
+        description: Webhook request specification.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                endpoint:
+                  description: The webhook endpoint url
+                  type: string
+                  nullable: false
+                event_types:
+                  description: Array of event type keys
+                  type: array
+                  items:
+                    type: string
+                  nullable: false
+                name:
+                  description: The webhook name
+                  type: string
+                  nullable: false
+                description:
+                  description: The webhook description
+                  type: string
+                  nullable: true
+              required:
+                - endpoint
+                - event_types
+                - name
+      responses:
+        '200':
+          description: Webhook successfully created.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Webhooks
+      operationId: UpdateWebHook
+      description: |
+        Update a webhook
+
+        <div>
+          <code>update:webhooks</code>
+        </div>
+      summary: Update a Webhook
+      requestBody:
+        description: Update webhook request specification.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event_types:
+                  description: Array of event type keys
+                  type: array
+                  items:
+                    type: string
+                  nullable: false
+                name:
+                  description: The webhook name
+                  type: string
+                  nullable: false
+                description:
+                  description: The webhook description
+                  type: string
+                  nullable: true
+      responses:
+        '200':
+          description: Webhook successfully updated.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/update_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+components:
+  parameters:
+    api_id:
+      in: path
+      name: api_id
+      description: The API's ID.
+      required: true
+      schema:
+        type: string
+        example: 7ccd126599aa422a771abcb341596881
+    application_id:
+      in: path
+      name: application_id
+      description: The application's ID / client ID.
+      required: true
+      schema:
+        type: string
+        example: 3b0b5c6c8fcc464fab397f4969b5f482
+    property_key:
+      in: path
+      name: property_key
+      description: The property's key.
+      required: true
+      schema:
+        type: string
+        example: kp_some_key
+    variable_id:
+      in: path
+      name: variable_id
+      description: The environment variable's ID.
+      required: true
+      schema:
+        type: string
+        example: env_var_0192b1941f125645fa15bf28a662a0b3
+  responses:
+    bad_request:
+      description: Invalid request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+    not_found:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/not_found_response'
+    forbidden:
+      description: Unauthorized - invalid credentials.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+    too_many_requests:
+      description: Too many requests. Request was throttled.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+  schemas:
+    success_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Success
+        code:
+          type: string
+          example: OK
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Error code.
+        message:
+          type: string
+          description: Error message.
+    error_response:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/error'
+    not_found_response:
+      type: object
+      properties:
+        errors:
+          type: object
+          properties:
+            code:
+              type: string
+              example: ROUTE_NOT_FOUND
+            message:
+              type: string
+              example: The requested API route does not exist
+    get_apis_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        next_token:
+          type: string
+          description: Pagination token.
+          example: Njo5Om1hvWVfYXNj
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                description: The unique ID for the API.
+                type: string
+                example: 7ccd126599aa422a771abcb341596881
+              name:
+                type: string
+                description: The API’s name.
+                example: Example API
+              audience:
+                type: string
+                description: >-
+                  A unique identifier for the API - commonly the URL. This value
+                  will be used as the `audience` parameter in authorization
+                  claims.
+                example: https://api.example.com
+              is_management_api:
+                type: boolean
+                description: Whether or not it is the Kinde management API.
+                example: false
+    create_apis_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Success
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: OK
+        api:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the API.
+              type: string
+              example: 7ccd126599aa422a771abcb341596881
+    get_environment_variables_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+        environment_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/environment_variable'
+    get_environment_variable_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        environment_variable:
+          $ref: '#/components/schemas/environment_variable'
+    create_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable created
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: VARIABLE_CREATED
+        environment_variable:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the environment variable.
+              type: string
+              example: env_var_0192b194f6156fb7452fe38cfb144958
+    update_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable updated
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: ENVIRONMENT_VARIABLE_UPDATED
+    delete_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable deleted
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: ENVIRONMENT_VARIABLE_DELETED
+    get_business_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        business:
+          type: object
+          properties:
+            code:
+              type: string
+              description: The unique ID for the business.
+              example: bus_c69fb73b091
+            name:
+              type: string
+              description: Your business's name.
+              example: Tailsforce Ltd
+            phone:
+              type: string
+              description: Phone number associated with business.
+              example: 555-555-5555
+              nullable: true
+            email:
+              type: string
+              description: Email address associated with business.
+              example: sally@example.com
+              nullable: true
+            industry:
+              type: string
+              description: The industry your business is in.
+              example: Healthcare & Medical
+              nullable: true
+            timezone:
+              type: string
+              description: The timezone your business is in.
+              example: Los Angeles (Pacific Standard Time)
+              nullable: true
+            privacy_url:
+              type: string
+              description: Your Privacy policy URL.
+              example: https://example.com/privacy
+              nullable: true
+            terms_url:
+              type: string
+              description: Your Terms and Conditions URL.
+              example: https://example.com/terms
+              nullable: true
+    get_industries_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        industries:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                description: The unique key for the industry.
+                type: string
+                example: administration_office_support
+              name:
+                type: string
+                description: The display name for the industry.
+                example: Administration & Office Support
+    get_timezones_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        timezones:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                description: The unique key for the timezone.
+                type: string
+                example: london_greenwich_mean_time
+              name:
+                type: string
+                description: The display name for the timezone.
+                example: London (Greenwich Mean Time) [+01:00]
+    get_api_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: success_response
+        api:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Unique ID of the API.
+              example: 7ccd126599aa422a771abcb341596881
+            name:
+              type: string
+              description: The API’s name.
+              example: Example API
+            audience:
+              type: string
+              description: >-
+                A unique identifier for the API - commonly the URL. This value
+                will be used as the `audience` parameter in authorization
+                claims.
+              example: https://api.example.com
+            is_management_api:
+              type: boolean
+              description: Whether or not it is the Kinde management API.
+              example: false
+            applications:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: The Client ID of the application.
+                    example: 3b0b5c6c8fcc464fab397f4969b5f482
+                  name:
+                    type: string
+                    description: The application's name.
+                    example: My M2M app
+                  type:
+                    type: string
+                    description: The application's type.
+                    enum:
+                      - Machine to machine (M2M)
+                      - Back-end web
+                      - Front-end and mobile
+                    example: Machine to machine (M2M)
+                  is_active:
+                    type: boolean
+                    description: >-
+                      Whether or not the application is authorized to access the
+                      API
+                    example: true
+                    nullable: true
+    authorize_app_api_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: API applications updated
+        code:
+          type: string
+          example: API_APPLICATIONS_UPDATED
+        applications_disconnected:
+          type: array
+          items:
+            type: string
+        applications_connected:
+          type: array
+          items:
+            type: string
+            example: d2db282d6214242b3b145c123f0c123
+    delete_api_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: API successfully deleted
+        code:
+          type: string
+          example: API_DELETED
+    user:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique ID of the user in Kinde.
+        provided_id:
+          type: string
+          description: External ID for user.
+        preferred_email:
+          type: string
+          description: Default email address of the user in Kinde.
+        username:
+          type: string
+          description: Primary username of the user in Kinde.
+        last_name:
+          type: string
+          description: User's last name.
+        first_name:
+          type: string
+          description: User's first name.
+        is_suspended:
+          type: boolean
+          description: Whether the user is currently suspended or not.
+        picture:
+          type: string
+          description: User's profile picture URL.
+        total_sign_ins:
+          type: integer
+          description: Total number of user sign ins.
+          nullable: true
+        failed_sign_ins:
+          type: integer
+          description: Number of consecutive failed user sign ins.
+          nullable: true
+        last_signed_in:
+          type: string
+          description: Last sign in date in ISO 8601 format.
+          nullable: true
+        created_on:
+          type: string
+          description: Date of user creation in ISO 8601 format.
+          nullable: true
+        organizations:
+          type: array
+          description: Array of organizations a user belongs to.
+          items:
+            type: string
+        identities:
+          type: array
+          description: Array of identities belonging to the user.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              identity:
+                type: string
+    update_user_response:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique ID of the user in Kinde.
+        given_name:
+          type: string
+          description: User's first name.
+        family_name:
+          type: string
+          description: User's last name.
+        email:
+          type: string
+          description: User's preferred email.
+        is_suspended:
+          type: boolean
+          description: Whether the user is currently suspended or not.
+        is_password_reset_requested:
+          type: boolean
+          description: Whether a password reset has been requested.
+        picture:
+          type: string
+          description: User's profile picture URL.
+          nullable: true
+    users:
+      type: array
+      description: Array of users.
+      items:
+        $ref: '#/components/schemas/user'
+    users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique ID of the user in Kinde.
+              provided_id:
+                type: string
+                description: External ID for user.
+              email:
+                type: string
+                description: Default email address of the user in Kinde.
+              username:
+                type: string
+                description: Primary username of the user in Kinde.
+              last_name:
+                type: string
+                description: User's last name.
+              first_name:
+                type: string
+                description: User's first name.
+              is_suspended:
+                type: boolean
+                description: Whether the user is currently suspended or not.
+              picture:
+                type: string
+                description: User's profile picture URL.
+              total_sign_ins:
+                type: integer
+                description: Total number of user sign ins.
+                nullable: true
+              failed_sign_ins:
+                type: integer
+                description: Number of consecutive failed user sign ins.
+                nullable: true
+              last_signed_in:
+                type: string
+                description: Last sign in date in ISO 8601 format.
+                nullable: true
+              created_on:
+                type: string
+                description: Date of user creation in ISO 8601 format.
+                nullable: true
+              organizations:
+                type: array
+                description: Array of organizations a user belongs to.
+                items:
+                  type: string
+              identities:
+                type: array
+                description: Array of identities belonging to the user.
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    identity:
+                      type: string
+        next_token:
+          type: string
+          description: Pagination token.
+    create_user_response:
+      type: object
+      properties:
+        id:
+          description: Unique ID of the user in Kinde.
+          type: string
+        created:
+          description: True if the user was successfully created.
+          type: boolean
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/user_identity'
+    create_organization_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        organization:
+          type: object
+          properties:
+            code:
+              description: The organization's unique code.
+              type: string
+              example: org_1ccfb819462
+    user_identity:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of identity object created.
+        result:
+          type: object
+          description: The result of the user creation operation.
+          properties:
+            created:
+              type: boolean
+              description: True if the user identity was successfully created.
+    create_property_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        property:
+          type: object
+          properties:
+            id:
+              description: The property's ID.
+              type: string
+    create_identity_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        identity:
+          type: object
+          properties:
+            id:
+              description: The identity's ID.
+              type: string
+    get_identities_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/identity'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_properties_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_property_values_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property_value'
+        next_token:
+          description: Pagination token.
+          type: string
+    create_category_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        category:
+          type: object
+          properties:
+            id:
+              description: The category's ID.
+              type: string
+    get_categories_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/category'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_event_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        event:
+          type: object
+          properties:
+            type:
+              type: string
+            source:
+              type: string
+            event_id:
+              type: string
+            timestamp:
+              type: string
+              description: Timestamp in ISO 8601 format.
+            data:
+              type: object
+              description: Event specific data object.
+    get_event_types_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        event_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/event_type'
+    get_webhooks_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        webhooks:
+          type: array
+          items:
+            $ref: '#/components/schemas/webhook'
+    webhook:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        endpoint:
+          type: string
+        description:
+          type: string
+        event_types:
+          type: array
+          items:
+            type: string
+        created_on:
+          type: string
+          description: Created on date in ISO 8601 format.
+    create_webhook_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        webhook:
+          type: object
+          properties:
+            id:
+              type: string
+            endpoint:
+              type: string
+    update_webhook_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        webhook:
+          type: object
+          properties:
+            id:
+              type: string
+    create_connection_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        connection:
+          type: object
+          properties:
+            id:
+              description: The connection's ID.
+              type: string
+    get_connections_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        connections:
+          type: array
+          items:
+            $ref: '#/components/schemas/connection'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    delete_webhook_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+    event_type:
+      type: object
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+        name:
+          type: string
+        origin:
+          type: string
+        schema:
+          type: object
+    organization_item_schema:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The unique identifier for the organization.
+          example: org_1ccfb819462
+        name:
+          type: string
+          description: The organization's name.
+          example: Acme Corp
+        handle:
+          type: string
+          description: >-
+            A unique handle for the organization - can be used for dynamic
+            callback urls.
+          example: acme_corp
+          nullable: true
+        is_default:
+          type: boolean
+          description: Whether the organization is the default organization.
+          example: false
+        external_id:
+          type: string
+          description: >-
+            The organization's external identifier - commonly used when
+            migrating from or mapping to other systems.
+          example: some1234
+          nullable: true
+        is_auto_membership_enabled:
+          type: boolean
+          example: true
+          description: >-
+            If users become members of this organization when the org code is
+            supplied during authentication.
+    get_organization_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The unique identifier for the organization.
+          example: org_1ccfb819462
+        name:
+          type: string
+          description: The organization's name.
+          example: Acme Corp
+        handle:
+          type: string
+          description: >-
+            A unique handle for the organization - can be used for dynamic
+            callback urls.
+          example: acme_corp
+          nullable: true
+        is_default:
+          type: boolean
+          description: Whether the organization is the default organization.
+          example: false
+        external_id:
+          type: string
+          description: >-
+            The organization's external identifier - commonly used when
+            migrating from or mapping to other systems.
+          example: some1234
+          nullable: true
+        is_auto_membership_enabled:
+          type: boolean
+          example: true
+          description: >-
+            If users become members of this organization when the org code is
+            supplied during authentication.
+        logo:
+          type: string
+          deprecated: true
+          nullable: true
+        link_color:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        background_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#ffffff'
+            hex:
+              type: string
+              example: '#ffffff'
+            hsl:
+              type: string
+              example: hsl(0, 0%, 100%)
+        button_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_text_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#ffffff'
+            hex:
+              type: string
+              example: '#ffffff'
+            hsl:
+              type: string
+              example: hsl(0, 0%, 100%)
+        link_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        background_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_text_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        is_allow_registrations:
+          nullable: true
+          type: boolean
+          example: true
+          deprecated: true
+          description: Deprecated - Use 'is_auto_membership_enabled' instead
+    organization_user:
+      type: object
+      properties:
+        id:
+          type: string
+          example: kp:97c2ba24217d48e3b96a799b76cf2c74
+          description: The unique ID for the user.
+        email:
+          type: string
+          example: john.snow@example.com
+          description: The user's email address.
+        full_name:
+          type: string
+          example: John Snow
+          description: The user's full name.
+        last_name:
+          type: string
+          example: Snow
+          description: The user's last name.
+        first_name:
+          type: string
+          example: John
+          description: The user's first name.
+        picture:
+          type: string
+          example: https://example.com/john_snow.jpg
+          description: The user's profile picture URL.
+        joined_on:
+          type: string
+          example: '2021-01-01T00:00:00Z'
+          description: The date the user joined the organization.
+        roles:
+          type: array
+          description: The roles the user has in the organization.
+          items:
+            type: string
+            example: admin
+            description: The role's key.
+    category:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    connection:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        display_name:
+          type: string
+        strategy:
+          type: string
+    environment_variable:
+      type: object
+      properties:
+        id:
+          description: The unique ID for the environment variable.
+          type: string
+          example: env_var_0192b1941f125645fa15bf28a662a0b3
+        key:
+          type: string
+          description: The name of the environment variable.
+          example: MY_API_KEY
+        value:
+          type: string
+          description: The value of the environment variable.
+          example: some-secret
+          nullable: true
+        is_secret:
+          type: boolean
+          description: Whether the environment variable is sensitive.
+          example: false
+        created_on:
+          type: string
+          description: The date the environment variable was created.
+          example: '2021-01-01T00:00:00Z'
+    identity:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        is_confirmed:
+          type: boolean
+        created_on:
+          type: string
+          description: Date of user creation in ISO 8601 format.
+        last_login_on:
+          type: string
+          description: Date of user creation in ISO 8601 format.
+        total_logins:
+          type: integer
+        name:
+          type: string
+    property:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        is_private:
+          type: boolean
+        description:
+          type: string
+        is_kinde_property:
+          type: boolean
+    property_value:
+      type: object
+      properties:
+        id:
+          type: string
+          example: prop_0192b7e8b4f8ca08110d2b22059662a8
+        name:
+          type: string
+          example: Town
+        description:
+          type: string
+          example: Where the entity is located
+          nullable: true
+        key:
+          type: string
+          example: kp_town
+        value:
+          type: string
+          example: West-side Staines massive
+          nullable: true
+    role:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+    subscribers_subscriber:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        full_name:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+    subscriber:
+      type: object
+      properties:
+        id:
+          type: string
+        preferred_email:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+    organization_user_role:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+    organization_user_role_permissions:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          type: string
+        permissions:
+          type: object
+          properties:
+            key:
+              type: string
+    organization_user_permission:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        roles:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              key:
+                type: string
+    organization_users:
+      type: array
+      items:
+        $ref: '#/components/schemas/organization_user'
+    get_subscriber_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        subscribers:
+          type: array
+          items:
+            $ref: '#/components/schemas/subscriber'
+    get_subscribers_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        subscribers:
+          type: array
+          items:
+            $ref: '#/components/schemas/subscribers_subscriber'
+        next_token:
+          description: Pagination token.
+          type: string
+    get_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/roles'
+        next_token:
+          description: Pagination token.
+          type: string
+    get_role_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        role:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The role's ID.
+              example: 01929904-316d-bb2c-069f-99dfea4ac394
+            key:
+              type: string
+              description: The role identifier to use in code.
+              example: admin
+            name:
+              type: string
+              description: The role's name.
+              example: Administrator
+            description:
+              type: string
+              description: The role's description.
+              example: Full access to all resources.
+            is_default_role:
+              type: boolean
+              description: Whether the role is the default role.
+              example: false
+    create_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        role:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The role's ID.
+    get_organizations_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_item_schema'
+        next_token:
+          description: Pagination token.
+          type: string
+          example: Mjo5Om1hbWVfYZNj
+    get_organization_users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        organization_users:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user'
+        next_token:
+          type: string
+          description: Pagination token.
+    get_organizations_user_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user_role'
+        next_token:
+          type: string
+          description: Pagination token.
+    get_organizations_user_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user_permission'
+    get_organization_feature_flags_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        feature_flags:
+          type: object
+          description: The environment's feature flag settings.
+          additionalProperties:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - str
+                  - int
+                  - bool
+              value:
+                type: string
+    get_environment_feature_flags_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        feature_flags:
+          type: object
+          description: The environment's feature flag settings.
+          additionalProperties:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - str
+                  - int
+                  - bool
+              value:
+                type: string
+        next_token:
+          type: string
+          description: Pagination token.
+    add_organization_users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        users_added:
+          type: array
+          items:
+            type: string
+    update_role_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        permissions_added:
+          type: array
+          items:
+            type: string
+        permissions_removed:
+          type: array
+          items:
+            type: string
+    update_organization_users_response:
+      type: object
+      properties:
+        message:
+          type: string
+        users_added:
+          type: array
+          items:
+            type: string
+        users_updated:
+          type: array
+          items:
+            type: string
+        users_removed:
+          type: array
+          items:
+            type: string
+    connected_apps_auth_url:
+      type: object
+      properties:
+        url:
+          type: string
+          description: >-
+            A URL that is used to authenticate an end-user against a connected
+            app.
+        session_id:
+          type: string
+          description: A unique identifier for the login session.
+    create_subscriber_success_response:
+      type: object
+      properties:
+        subscriber:
+          type: object
+          properties:
+            subscriber_id:
+              type: string
+              description: A unique identifier for the subscriber.
+    connected_apps_access_token:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: The access token to access a third-party provider.
+        access_token_expiry:
+          type: string
+          description: The date and time that the access token expires.
+    api_result:
+      type: object
+      properties:
+        result:
+          type: string
+          description: The result of the api operation.
+    create_application_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        application:
+          type: object
+          properties:
+            id:
+              description: The application's identifier.
+              type: string
+            client_id:
+              description: The application's client ID.
+              type: string
+            client_secret:
+              description: The application's client secret.
+              type: string
+    get_application_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        application:
+          type: object
+          properties:
+            id:
+              description: The application's identifier.
+              type: string
+            name:
+              description: The application's name.
+              type: string
+            type:
+              description: The application's type.
+              type: string
+            client_id:
+              description: The application's client ID.
+              type: string
+            client_secret:
+              description: The application's client secret.
+              type: string
+            login_uri:
+              description: The default login route for resolving session issues.
+              type: string
+            homepage_uri:
+              description: The homepage link to your application.
+              type: string
+    applications:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+    get_applications_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/applications'
+        next_token:
+          description: Pagination token.
+          type: string
+    redirect_callback_urls:
+      type: object
+      properties:
+        redirect_urls:
+          type: array
+          description: An application's redirect URLs.
+          items:
+            type: string
+    get_redirect_callback_urls_response:
+      type: object
+      properties:
+        redirect_urls:
+          description: An application's redirect callback URLs.
+          type: array
+          items:
+            $ref: '#/components/schemas/redirect_callback_urls'
+    logout_redirect_urls:
+      type: object
+      properties:
+        logout_urls:
+          type: array
+          description: An application's logout URLs.
+          items:
+            type: string
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+    get_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/permissions'
+        next_token:
+          type: string
+          description: Pagination token.
+    permissions:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The permission's ID.
+        key:
+          type: string
+          description: The permission identifier to use in code.
+        name:
+          type: string
+          description: The permission's name.
+        description:
+          type: string
+          description: The permission's description.
+    roles:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The role's ID.
+        key:
+          type: string
+          description: The role identifier to use in code.
+        name:
+          type: string
+          description: The role's name.
+        description:
+          type: string
+          description: The role's description.
+          nullable: true
+        is_default_role:
+          type: boolean
+          description: Whether the role is the default role.
+    role_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/permissions'
+        next_token:
+          type: string
+          description: Pagination token.
+  securitySchemes:
+    kindeBearerAuth:
+      description: >
+        Accessing the API requires obtaining an access token when login in
+        through Kinde. However, management functions (for e.g. user management)
+        requires an access token obtained using the client_credentials flow.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/scripts/fetch-api-specs.js
+++ b/scripts/fetch-api-specs.js
@@ -1,0 +1,49 @@
+import {writeFile, mkdir} from "fs/promises";
+import path from "path";
+import "dotenv/config";
+
+const fetchAndSaveSpec = async (url, fileName) => {
+  try {
+    const specsDir = path.resolve("public", "specs");
+
+    // Ensure the 'public/specs' directory exists
+    await mkdir(specsDir, {recursive: true});
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch '${url}': ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.text();
+
+    // Define the path within the 'public/specs' folder
+    const filePath = path.join(specsDir, fileName);
+    await writeFile(filePath, data);
+    console.log(`Saved spec to ${filePath}`);
+  } catch (error) {
+    console.error(`Error fetching ${url}:`, error.message);
+    throw error;
+  }
+};
+
+const main = async () => {
+  try {
+    await Promise.all([
+      fetchAndSaveSpec(
+        process.env.PUBLIC_KINDE_MANAGEMENT_API_SPEC_URL,
+        "kinde-management-api-spec.yaml"
+      ),
+      fetchAndSaveSpec(
+        process.env.PUBLIC_KINDE_FRONTEND_API_SPEC_URL,
+        "kinde-frontend-api-spec.yaml"
+      )
+    ]);
+    console.log("API specs downloaded successfully.");
+  } catch (error) {
+    console.error("Error during API spec fetching or build process:", error.message);
+    process.exit(1);
+  }
+};
+
+main();

--- a/src/components/APICards.astro
+++ b/src/components/APICards.astro
@@ -1,0 +1,43 @@
+<ul class="grid list-none grid-cols-1 gap-6 p-0 sm:grid-cols-2">
+  <li
+    class="relative flex list-none flex-col gap-4 rounded-2xl bg-kinde-grey-50 p-12 dark:bg-kinde-grey-900"
+  >
+    <h3>Kinde Management API</h3>
+    <p>
+      For managing your Kinde account. Most things that can be done via the Kinde admin UI can be
+      done with this API
+    </p>
+    <p
+      aria-hidden="true"
+      class="mt-12 text-inherit underline decoration-inherit underline-offset-[6px] transition-all hover:text-current"
+    >
+      Explore the Management API reference
+    </p>
+    <a
+      href="/kinde-apis/management"
+      class="absolute inset-0 rounded-2xl transition duration-200 hover:ring-2 hover:ring-black focus:border-0 focus:shadow-none focus:ring-2 focus:ring-black focus-visible:overflow-hidden focus-visible:border-none focus-visible:shadow-none focus-visible:outline-black focus-visible:ring-2 focus-visible:ring-black dark:hover:ring-white dark:focus:ring-white dark:focus-visible:outline-white dark:focus-visible:ring-white"
+    >
+      <span class="sr-only">Go to the Kinde Management API reference docs</span>
+    </a>
+  </li>
+  <li
+    class="relative flex list-none flex-col gap-4 rounded-2xl bg-kinde-grey-50 p-12 dark:bg-kinde-grey-900"
+  >
+    <h3>Kinde Frontend API</h3>
+    <p>
+      For managing the currently signed-in user, includes getting their profile and revoking tokens
+    </p>
+    <p
+      aria-hidden="true"
+      class="mt-12 text-inherit underline decoration-inherit underline-offset-[6px] transition-all hover:text-current"
+    >
+      Explore the Frontend API reference
+    </p>
+    <a
+      href="/kinde-apis/frontend"
+      class="absolute inset-0 rounded-2xl transition duration-200 hover:ring-2 hover:ring-black focus:border-0 focus:shadow-none focus:ring-2 focus:ring-black focus-visible:overflow-hidden focus-visible:border-none focus-visible:shadow-none focus-visible:outline-black focus-visible:ring-2 focus-visible:ring-black dark:hover:ring-white dark:focus:ring-white dark:focus-visible:outline-white dark:focus-visible:ring-white"
+    >
+      <span class="sr-only">Go to the Kinde Frontend API reference docs</span>
+    </a>
+  </li>
+</ul>

--- a/src/components/ScalarApiReference.astro
+++ b/src/components/ScalarApiReference.astro
@@ -1,0 +1,333 @@
+---
+interface Props {
+  specURL: string;
+  proxyURL?: string;
+}
+
+const {specURL, proxyURL = import.meta.env.PUBLIC_KINDE_PROXY_URL} = Astro.props;
+---
+
+<script
+  id="api-reference"
+  data-url={specURL}
+  data-proxy-url={proxyURL}
+  data-configuration='{"theme": "deepSpace", "hideDarkModeToggle": "true", "searchHotKey": "j", "hideModels": "true"}'
+></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.23.5/dist/browser/standalone.min.js"
+></script>
+
+<script>
+  import waitForElement from "@utils/waitForElement";
+
+  // Function to update the URL based on input changes
+  function updateURL(subdomain: string, token: string) {
+    // Get the current URL
+    const url = new URL(window.location.href as any);
+
+    // Set the new values for 'subdomain' and 'token'
+    url.searchParams.set("subdomain", subdomain);
+    url.searchParams.set("token", token);
+
+    // Update the URL in the browser without reloading the page
+    window.history.replaceState({}, "", url);
+  }
+
+  // Wait for subdomain input to be ready, then focus and select text on focus, making it easier for users to enter their Kinde subdomain
+  waitForElement("#variable-subdomain", (inputElement: HTMLInputElement) => {
+    inputElement.addEventListener("focus", () => {
+      inputElement.select();
+    });
+    inputElement.addEventListener("mouseup", (e) => {
+      e.preventDefault();
+    });
+  });
+
+  waitForElement(".introduction-card", (parentEl: HTMLDivElement) => {
+    const subdomainInputElement = parentEl.querySelector(
+      "input#variable-subdomain"
+    ) as HTMLInputElement;
+    const tokenInputElement = parentEl.querySelector(
+      ".authentication-content input"
+    ) as HTMLInputElement;
+    const urlParams = new URL(window.location.href);
+    const subdomain = urlParams.searchParams.get("subdomain");
+    const token = urlParams.searchParams.get("token");
+
+    subdomainInputElement.value = subdomain as string;
+
+    subdomainInputElement.addEventListener("input", (event: Event) => {
+      const subdomain = (event.target as HTMLInputElement).value;
+      const token = tokenInputElement.value;
+      updateURL(subdomain, token);
+    });
+
+    subdomainInputElement.dispatchEvent(new Event("input"));
+
+    tokenInputElement.value = token as string;
+
+    tokenInputElement.addEventListener("input", (event) => {
+      const subdomain = subdomainInputElement.value;
+      const token = (event.target as HTMLInputElement).value;
+      updateURL(subdomain, token);
+    });
+
+    tokenInputElement.dispatchEvent(new Event("input"));
+  });
+
+  // Detect when api client overlay is up, so we can add a class to the body and then control body overflow, header z-index and position (from fixed to static)
+  const observer = new MutationObserver((mutationsList) => {
+    mutationsList.forEach((mutation) => {
+      mutation.addedNodes.forEach((node: any) => {
+        if (node.nodeType === 1 && node.classList.contains("api-client-drawer")) {
+          document.body?.classList.add("api-client-drawer-open");
+        }
+      });
+
+      mutation.removedNodes.forEach((node: any) => {
+        if (node.nodeType === 1 && node.classList.contains("api-client-drawer")) {
+          document.body?.classList.remove("api-client-drawer-open");
+        }
+      });
+    });
+  });
+
+  // Start observing for when the .api-client-drawer is added/removed from the DOM tree
+  observer.observe(document.body, {childList: true, subtree: true});
+</script>
+
+<style is:inline>
+  body.api-client-drawer-open {
+    overflow: hidden;
+  }
+
+  body.api-client-drawer-open header.header {
+    position: static;
+    z-index: 0;
+  }
+
+  body.api-client-drawer-open .main-frame {
+    padding-top: 0;
+  }
+
+  :root {
+    --kinde-header-height: 72px;
+  }
+
+  html,
+  body {
+    background-color: transparent;
+  }
+
+  main .content-panel {
+    padding: 0;
+  }
+
+  main .content-panel .sl-container {
+    margin-inline: 0;
+    min-width: 100%;
+  }
+
+  main :global(.scalar-api-reference) {
+    width: 100% !important;
+  }
+
+  span.sidebar-search-placeholder::after {
+    content: " API";
+  }
+
+  p.sidebar-heading-link-title {
+    font-size: 13px;
+  }
+
+  .scalar-api-references-standalone-search {
+    display: none !important;
+  }
+
+  .kinde-header {
+    background-color: var(--scalar-background-1);
+    border-block-end: 1px solid var(--scalar-scrollbar-color);
+    max-width: 100%;
+    display: flex;
+    padding-inline: 18px;
+    min-height: var(--kinde-header-height);
+    align-items: center;
+    justify-content: space-between;
+    position: fixed;
+    inset-block-start: 0;
+    inset-inline: 0;
+    z-index: 10;
+    overflow: hidden;
+  }
+
+  .input:has(input#variable-subdomain:placeholder-shown),
+  .authentication-content .card-form-input:has(input:placeholder-shown) {
+    animation: pulse 1.2s linear infinite;
+  }
+
+  .sidebar-heading-type {
+    font-weight: normal !important;
+  }
+
+  .sidebar-heading-link-title {
+    line-height: 1.5rem !important;
+  }
+
+  @keyframes pulse {
+    50% {
+      /* background-color: var(--scalar-background-2) !important; */
+      background-color: hsl(42.81deg 100% 65.1% / 12%);
+      outline: 1px solid var(--scalar-color-orange);
+    }
+    0%,
+    100% {
+      background-color: hsl(42.81deg 100% 65.1% / 3%);
+      outline: 1px solid var(--scalar-color-yellow);
+    }
+  }
+
+  h1.section-header.tight {
+    font-size: clamp(38px, 2.75vw + 16px, 56px);
+    letter-spacing: -0.03em;
+    line-height: 1.2;
+    margin-block: 16px !important;
+  }
+
+  h2.section-header .label {
+    font-size: 32px;
+    letter-spacing: -0.03em;
+  }
+
+  .kinde-header ul {
+    align-items: center;
+    display: flex;
+    list-style-type: none;
+    gap: 24px;
+  }
+
+  .kinde-header ul li a {
+    font-family: "Inter", sans-serif;
+    text-decoration: none;
+    color: var(--scalar-color-1);
+    background-color: transparent;
+    letter-spacing: normal;
+    font-weight: 400;
+    border-radius: 8px;
+    transition: background-color 0.3s ease;
+  }
+
+  .kinde-header ul li a.button {
+    background-color: var(--scalar-color-1);
+    color: var(--scalar-background-1);
+    padding: 12px 16px;
+  }
+
+  .kinde-header ul li a.button:hover {
+    background-color: var(--scalar-button-1-hover);
+  }
+
+  .darklight-reference-promo {
+    display: none !important;
+  }
+
+  button.darklight {
+    padding-bottom: 18px !important;
+    padding-block-end: 18px !important;
+  }
+
+  @media (min-width: 1001px) {
+    .kinde-header {
+      background-color: rgba(255, 255, 255, 0.7);
+      backdrop-filter: blur(20px);
+    }
+
+    .dark-mode .kinde-header {
+      background-color: rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  div#description\/intro {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+    top: 0;
+  }
+
+  div#description\/prerequisites {
+    margin-block: 24px;
+    scroll-margin-top: calc(var(--kinde-header-height) + 16px);
+  }
+
+  div#description\/prerequisites .markdown h2 {
+    display: inline;
+    color: var(--scalar-background-1);
+    background-color: var(--scalar-color-1);
+    padding: 0.25em 0.5em;
+    border-radius: 0.3em;
+  }
+
+  div#description\/prerequisites .markdown ol {
+    max-width: 48ch;
+    margin-block-start: 1.5rem !important;
+  }
+
+  .endpoint-description .markdown > div {
+    display: flex;
+    margin-block-start: 24px !important;
+    position: relative;
+    padding-top: 48px;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .endpoint-description .markdown > div > code {
+    margin: 0 !important;
+    font-family: var(--scalar-font-code) !important;
+    background-color: var(--scalar-color-1) !important;
+    /* box-shadow: 0 0 0 1px var(--scalar-border-color) !important; */
+    box-shadow: none !important;
+    font-size: var(--scalar-micro) !important;
+    border-radius: 0.3em !important;
+    padding: 0.4em !important;
+    color: var(--scalar-background-1) !important;
+    line-height: 1;
+  }
+
+  .endpoint-description .markdown > div::before {
+    content: "Scopes";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--scalar-border-color);
+    font-size: var(--scalar-heading-4);
+    font-weight: var(--scalar-semibold);
+    color: var(--scalar-color-1);
+    line-height: 1.45;
+    width: 100%;
+  }
+
+  .sl-markdown-content aside.references-navigation {
+    padding: 0;
+    border: none;
+  }
+
+  @media (min-width: 768px) {
+    .api-client-drawer {
+      width: calc(100vw - 80px) !important;
+    }
+  }
+
+  @media (min-width: 1540px) {
+    .api-client-drawer {
+      width: calc(100vw - 120px) !important;
+    }
+  }
+</style>

--- a/src/pages/kinde-apis/frontend.astro
+++ b/src/pages/kinde-apis/frontend.astro
@@ -1,0 +1,17 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import ScalarApiReference from "@components/ScalarApiReference.astro";
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Kinde Frontend API",
+    template: "splash",
+    editUrl: false,
+    page_id: "687ab2b7-55b1-491a-8376-19022c6fd16c"
+  }}
+>
+  <div class="not-content">
+    <ScalarApiReference specURL={"/specs/kinde-frontend-api-spec.yaml"} />
+  </div>
+</StarlightPage>

--- a/src/pages/kinde-apis/management.astro
+++ b/src/pages/kinde-apis/management.astro
@@ -1,0 +1,17 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import ScalarApiReference from "@components/ScalarApiReference.astro";
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Kinde Management API",
+    template: "splash",
+    editUrl: false,
+    page_id: "ef2c3b17-8654-4a6c-a493-3930000ed2d9"
+  }}
+>
+  <div class="not-content">
+    <ScalarApiReference specURL="/specs/kinde-management-api-spec.yaml" />
+  </div>
+</StarlightPage>

--- a/src/starlight-overrides/ThemeSelect.astro
+++ b/src/starlight-overrides/ThemeSelect.astro
@@ -66,13 +66,18 @@ import {Icon} from "astro-icon/components";
   }
 
   function applyTheme(theme) {
+    document.body.classList.remove("dark-mode");
+    document.body.classList.remove("light-mode");
     document.documentElement.setAttribute("data-theme", theme);
     localStorage.setItem("theme", theme);
+    theme === "dark" ? localStorage.setItem("isDark", true) : localStorage.setItem("isDark", false);
 
     if (theme === "light") {
       document.documentElement.setAttribute("data-theme", "light");
+      document.body.classList.add("light-mode");
     } else if (theme === "dark") {
       document.documentElement.setAttribute("data-theme", "dark");
+      document.body.classList.add("dark-mode");
     } else {
       systemThemeUpdate();
     }
@@ -95,10 +100,20 @@ import {Icon} from "astro-icon/components";
     const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
+
+    document.body.classList.remove("light-mode");
+    document.body.classList.remove("dark-mode");
+
     if (systemTheme === "dark") {
       document.documentElement.setAttribute("data-theme", "dark");
+
+      document.body.classList.add("dark-mode");
+      localStorage.setItem("isDark", true);
     } else {
       document.documentElement.setAttribute("data-theme", "light");
+
+      document.body.classList.add("light-mode");
+      localStorage.removeItem("isDark");
     }
   }
 

--- a/src/utils/waitForElement.js
+++ b/src/utils/waitForElement.js
@@ -1,0 +1,8 @@
+export default function waitForElement(selector, callback) {
+  const element = document.querySelector(selector);
+  if (element) {
+    callback(element);
+  } else {
+    setTimeout(() => waitForElement(selector, callback), 100);
+  }
+}


### PR DESCRIPTION
Stage 1 of adding API reference docs and client for the Kinde Management API and Kinde Frontend API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new API documentation pages for Kinde Management and Frontend APIs.
  - Added an API reference interface with dynamic URL management.
  - New OpenAPI specifications for Kinde Frontend API with key endpoints.

- **Enhancements**
  - Updated Content-Security-Policy headers for improved security.
  - Enhanced theme management logic for better user experience and accessibility.

- **Bug Fixes**
  - Improved error handling in API specification fetching script.

- **Chores**
  - Updated `dotenv` package version and modified build scripts for better functionality.
  - Added `.gitignore` entry to ignore specification files in the public directory.
  - Modified workflow concurrency settings for duplicate page ID check and link validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->