### PR TITLE
Feat/org logo fallback

### DIFF
--- a/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
+++ b/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
@@ -47,6 +47,12 @@ Logos need to be under 1MB in size. SVG format works best.
 7. Select **Save** to apply the changes.
 8. Test the change in your test or production environments.
 
+<Aside title="Logo fallback behavior">
+
+If an organization logo fails to load, you can set fallback behavior to show the org name or the global business logo instead. See [set global brand](/design/pages/design-your-welcome-pages/).
+
+</Aside>
+
 ## To add a logo via the Kinde Management API
 
 Use this endpoint `POST {{domain}}/api/v1/organizations/{org_code}/logos/light`

--- a/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
+++ b/src/content/docs/design/brand/apply-branding-for-an-organization.mdx
@@ -49,7 +49,7 @@ Logos need to be under 1MB in size. SVG format works best.
 
 <Aside title="Logo fallback behavior">
 
-If an organization logo fails to load, you can set fallback behavior to show the org name or the global business logo instead. See [set global brand](/design/pages/design-your-welcome-pages/).
+If an organization logo is not available, you can set fallback behavior to show the org name or the global business logo instead. See [set global brand](/design/pages/design-your-welcome-pages/).
 
 </Aside>
 

--- a/src/content/docs/design/pages/design-your-welcome-pages.mdx
+++ b/src/content/docs/design/pages/design-your-welcome-pages.mdx
@@ -28,9 +28,9 @@ Use the following procedures to make design changes to suit your brand.
 
 1. In Kinde, go to **Design > Global > Brand**.
 2. In the **Logo** section, upload your company logo. Make sure images are less than 1MB, are PNG, JPEG, or GIF.
-3. Scroll down to the bottom of the page and select the global logo fallback behaviour. 
+3. Scroll down to the bottom of the page and select the global logo fallback behavior. 
     - Enable to use the global logo as a fallback default for organizations where the logo is not available. This means the end customer will see the organization logo, if not the global level logo, and failing that, the name of the organization.
-    - Disable if you want the default behaviour to be show the organization logo, then the organization name, and as a last option show the global logo.
+    - Disable if you want the default behavior to be show the organization logo, then the organization name, and as a last option show the global logo.
 3. Select **Save**.
 
 <Aside>

--- a/src/content/docs/design/pages/design-your-welcome-pages.mdx
+++ b/src/content/docs/design/pages/design-your-welcome-pages.mdx
@@ -28,14 +28,16 @@ Use the following procedures to make design changes to suit your brand.
 
 1. In Kinde, go to **Design > Global > Brand**.
 2. In the **Logo** section, upload your company logo. Make sure images are less than 1MB, are PNG, JPEG, or GIF.
+3. Scroll down to the bottom of the page and select the global logo fallback behaviour. 
+    - Enable to use the global logo as a fallback default for organizations where the logo is not available. This means the end customer will see the organization logo, if not the global level logo, and failing that, the name of the organization.
+    - Disable if you want the default behaviour to be show the organization logo, then the organization name, and as a last option show the global logo.
+3. Select **Save**.
 
-   <Aside>
+<Aside>
 
    The logo will be automatically linked to the [Redirect URL](/get-started/connect/callback-urls/) set for your business, or the [application homepage URL](/design/pages/link-to-homepage/) set up for each application. If you are using tracking, the URL will also reflect that the user clicked out of the sign up/sign in screen, so you can distinguish this action from successful sign ins.
 
    </Aside>
-
-3. Select **Save**.
 
 ## Add favicons for web browsers
 


### PR DESCRIPTION
Update to procedure for setting global logo, to include default toggle
Added info to adding logo for org procedure, to point out default behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated branding guidelines to include a new section on logo fallback behavior. If an organization logo fails to load, users can now opt to display either the organization name or a global business logo.
	- Enhanced design documentation with revised steps for configuring global logo fallback settings, ensuring users clearly understand the available display options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->