### PR TITLE
fix: remove unnecessary padding

### DIFF
--- a/src/components/Topics.astro
+++ b/src/components/Topics.astro
@@ -3,7 +3,7 @@ import {Icon} from "astro-icon/components";
 import sidebarData from "@data/sidebarData";
 ---
 
-<ul class="topics grid grid-cols-1 gap-6 px-0 py-16 md:grid-cols-2 lg:grid-cols-3">
+<ul class="topics grid grid-cols-1 gap-6 px-0 md:grid-cols-2 lg:grid-cols-3">
   {
     sidebarData?.map((topic) => (
       <li class="relative flex list-none flex-col gap-4 rounded-2xl bg-kinde-grey-50 p-12 dark:bg-kinde-grey-900">


### PR DESCRIPTION
Remove unnecessary padding within the`Topics` component. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the vertical padding of the topics list for improved layout.
  
These changes enhance the visual presentation of the topics without affecting their functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->