### PR TITLE
Feat/sha256 via api

### DIFF
--- a/src/content/docs/manage-users/access-control/set-temporary-password.mdx
+++ b/src/content/docs/manage-users/access-control/set-temporary-password.mdx
@@ -64,11 +64,11 @@ Include the following information for the password API:
 
     </Aside>
 
-<Aside title="sha256 support:">
+    <Aside title="sha256 support:">
 
   Provide the hash in hex format. For the `salt_format`, specify how the salt should be interpreted: e.g. **hex** for a hex-encoded string (68656c6c6f for hello). By default, the salt is treated as a plain string, and escape sequences (like \n or \v) are treated as literal characters.
 
-  </Aside>
+    </Aside>
 
 - `salt` - extra characters added to passwords to make them stronger
 - `salt_position` - position of salt in password string. Prefix (before) or suffix (after).

--- a/src/content/docs/manage-users/access-control/set-temporary-password.mdx
+++ b/src/content/docs/manage-users/access-control/set-temporary-password.mdx
@@ -56,13 +56,19 @@ We only accept password hashes and will never allow plain text passwords
 Include the following information for the password API:
 
 - `hashed_password` - the user’s password encrypted using a hashing method or algorithm
-- `hashing_method` - the name of the algorithm used to encrypt the user’s password. Currently **crypt**, **bcrypt**, **md5**, and **wordpress** are supported.
+- `hashing_method` - the name of the algorithm used to encrypt the user’s password. Currently **crypt**, **bcrypt**, **md5**, **SHA256**, and **wordpress** are supported.
 
     <Aside title="bcrypt $2b variant support">
 
   If you are importing bcrypt hashes with the $2b variant, Kinde will substitute this for the $2a variant. These are interchangeable as long as you were not running OpenBSD at the time the hashes were generated.
 
     </Aside>
+
+<Aside title="sha256 support:">
+
+  Provide the hash in hex format. For the `salt_format`, specify how the salt should be interpreted: e.g. **hex** for a hex-encoded string (68656c6c6f for hello). By default, the salt is treated as a plain string, and escape sequences (like \n or \v) are treated as literal characters.
+
+  </Aside>
 
 - `salt` - extra characters added to passwords to make them stronger
 - `salt_position` - position of salt in password string. Prefix (before) or suffix (after).
@@ -73,5 +79,6 @@ Include the following information for the password API:
   | bcrypt         |          |                           |
   | crypt          | Optional |                           |
   | wordpress      | Optional |                           |
+  | SHA256         | Optional | required if salt included |
 
 - `is_temporary_password` - indicates a single use password, the user will be prompted to set a new password after the first time they use it.


### PR DESCRIPTION
Added option for setting SHA256 Hashed password via API as per Slack discussion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced API documentation by adding support for the SHA256 hashing method for setting temporary passwords.
	- Provided clear instructions on how to format the hash in hex and correctly use the salt when SHA256 is included.
	- Updated the details on supported hashing methods to improve clarity and guide end-user implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->