### PR TITLE
Feat/show sso sign in button

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -41,20 +41,18 @@ Many businesses have businesses for customers (B2B), and use Kinde organizations
 
 ## Routing in enterprise connections
 
-When users sign up via an enterprise connection with single-sign-on (SSO), they are routed to the identity provider (IdP) for identity verification. Here’s how this happens.
-
-### The sign in button on the auth page
-
-When you set up an enterprise connection in Kinde, the SSO button on the authentication page gets linked to the IdP by default, similar to how you see a Google or Facebook sign-in option.
-
-This is fine if you only have one connection, but is not ideal if you have multiple connections and you don’t want to show multiple SSO buttons to all users.
-
-To avoid this, you can use home realm discovery (below).
+When users sign up via an enterprise connection with single-sign-on (SSO), they are routed to the identity provider (IdP) for identity verification. This happens when they select the SSO button on the home screen. You can set up a more seamless routing option using home realm discovery.
 
 ### Home realm discovery
 
-Home realm discovery routes users based on their email domain. So when a users enter their email and selects the SSO button, they are routed to their IdP based on the email domain, to authenticate. For example if the user enters [chris@acme.com](mailto:chris@acme.com) Kinde checks which IdP uses the [**acme.com**](http://acme.com/) domain and sends Chris there to authenticate.
+Home realm discovery routes users based on their email domain. So when a users enter their email and selects the continue button, they are routed to their IdP based on the email domain, to authenticate. For example if the user enters [chris@acme.com](mailto:chris@acme.com) Kinde checks which IdP uses the [**acme.com**](http://acme.com/) domain and sends Chris there to authenticate.
 
 Note that this feature has nothing to do with security or access control and everything to do with routing. Do not confuse this feature with access restrictions for [domain allowlists](/authenticate/enterprise-connections/enterprise-connections-b2b/#restrict-org-access-via-connections).
 
 Learn more about [home realm discovery](/authenticate/enterprise-connections/home-realm-discovery/).
+
+## Show or hide the sign-in button on the auth page
+
+When you set up an enterprise connection in Kinde, the SSO button on the authentication page gets linked to the IdP by default, similar to how you see a Google or Facebook sign-in option.
+
+If you use home realm discovery, the SSO button will be hidden by default. This is ideal if you have multiple connections and you don’t want to show multiple SSO buttons to all users. However, there might be a reason you want to show a specific or all SSO buttons. If this is the case, select the **Always show sign-in button** option in the Enterprise connection configuration.

--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -45,14 +45,28 @@ When users sign up via an enterprise connection with single-sign-on (SSO), they 
 
 ### Home realm discovery
 
-Home realm discovery routes users based on their email domain. So when a users enter their email and selects the continue button, they are routed to their IdP based on the email domain, to authenticate. For example if the user enters [chris@acme.com](mailto:chris@acme.com) Kinde checks which IdP uses the [**acme.com**](http://acme.com/) domain and sends Chris there to authenticate.
+Home realm discovery routes users based on their email domain. So when a user enters their email and selects the continue button, they are routed to their IdP based on the email domain, to authenticate. For example if the user enters [chris@acme.com](mailto:chris@acme.com) Kinde checks which IdP uses the [**acme.com**](http://acme.com/) domain and silently verifies his identity. He only signs in once.
 
-Note that this feature has nothing to do with security or access control and everything to do with routing. Do not confuse this feature with access restrictions for [domain allowlists](/authenticate/enterprise-connections/enterprise-connections-b2b/#restrict-org-access-via-connections).
+Note that this feature has nothing to do with security or access control and everything to do with routing. Not to be confused with setting access restrictions for [domain allowlists](/authenticate/enterprise-connections/enterprise-connections-b2b/#restrict-org-access-via-connections).
 
 Learn more about [home realm discovery](/authenticate/enterprise-connections/home-realm-discovery/).
 
-## Show or hide the sign-in button on the auth page
+## Show or hide the SSO sign-in button on the auth page
 
-When you set up an enterprise connection in Kinde, the SSO button on the authentication page gets linked to the IdP by default, similar to how you see a Google or Facebook sign-in option.
+When you set up enterprise auth in Kinde, an SSO button appears on the authentication page which is linked to the IdP by default. Users can select this as a sign up method, similar to how they might select a Google or Facebook sign-in option. For a more seamless experience, you can hide the SSO button by entering a home realm domain for the connection (more info above). Users will be routed silently via their IdP when they enter their credentials.
 
-If you use home realm discovery, the SSO button will be hidden by default. This is ideal if you have multiple connections and you don’t want to show multiple SSO buttons to all users. However, there might be a reason you want to show a specific or all SSO buttons. If this is the case, select the **Always show sign-in button** option in the Enterprise connection configuration.
+If you have multiple enterprise auth methods (E.g. SAML and Entra ID), you may not want to show multiple SSO buttons. Here's the options for showing and hiding, depending how many enterprise auth methods you add:
+
+### (Option 1) Hide all SSO buttons
+
+If you configure home realm discovery in each enterprise auth method, all SSO buttons will be hidden by default. The user enters their credentials and they are silently authenticated against the relevant IdP based on email domain.
+
+### (Option 2) Show a universal SSO button for all
+
+If you would prefer users explicitly choose to sign in with SSO, you can add a universal button to the sign in screen. 
+
+1. Go to **Settings > Applications > Your application**.
+2. On the **Details** page scroll down to the **Authentication experience** section. 
+3. Switch on **Always show sign-in button**.
+
+Users click the universal button, enter their credentials, and get routed silently to the IdP for verification. 

--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -53,9 +53,10 @@ If you are [importing users into Kinde](/manage-users/add-and-edit/import-users
 5. Enter the **Client ID** and **Client secret** as they appear in the MS Azure portal. Make sure you use the **Value** of the client secret.
 6. Enter **Home realm domains**. This speeds up the sign in process for users of those domains.
    Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
-7. If you want, select the **Use common endpoint** option. Recommended if you use multi-tenancy.
-8. Select **Extended profile** if you want to sync the additional information stored in a user’s Microsoft profile to their Kinde user profile.
-9. If you want to sync user groups, select **Get user groups**. Recommended if you manage permissions and access via user groups in Microsoft. You also need to do some additional setup, see below.
+7. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option. 
+8. If you want, select the **Use common endpoint** option. Recommended if you use multi-tenancy.
+9. Select **Extended profile** if you want to sync the additional information stored in a user’s Microsoft profile to their Kinde user profile.
+10. If you want to sync user groups, select **Get user groups**. Recommended if you manage permissions and access via user groups in Microsoft. You also need to do some additional setup, see below.
   
     <Aside>
 
@@ -63,11 +64,11 @@ If you are [importing users into Kinde](/manage-users/add-and-edit/import-users
 
     </Aside>
 
-9. If you want, select **Sync user profiles and attributes on sign in**. Recommended to keep Kinde user profile data in sync with user profile data from Microsoft. If you choose this option, ensure that the global profile sync preference is also switched on in **Settings > Environment > Policies**.
-10. If you want to enable just-in-time (JIT) provisioning, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.
-11. Copy the **Callback URL**. You’ll need to enter this in your Microsoft app.
-12. In the **Applications** section, select the applications you want to activate the connection for.
-13. Select **Save**.
+11. If you want, select **Sync user profiles and attributes on sign in**. Recommended to keep Kinde user profile data in sync with user profile data from Microsoft. If you choose this option, ensure that the global profile sync preference is also switched on in **Settings > Environment > Policies**.
+12. If you want to enable just-in-time (JIT) provisioning, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.
+13. Copy the **Callback URL**. You’ll need to enter this in your Microsoft app.
+14. In the **Applications** section, select the applications you want to activate the connection for.
+15. Select **Save**.
 
 ## (Optional) Sync Entra ID groups with Kinde
 

--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -55,15 +55,8 @@ If you are [importing users into Kinde](/manage-users/add-and-edit/import-users
    Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
 7. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option. 
 8. If you want, select the **Use common endpoint** option. Recommended if you use multi-tenancy.
-9. Select **Extended profile** if you want to sync the additional information stored in a user’s Microsoft profile to their Kinde user profile.
-10. If you want to sync user groups, select **Get user groups**. Recommended if you manage permissions and access via user groups in Microsoft. You also need to do some additional setup, see below.
-  
-    <Aside>
-
-   Extended attributes data is included in the `extra_claims` object of the access token.
-
-    </Aside>
-
+9. Select **Extended profile** if you want to sync the additional information stored in a user’s Microsoft profile to their Kinde user profile. Extended attributes data is included in the `extra_claims` object of the access token.
+10. If you want to sync user groups, select **Get user groups**. Recommended if you manage permissions and access via user groups in Microsoft. You also need to do some additional setup, see below. 
 11. If you want, select **Sync user profiles and attributes on sign in**. Recommended to keep Kinde user profile data in sync with user profile data from Microsoft. If you choose this option, ensure that the global profile sync preference is also switched on in **Settings > Environment > Policies**.
 12. If you want to enable just-in-time (JIT) provisioning, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.
 13. Copy the **Callback URL**. You’ll need to enter this in your Microsoft app.

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -4,6 +4,8 @@ title: Use Cloudflare as a SAML identity provider
 sidebar:
   order: 10
 relatedArticles:
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
+  - e100d77b-530b-4327-8216-93c955657e0c	
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041
   - d894dd3c-356f-41b0-b510-c35066a2277d
@@ -42,7 +44,13 @@ You need to set up an enterprise connection in Kinde for this, and add a Cloudfl
   decoding="async"
 />
 
-6. Copy the **Assertion Customer Service (ACS) URL** and the Entity ID somewhere you can access it later. You’ll need this to set up your Cloudflare application.
+6. Complete any optional fields you want, including Entity ID, and key attributes. You'll add the IdP Metadata URL later.
+7. Enter Home realm domains. This speeds up the sign in process for users of those domains. Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
+8. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option.
+9. Copy the **Assertion Customer Service (ACS) URL** and the Entity ID somewhere you can access it later. You’ll need this to set up your Cloudflare application.
+10. Select provisioning options.
+11. Add a signed certificate and key if you have it. You can also do this later.
+12. Select **Save**. 
 
 ## Step 2: Add and configure your Cloudflare application
 
@@ -91,7 +99,7 @@ You need to set up an enterprise connection in Kinde for this, and add a Cloudfl
   decoding="async"
 />
 
-## Step 3: Add the metadata URL to your Cloudflare connection
+## Step 3: Finish setting up your Cloudflare connection
 
 1. In Kinde, go to **Settings > Authentication**.
 2. Select **Configure** on the Cloudflare connection.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -4,6 +4,7 @@ title: Custom SAML with Google Workspace
 sidebar:
   order: 9
 relatedArticles:
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - e100d77b-530b-4327-8216-93c955657e0c
 ---
@@ -41,8 +42,9 @@ Sign in to both Kinde and the Google Workspace Admin Console in separate tabs or
      loading="lazy"
      decoding="async"
    />
-
-6. Scroll down and copy the **ACS URL**. Paste the URL somewhere you can access it later.
+7. Enter Home realm domains. This speeds up the sign in process for users of those domains. Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
+8. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option.
+9. Scroll down and copy the **ACS URL**. Paste the URL somewhere you can access it later.
 
 <img
   src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/c2201994-75d8-44a9-1ced-d3890e359300/public"
@@ -54,7 +56,9 @@ Sign in to both Kinde and the Google Workspace Admin Console in separate tabs or
   decoding="async"
 />
 
-8. Select **Save**. We will need to get some information from Google Workspace Console to complete these fields.
+10. Select provisioning options.
+11. Add a signed certificate and key if you have it. You can also do this later.
+12. Select **Save**. We need to get some information from Google Workspace Console to complete these fields.
 
 ## Step 2: Configure Google Workspace Admin Console
 
@@ -136,7 +140,8 @@ As mentioned at the start, you need to upload the **metadata file** that you dow
 2. Scroll down to **Enterprise Connections.**
 3. On the **Google Workspace** tile, select **Configure.**
 4. In the **IdP metadata URL** field, paste the URL for the metadata file.
-5. Select **Save**.
+5. Scroll down and select the apps that will use the auth method.
+6. Select **Save**.
 
 ## Test the connection
 

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -4,6 +4,7 @@ title: Custom authentication with SAML
 sidebar:
   order: 7
 relatedArticles:
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
@@ -58,8 +59,10 @@ You can obtain the certificate and key from your IdP or you can generate yoursel
 9. Enter the **IdP metadata URL**. This URL comes from your identity provider.
 10. Enter an **Email key attribute**. This is the attribute in the SAML token that contains the user’s email. Setting this value ensures that the email address returned in the SAML response is correctly retrieved. We do not recommend leaving this field blank, but if you do we will set ‘email’ as the attribute.
 11. Enter any relevant **Home realm domains**. This is how SAML recognizes a user’s credentials and routes them to the correct sign in page. Note that home realm domains need to be unique across all connections in an environment. [Read more about home realm domains](/authenticate/enterprise-connections/home-realm-discovery/).
-12. Copy the **ACS URL**, which is also known as a reply URL. This will need to be copied to the relevant area of your identity provider configuration.
-13. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.
+12. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option. 
+
+13. Copy the **ACS URL**, which is also known as a reply URL. This will need to be copied to the relevant area of your identity provider configuration.
+14. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.
 
 <img
   src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/96a64401-60df-409d-df80-ffeb3d2a7900/public"
@@ -71,9 +74,9 @@ You can obtain the certificate and key from your IdP or you can generate yoursel
   decoding="async"
 />
 
-14. (Optional) In the **Sign SAML request** section, paste in the **Signed certificate** and **Private key**. You may have got these from your IdP or you may have generated yourself (see procedure above).
-15. Choose which applications you want to enable SAML for and select **Save**.
-16. Complete any additional configuration in your identity provider’s settings, such as adding the **Entity ID** and **ACS URL**.
+15. (Optional) In the **Sign SAML request** section, paste in the **Signed certificate** and **Private key**. You may have got these from your IdP or you may have generated yourself (see procedure above).
+16. Choose which applications you want to enable SAML for and select **Save**.
+17. Complete any additional configuration in your identity provider’s settings, such as adding the **Entity ID** and **ACS URL**.
 
 ## Test the connection
 

--- a/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
@@ -4,17 +4,18 @@ title: Home realm or IdP discovery
 sidebar:
   order: 4
 relatedArticles:
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - cc242fb3-4b06-4842-97c8-dd58e87308df
 ---
 
-Home realm discovery (HRD) is the process of checking which provider or connection group a user belongs to, before authenticating them. It is also known as Identity Provider or IdP discovery.
+Home realm discovery (HRD) provides a seamless sign-in experience for your enterprise auth users. When HRD is configured and a user sign in, Kinde checks which IdP or connection group a user belongs to, before authenticating them. It is also known as Identity Provider or IdP discovery.
 
-When HRD is set up in Kinde, users are authenticated via the **Home Realm Domain** domain that has been specified.
+When HRD is set up in Kinde, users are authenticated based on the **Home Realm Domain** (email domain) that is entered.
 
 HRD is usually applied where your identity provider (IdP) is a third party, such as Microsoft Entra ID, Google, Cloudflare, etc, and you are using an enterprise or SAML auth setup.
 
-Kinde provides HRD through a universal login page.
+By default, Kinde provides a universal login page where users of any enterprise connection can sign in. They are then silently routed and verified via the relevant IdP.
 
 ## How it works
 
@@ -29,6 +30,10 @@ For example, you could configure two different connections as follows:
 - Email addresses ending with `enterpriseA.com` use SAML connection A
 - Email addresses ending with `enterpriseB.com` use Entra ID connection B
 
-In the back end, the end-user is linked to the correct identity provider via the connection.
+In the back end, the end-user is linked to the correct identity provider via the connection, and they are silently authenticated.
 
-So when Jude Watson arrives at the sign in window and enters `judewatson@enterpriseA.com`, they are redirected to SAML connection A.
+So when Jude Watson arrives at the sign in window and enters `judewatson@enterpriseA.com`, they are routed to the IdP for SAML connection A, and authenticated.
+
+## Showing or hiding the sign in buttons
+
+Even if you have set up HRD, you can choose to show an SSO sign in button so the user has to click to proceed. Learn more [here](/authenticate/enterprise-connections/about-enterprise-connections/#show-or-hide-the-sso-sign-in-button-on-the-auth-page).

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -4,6 +4,8 @@ title: Use Okta as a SAML identity provider
 sidebar:
   order: 11
 relatedArticles:
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
+  - e100d77b-530b-4327-8216-93c955657e0c	
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041
   - d894dd3c-356f-41b0-b510-c35066a2277d
@@ -31,8 +33,12 @@ You need to set up an enterprise connection in Kinde for this, and add an Okta a
   decoding="async"
 />
 
-6. Copy the **Assertion Customer Service (ACS) URL** and the Entity ID somewhere you can access it later. You’ll need this to set up your Okta application.
-7. Select **Save**.
+6. Complete any optional fields you want, including the key attributes. You'll add the IdP Metadata URL later.
+7. Enter Home realm domains. This speeds up the sign in process for users of those domains. Note that all home realm domains must be unique across all connections in an environment. For more information about how, see [Home realm domains or IdP discovery](/authenticate/enterprise-connections/home-realm-discovery/).
+8. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option.
+9. Copy the **Assertion Customer Service (ACS) URL** and the Entity ID somewhere you can access it later. You’ll need this to set up your Okta application.
+10. Select provisioning options.
+10. Select **Save**.
 
 ## Step 2: Add and configure your Okta application
 
@@ -93,7 +99,7 @@ You need to set up an enterprise connection in Kinde for this, and add an Okta a
   decoding="async"
 />
 
-## Step 3: Add the metadata URL to your SAML connection
+## Step 3: Finish setting up your SAML connection in Kinde
 
 1. In Kinde, go to **Settings > Authentication**.
 2. Select **Configure** on the Okta connection.
@@ -109,7 +115,8 @@ You need to set up an enterprise connection in Kinde for this, and add an Okta a
   decoding="async"
 />
 
-4. In the **Applications** area, switch on the applications you want to use this connection.
+4. Enter the signed certificate and key information if you have it. You can do this later as well. 
+5. In the **Applications** area, switch on the applications you want to use this connection.
 
 <img
   src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/2eaf47d6-abb7-45db-4b85-18b53b24ef00/public"
@@ -121,4 +128,4 @@ You need to set up an enterprise connection in Kinde for this, and add an Okta a
   decoding="async"
 />
 
-5. Select **Save**. You can now use Okta as an IdP for the selected applications.
+6. Select **Save**. You can now use Okta as an IdP for the selected applications.

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -38,7 +38,7 @@ You need to set up an enterprise connection in Kinde for this, and add an Okta a
 8. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option.
 9. Copy the **Assertion Customer Service (ACS) URL** and the Entity ID somewhere you can access it later. You’ll need this to set up your Okta application.
 10. Select provisioning options.
-10. Select **Save**.
+11. Select **Save**.
 
 ## Step 2: Add and configure your Okta application
 


### PR DESCRIPTION
Update to all enterprise connection topics
- Added ref to showing the button (optional step)
- Made sure all procedures included same steps
- update to related topics

Added new section to overview topic about showing and hiding the SSO button.
Added reference to the HRD topic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined enterprise authentication guidance to clarify the SSO sign-up experience.
  - Enhanced explanations for home realm discovery that now route users based on their email domains.
  - Updated configuration steps and terminology for several identity providers, including Microsoft Entra ID, Cloudflare, Google Workspace, custom, and Okta SAML integrations.
  - Introduced clear options for managing SSO button visibility, ensuring a smoother and more intuitive sign-in process.
  - Added detailed instructions for setting up Cloudflare and Google Workspace SAML connections, improving clarity and completeness.
  - Expanded guidance on configuring the Okta SAML connection, emphasizing unique home realm domains and optional fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->