### PR TITLE
docs: Add example for publicPaths in Kinde Next.js middleware documen…

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
@@ -1398,6 +1398,7 @@ export default withAuth(
   {
     isReturnToCurrentPage: true,
     loginPage: "/login",
+    publicPaths: ["/public", '/more'],
     isAuthorized: ({token}) => {
       // The user will be considered authorized if they have the permission 'eat:chips'
       return token.permissions.includes("eat:chips");
@@ -1721,7 +1722,7 @@ You need to create a [machine to machine (M2M)](/developer-tools/kinde-api/conne
 
    <Aside>
 
-      You can adapt the script above to use our [Kinde Management API JS](https://github.com/kinde-oss/management-api-js) package. Please note that in this case you would have to add this package as a dependency in your project along with a few required environment variables. [See configuration details](https://github.com/kinde-oss/management-api-js?tab=readme-ov-file#installation).
+   You can adapt the script above to use our [Kinde Management API JS](https://github.com/kinde-oss/management-api-js) package. Please note that in this case you would have to add this package as a dependency in your project along with a few required environment variables. [See configuration details](https://github.com/kinde-oss/management-api-js?tab=readme-ov-file#installation).
 
    </Aside>
 


### PR DESCRIPTION
## Documentation Update: Add Example for `publicPaths` in Middleware Configuration

### Issue
The current documentation for Kinde's Next.js SDK middleware lacks a clear example demonstrating the `publicPaths` option, which can cause confusion for developers implementing route protection.

### Changes
- Added an example showcasing the `publicPaths` option in the middleware configuration
- Demonstrated how `publicPaths` can be used alongside other middleware options
- Provided a clear, practical implementation snippet

### Benefits
- Clarifies the usage of the `publicPaths` option
- Reduces developer confusion and trial-and-error
- Improves documentation completeness and clarity

### Related Issue
Resolves [#244](https://github.com/kinde-oss/kinde-auth-nextjs/issues/244) - Missing `publicPaths` Example in Middleware Documentation originally posted in the issues for [kinde-oss/kinde-auth-nextjs](https://github.com/kinde-oss/kinde-auth-nextjs/issues/244)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded documentation for the Next.js App Router SDK, including setup and usage instructions.
	- Added detailed installation guidance, environment variable configuration, and examples for authentication components.
	- Enhanced sections on route protection, middleware options, and Kinde Management API interaction.
	- Updated migration guide to reflect recent changes in function imports and promise handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->