### PR TITLE
feat: expose models/schemas in api docs

### DIFF
--- a/src/components/ScalarApiReference.astro
+++ b/src/components/ScalarApiReference.astro
@@ -11,7 +11,7 @@ const {specURL, proxyURL = import.meta.env.PUBLIC_KINDE_PROXY_URL} = Astro.props
   id="api-reference"
   data-url={specURL}
   data-proxy-url={proxyURL}
-  data-configuration='{"theme": "deepSpace", "hideDarkModeToggle": "true", "searchHotKey": "j", "hideModels": "true"}'
+  data-configuration='{"theme": "deepSpace", "hideDarkModeToggle": "true", "searchHotKey": "j"}'
 ></script>
 <script
   src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.23.5/dist/browser/standalone.min.js"


### PR DESCRIPTION
Expose models (schemas) for the API reference docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the "hideModels" parameter from the data-configuration, ensuring improved clarity in the component's functionality.
  
- **Documentation**
	- Maintained existing structure for `specURL` and `proxyURL`, ensuring consistency in user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->