### PR TITLE
Feat/email content

### DIFF
--- a/src/content/docs/design/emails/email-notifications.mdx
+++ b/src/content/docs/design/emails/email-notifications.mdx
@@ -63,7 +63,7 @@ You can change the content of the OTP email if you use a [custom email sender](/
 
 ## Add sign-in code to the email subject line (passwordless auth)
 
-It's common to want to include the sign-in code in the subject line of OTP emails, to make it visible for users in notifications. For security, Kinde displays the OTP in the email body by default, but you can override this. 
+You can include the sign-in code in the subject line of OTP emails to make it visible for users in notifications. Note that it is less secure to do this, as the code can be seen by anyone when notifications are displayed openly on devices.
 
 1. In Kinde, go to **Design > Emails > Email content.**
 2. Select the language you want to edit. Only [languages you have selected](/design/pages/internationalization/) in your business are available.

--- a/src/content/docs/design/emails/email-notifications.mdx
+++ b/src/content/docs/design/emails/email-notifications.mdx
@@ -52,6 +52,22 @@ For example:
 
 If you want emails to come from your app name instead (if it is different), then you can edit the business name in **Settings > Business > Details**, without it affecting your Kinde domain or other environment settings.
 
-## Change email content
+## Change the content of the one-time passcode (OTP) email (for Passwordless auth)
 
-It is not currently possible to change the content of emails.
+You can change the content of the OTP email if you use a [custom email sender](/get-started/connect/customize-email-sender/) for sending OTP emails. Once this is set up, make content changes as follows.
+
+1. In Kinde, go to **Design > Emails > Email content.**
+2. Select the language you want to edit. Only [languages you have selected](/design/pages/internationalization/) in your business are available.
+3. You can edit the subject line, body content, and disclaimer footer. You can use the placeholders indicated.
+4. When you have made your changes, select **Save**. The new email content will now be sent.
+
+## Add sign-in code to the email subject line (for passwordless auth)
+
+It's common to want to include the sign-in code in the subject line of OTP emails, to make it visible for users in notifications. Kinde don't have it this way by default, for added security, but you can override this. 
+
+1. In Kinde, go to **Design > Emails > Email content.**
+2. Select the language you want to edit. Only [languages you have selected](/design/pages/internationalization/) in your business are available.
+3. In the subject line field, include the `${code}` placeholder. This is where the code will appear. E.g. Enter `${code}` for access.
+4. Select **Save**.
+
+

--- a/src/content/docs/design/emails/email-notifications.mdx
+++ b/src/content/docs/design/emails/email-notifications.mdx
@@ -52,22 +52,20 @@ For example:
 
 If you want emails to come from your app name instead (if it is different), then you can edit the business name in **Settings > Business > Details**, without it affecting your Kinde domain or other environment settings.
 
-## Change the content of the one-time passcode (OTP) email (for Passwordless auth)
+## Change the content of the one-time passcode (OTP) email (passwordless auth)
 
-You can change the content of the OTP email if you use a [custom email sender](/get-started/connect/customize-email-sender/) for sending OTP emails. Once this is set up, make content changes as follows.
+You can change the content of the OTP email if you use a [custom email sender](/get-started/connect/customize-email-sender/) for sending OTP emails. Once this is set up, you can make content changes as follows.
 
 1. In Kinde, go to **Design > Emails > Email content.**
 2. Select the language you want to edit. Only [languages you have selected](/design/pages/internationalization/) in your business are available.
-3. You can edit the subject line, body content, and disclaimer footer. You can use the placeholders indicated.
+3. You can edit the subject line, body content, and disclaimer footer. Use the placeholders to personalize and define where the code appears.
 4. When you have made your changes, select **Save**. The new email content will now be sent.
 
-## Add sign-in code to the email subject line (for passwordless auth)
+## Add sign-in code to the email subject line (passwordless auth)
 
-It's common to want to include the sign-in code in the subject line of OTP emails, to make it visible for users in notifications. Kinde don't have it this way by default, for added security, but you can override this. 
+It's common to want to include the sign-in code in the subject line of OTP emails, to make it visible for users in notifications. For security, Kinde displays the OTP in the email body by default, but you can override this. 
 
 1. In Kinde, go to **Design > Emails > Email content.**
 2. Select the language you want to edit. Only [languages you have selected](/design/pages/internationalization/) in your business are available.
 3. In the subject line field, include the `${code}` placeholder. This is where the code will appear. E.g. Enter `${code}` for access.
 4. Select **Save**.
-
-


### PR DESCRIPTION
Added two procedures - one general, one specifically to add OTP to subject line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for email notifications in passwordless authentication.
	- Added detailed instructions for customizing one-time passcode (OTP) email content.
	- Introduced guidance on adding sign-in code to email subject line.
	- Removed previous limitation statement about email content modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->