### PR TITLE
Link fix to other token test doc

### DIFF
--- a/src/content/docs/developer-tools/your-apis/test-your-api-m2m-token.mdx
+++ b/src/content/docs/developer-tools/your-apis/test-your-api-m2m-token.mdx
@@ -12,7 +12,7 @@ This doc describes how to test the security of token exchange for your API conne
 
 You can use this process to request tokens for your own and third-party APIs, and to test custom scopes added to claims. Below are the steps to generate `id` and `access` tokens with Postman.
 
-If you are testing user access tokens, see [Get a user access token to test your APIs].
+If you are testing user access tokens, see [Get a user access token to test your APIs](/developer-tools/your-apis/test-your-api-user-token/).
 
 ## Step 1: Add your API to Kinde
 


### PR DESCRIPTION
Link fix




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and navigation in the API testing documentation.
	- Updated hyperlink for user access token testing to enhance user experience.
	- Preserved existing content and structure for obtaining M2M access tokens using Postman.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->