### PR TITLE
fix: remove params from api docs links

### DIFF
--- a/src/components/ScalarApiReference.astro
+++ b/src/components/ScalarApiReference.astro
@@ -51,6 +51,15 @@ const {specURL, proxyURL = import.meta.env.PUBLIC_KINDE_PROXY_URL} = Astro.props
     // update url params
     const newUrl = urlParams.toString() ? window.location.pathname + '?' + urlParams.toString() : window.location.pathname;
     history.replaceState(null, '', newUrl);
+
+    // remove params from links
+    const links: NodeListOf<HTMLAnchorElement> = document.querySelectorAll('.sidebar-group a');
+    links.forEach((link) => {
+        const url = new URL(link.href, window.location.origin);
+        url.searchParams.delete('token');
+        url.searchParams.delete('subdomain');
+        link.href = url.toString();
+    });
   }
 
   function checkSubdomain(subdomainElement: HTMLInputElement) {


### PR DESCRIPTION
- On the api docs, if we have `token` or `subdomain` params in the URL, remove them from all sidebar links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved URL parameter management in the sidebar for a cleaner user experience.
	- Enhanced input fields with automatic text selection and refined authentication labels based on user context.
	- Visual feedback for subdomain input validity through animations.

- **Bug Fixes**
	- Fixed issues related to URL parameter handling, ensuring smoother navigation.

- **Documentation**
	- Updated interface to include an optional property for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->