### PR TITLE
Feat/Add logo to org

### DIFF
--- a/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
+++ b/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
@@ -47,6 +47,18 @@ Logos need to be under 1MB in size. SVG format works best.
 7. Select **Save** to apply the changes.
 8. Test the change in your test or production environments.
 
+## To add a logo via the Kinde Management API
+
+Use this endpoint `POST {{domain}}/api/v1/organizations/{org_code}/logos/light`
+
+For different logo variations, adjust the type path parameter (e.g., `light`, `dark`).
+
+In the Header, set `content-type: multipart/form-data; boundary=";”`
+
+Use `form-data` in the body to upload a valid PNG, JPEG, GIF, SVG, AVIF or WEBP image smaller than 1MB.
+
+You can also delete logos via the API. [See the API docs](https://docs.kinde.com/kinde-apis/management/#tag/organizations/post/api/v1/organizations/{org_code}/logos/{type}).
+
 ## To add or change a favicon for an organization
 
 Favicons are the tiny image shown on the tab of a browser. Image files must be a multiple of 48px square (e.g. 48x48, 96x96).

--- a/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
+++ b/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
@@ -53,7 +53,7 @@ Use this endpoint `POST {{domain}}/api/v1/organizations/{org_code}/logos/light`
 
 For different logo variations, adjust the type path parameter (e.g., `light`, `dark`).
 
-In the Header, set `content-type: multipart/form-data; boundary=";”`
+In the Header, set a boundary value, e.g. `content-type: multipart/form-data; boundary="value"`
 
 Use `form-data` in the body to upload a valid PNG, JPEG, GIF, SVG, AVIF or WEBP image smaller than 1MB.
 


### PR DESCRIPTION
Updated to add API method of logo upload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section detailing how to upload and manage organization logos via the Kinde Management API, including the required HTTP method and request specifications.
  - Included information on accepted image formats and size limitations, as well as the capability to delete logos through the API.
  - Provided a link to the relevant API documentation while retaining previous content on manual logo management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->