### PR TITLE
fix: add correct color of link on dark mode

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -21,10 +21,9 @@ import FooterCards from "@components/FooterCards.astro";
       <p class="text-lg">
         Alternatively, you can <button
           kui-trigger="search"
-          class="cursor-pointer bg-transparent font-normal text-black underline underline-offset-[.3em]"
-          >search the docs</button
-        >.
-      </p>
+          class="cursor-pointer bg-transparent font-normal text-black underline underline-offset-[.3em] dark:text-white"
+          >search the docs.</button
+        ></p>
     </section>
     <FooterCards />
   </div>


### PR DESCRIPTION
- Fix text on dark mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved button styling for dark mode in the 404 error page.
	- Enhanced accessibility with updated button text.

These changes refine the user interface without affecting the overall functionality of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->