### PR TITLE
Fix/apple sso warning messages

### DIFF
--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -48,8 +48,8 @@ See also, [Manage authentication across applications](/authenticate/manage-authe
 When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/), ensure you have added the third party app, and included the Client ID and Client Secret (Keys) to the configuration screens in your live environment. 
 
 If you don’t use your own app's keys:
-- Kinde will fallback to use our own credentials as proxy and this will cause rate limiting. 
-- In the case of Apple, if you do not use your own app from the start, users will be associated with the wrong app, and cannot be transferred later. 
+- Kinde will fall back to using our own credentials as a proxy, which will cause rate limiting
+- For Apple SSO specifically, if you don't use your own app from the start, users will be permanently associated with the wrong app and cannot be transferred later
 
 Using the Kinde app is okay for local development environments, but not for live production environments.
 

--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -43,9 +43,15 @@ Once a user is signed in to one domain or subdomain, they can switch to another 
 
 See also, [Manage authentication across applications](/authenticate/manage-authentication/user-auth-applications/).
 
-## Rate limiting if third party keys not entered
+## Rate limiting and identity management issues if third party keys not entered
 
-When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/) or enterprise sign in like [SAML](/authenticate/enterprise-connections/custom-saml/), ensure you have added the third party Client ID and Client Secret (Keys) to the configuration screens in your live environment. If you don’t enter these details, Kinde will fallback to use our own credentials as proxy and this will cause rate limiting. This is okay for local development environments, but not for live production environments.
+When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/) or enterprise sign in like [SAML](/authenticate/enterprise-connections/custom-saml/), ensure you have added the third party app, and included the Client ID and Client Secret (Keys) to the configuration screens in your live environment. 
+
+If you don’t use your own app's keys:
+- Kinde will fallback to use our own credentials as proxy and this will cause rate limiting. 
+- In the case of Apple, if you do not use your own app from the start, users will be associated with the wrong app, and cannot be transferred later. 
+
+Using the Kinde app is okay for local development environments, but not for live production environments.
 
 <img
   src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/d7bdcd1a-1800-4e8f-780f-ea7d56c37400/public"

--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -45,7 +45,7 @@ See also, [Manage authentication across applications](/authenticate/manage-authe
 
 ## Rate limiting and identity management issues if third party keys not entered
 
-When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/) or enterprise sign in like [SAML](/authenticate/enterprise-connections/custom-saml/), ensure you have added the third party app, and included the Client ID and Client Secret (Keys) to the configuration screens in your live environment. 
+When setting up third party authentication, such as [social sign in](/authenticate/social-sign-in/add-social-sign-in/), ensure you have added the third party app, and included the Client ID and Client Secret (Keys) to the configuration screens in your live environment. 
 
 If you don’t use your own app's keys:
 - Kinde will fallback to use our own credentials as proxy and this will cause rate limiting. 

--- a/src/content/docs/authenticate/social-sign-in/apple.mdx
+++ b/src/content/docs/authenticate/social-sign-in/apple.mdx
@@ -5,13 +5,15 @@ sidebar:
   order: 3
 ---
 
-You can enable users to sign up and sign in using their Apple credentials.
+You can enable users to sign up and sign in using their Apple credentials. 
 
-<Aside type="warning" title="Note:">
+<Aside type="warning" title="For Apple auth in production">
 
-Apple limits the information it passes when users sign up this way. Avatars and profile pictures do not flow through to the auth experience in Kinde.
+You MUST set up an Apple app and use the provided Client ID and Client secret in the Kinde Apple connection. Do not use Kinde's credentials (Client ID and Client secret) for third party SSO apps in your production environment. This adds a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
 
 </Aside>
+
+It's also important to note that Apple limits the information it passes when users sign up this way. Avatars and profile pictures do not flow through to the auth experience in Kinde. The user's email may also be excluded, depending how they have their Apple ID set up. 
 
 ## **What you need**
 

--- a/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
@@ -9,7 +9,7 @@ relatedArticles:
   - 66e7bda8-bc17-463b-8b63-980bccf57e86
 ---
 
-You can enable users to sign up and sign in using their Bitbucket credentials. To enable this, you’ll need a Bitbucket app and some developer know-how.
+You can enable users to sign up and sign in using their Bitbucket credentials. To enable this, follow all the steps below to create a Bitbucket app and configure credentials in Kinde.
 
 ## **Get your Kinde callback URL**
 
@@ -37,7 +37,13 @@ You can enable users to sign up and sign in using their Bitbucket credentials. T
 10. Go back to **Apps and features** > **oauth consumers.**
 11. Select the workspace you’ve just created and copy the key (client id) and secret (client secret) to paste into the kinde app.
 
-## **Add Bitbucket credentials to Kinde**
+## **Add Bitbucket app credentials to Kinde**
+
+<Aside type="warning" title="You must use your own app credentials in production">
+
+Before you make your production environment live, add your own app's Client ID and Client secret in the Kinde connection. Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
 
 1. In Kinde, go to **Settings** > **Authentication**.
 2. On the **Bitbucket** tile, select **Configure**.

--- a/src/content/docs/authenticate/social-sign-in/discord.mdx
+++ b/src/content/docs/authenticate/social-sign-in/discord.mdx
@@ -29,6 +29,12 @@ You can enable users to sign up and sign in using their Discord credentials. To 
 
 ## **Add Discord credentials to Kinde**
 
+<Aside type="warning" title="You must use your own app credentials in production">
+
+Before you make your production environment live, add your own app's Client ID and Client secret in the Kinde connection. Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 1. In Kinde, go to **Settings** > **Authentication**.
 2. On the **Discord** tile, select **Configure**.
 3. Paste the **Client ID** and **Client secret** from the Discord app into the relevant fields.


### PR DESCRIPTION
Updates to warnings about using your own credentials in SSO connections for prod
If okay for Apple, Bitbucket and Discord - will add for all other SSOs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded authentication guidelines to clarify risks associated with omitting proper third-party credentials.
  - Updated messages for Apple, Bitbucket, and Discord sign-ins to emphasize the importance of using dedicated production credentials.
  - Refined instructions to ensure users understand the impacts related to rate limiting and identity management when credentials are not correctly configured.
  - Added details about potential limitations of information shared by Apple during sign-up, including user email and profile pictures.
  - Introduced new warnings to highlight security risks of using incorrect credentials in production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->