### PR TITLE
Document header that can be used to see when rate limit resets

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/api-rate-limits.mdx
+++ b/src/content/docs/developer-tools/kinde-api/api-rate-limits.mdx
@@ -40,7 +40,7 @@ Rate limiting can occur under a variety of conditions, but it’s most common in
 
 ## Handle limiting gracefully
 
-Graceful handling involves monitoring for `429` status codes and triggering a retry method.
+Graceful handling involves monitoring for `429` status codes and triggering a retry method.  The header `RateLimit-Reset` will return the number of seconds until the rate limit is reset.
 
 Your method should follow an exponential back-off schedule to reduce request volume as needed. We also recommend building randomness into the back-off schedule to avoid a ‘thundering herd’ effect.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Document this `RateLimit-Reset` HTTP header as it can be useful to prevent unnecessarily early retries.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->
