### PR TITLE
feat: enable search in api reference docs

### DIFF
--- a/src/components/ScalarApiReference.astro
+++ b/src/components/ScalarApiReference.astro
@@ -162,10 +162,6 @@ const {specURL, proxyURL = import.meta.env.PUBLIC_KINDE_PROXY_URL} = Astro.props
     font-size: 13px;
   }
 
-  .scalar-api-references-standalone-search {
-    display: none !important;
-  }
-
   .kinde-header {
     background-color: var(--scalar-background-1);
     border-block-end: 1px solid var(--scalar-scrollbar-color);


### PR DESCRIPTION
Restore default for allowing search in the API docs references.
