### PR TITLE
Fix reference to wordpress domain

### DIFF
--- a/src/content/docs/integrate/third-party-tools/kinde-wordpress.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-wordpress.mdx
@@ -27,9 +27,9 @@ This topic includes only basic steps. Depending on your exact setup, additional 
 1. Sign in to your Kinde dashboard.
 2. Go to **Settings > Applications > [Your App Name] > View Details**.
 3. In the **Allowed callback URLs** field, enter:
-   `http://[your_kinde_domain].kinde.com/wp-admin/admin-ajax.php?action=openid-connect-authorize`
+   `https://[your_wordpress_domain]/wp-admin/admin-ajax.php?action=openid-connect-authorize`
 4. In the **Allowed logout redirect URLs** field, enter:
-   `http://[your_kinde_domain].kinde.com/`
+   `https://[your_wordpress_domain]/`
 5. Select **Save**.
 
 ## Step 3: Configure the Plugin


### PR DESCRIPTION
#### Description (required)

I don't have experience with the Wordpress integration, but typically the callback and login URLs configured in Kinde would be in another application and not on the Kinde domain.  In any case, the path looks like a WordPress one that doesn't exist in Kinde, so I expect it should be references to the WordPress instance.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Kinde WordPress integration guide to use secure HTTPS URLs for callback and logout redirect configurations.
	- Improved security recommendations for setting up authentication between Kinde and WordPress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->