### PR TITLE
Added note about scopes in token

### DIFF
--- a/src/content/docs/developer-tools/kinde-api/about-m2m-scopes.mdx
+++ b/src/content/docs/developer-tools/kinde-api/about-m2m-scopes.mdx
@@ -32,4 +32,4 @@ Follow this procedure if you already have an application and you experience a sc
 2. On the left, select **APIs**.
 3. Select the three dots next to the Kinde management API, then choose **Manage scopes**. 
 4. Select the scopes you want to include in the token. For maximum security only enable the minimum scopes you require. 
-5. Select **Save**.
+5. Select **Save**. The scopes will now be included in the token. You do not need to also send them in the token request.


### PR DESCRIPTION
Clarifying how scopes are added to token (through Kinde) and not needed to be included in the token request as well.
