### PR TITLE
Fix/additional claim in id token

### DIFF
--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -62,6 +62,8 @@ Access tokens are a secure way of authenticating users, and passing information 
   ]
   ```
 
+- **External provider ID** - The ID you use to identify the organization the user is authorized against
+
 - (MS Entra ID authentication only) Claims starting with `ext_` indicate that user details have come from a third party enterprise auth provider like Microsoft. For example:
 
   ```jsx

--- a/src/content/docs/build/tokens/about-id-tokens.mdx
+++ b/src/content/docs/build/tokens/about-id-tokens.mdx
@@ -33,7 +33,7 @@ During authentication, ID tokens carry information about authenticated users sec
 
 ## Kinde additional claims
 
-- **External ID** - The `provided_id` is the user‘s unique identification code in your system
+- **Social identity** - Details from the user’s third-party profile, such as handle, username, and ID.
 - **Organizations** - The `org_codes` claim contains an array of IDs for the Kinde organizations that the user belongs to.
 
 ## Example ID token


### PR DESCRIPTION
Additional claims were not quite right in the Access and ID tokens docs. 
Fixed by adding 'Social identity' for ID tokens and 'External provider ID' for Access tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated access tokens documentation with details about external provider ID
	- Added information about claims starting with `ext_` from third-party enterprise authentication providers
	- Modified ID tokens documentation to include a new "Social identity" claim
	- Refined description of token issuer and claims

<!-- end of auto-generated comment: release notes by coderabbit.ai -->