### PR TITLE
Fix/add app credentials

### DIFF
--- a/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
+++ b/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
@@ -14,6 +14,12 @@ An advantage of social sign in is that users don't have to create new credential
 
 If they have a gravatar picture associated with their social account, it will flow through to Kinde.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## Set up a social connection
 
 Follow the docs below for each social provider you want to use. This will give you the `Client ID` and `Client secret` (keys) you need to set up each auth method on the Kinde side.
@@ -32,12 +38,6 @@ Follow the docs below for each social provider you want to use. This will give y
 - [Twitch](/authenticate/social-sign-in/twitch/)
 - [Twitter](/authenticate/social-sign-in/twitter/)
 - [Xero](/authenticate/social-sign-in/xero-sso/)
-
-<Aside type="warning">
-
-Do not use Kinde's credentials (`Client ID` and `Client secret`) for third party SSO apps in your production environment. This adds a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
-
-</Aside>
 
 ### When an email is not provided
 

--- a/src/content/docs/authenticate/social-sign-in/apple.mdx
+++ b/src/content/docs/authenticate/social-sign-in/apple.mdx
@@ -9,7 +9,7 @@ You can enable users to sign up and sign in using their Apple credentials.
 
 <Aside type="warning" title="For Apple auth in production">
 
-You MUST set up an Apple app and use the provided Client ID and Client secret in the Kinde Apple connection. Do not use Kinde's credentials (Client ID and Client secret) for third party SSO apps in your production environment. This adds a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
+You MUST set up an Apple app and use the provided Client ID and Client secret in the Kinde Apple connection. Do not use Kinde's credentials (leave the Client ID and Client secret blank) for third party SSO apps in your production environment. This adds a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
 
 </Aside>
 

--- a/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
@@ -11,6 +11,12 @@ relatedArticles:
 
 You can enable users to sign up and sign in using their Bitbucket credentials. To enable this, follow all the steps below to create a Bitbucket app and configure credentials in Kinde.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get your Kinde callback URL**
 
 1. In Kinde, go to **Settings** > **Authentication**.
@@ -38,12 +44,6 @@ You can enable users to sign up and sign in using their Bitbucket credentials. T
 11. Select the workspace you’ve just created and copy the key (client id) and secret (client secret) to paste into the kinde app.
 
 ## **Add Bitbucket app credentials to Kinde**
-
-<Aside type="warning" title="You must use your own app credentials in production">
-
-Before you make your production environment live, add your own app's Client ID and Client secret in the Kinde connection. Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
-
-</Aside>
 
 1. In Kinde, go to **Settings** > **Authentication**.
 2. On the **Bitbucket** tile, select **Configure**.

--- a/src/content/docs/authenticate/social-sign-in/discord.mdx
+++ b/src/content/docs/authenticate/social-sign-in/discord.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their Discord credentials. To enable this, you’ll need a Discord app and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get your Kinde callback URL**
 
 1. In Kinde, go to **Settings** > **Authentication**.
@@ -28,12 +34,6 @@ You can enable users to sign up and sign in using their Discord credentials. To 
 5. Save your changes.
 
 ## **Add Discord credentials to Kinde**
-
-<Aside type="warning" title="You must use your own app credentials in production">
-
-Before you make your production environment live, add your own app's Client ID and Client secret in the Kinde connection. Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk for your business, and makes it difficult to change auth providers without service disruptions for your users.
-
-</Aside>
 
 1. In Kinde, go to **Settings** > **Authentication**.
 2. On the **Discord** tile, select **Configure**.

--- a/src/content/docs/authenticate/social-sign-in/facebook.mdx
+++ b/src/content/docs/authenticate/social-sign-in/facebook.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their Facebook credentials. To enable this, you’ll need a Facebook app and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Copy the callback URL from Kinde**
 
 1. In Kinde, go to **Settings** > **Authentication**.

--- a/src/content/docs/authenticate/social-sign-in/github.mdx
+++ b/src/content/docs/authenticate/social-sign-in/github.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their GitHub credentials. To enable this, you’ll need some technical know-how and a [GitHub app](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) and credentials.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get the Kinde callback URL**
 
 1. In Kinde, go to **Settings** > **Authentication**.

--- a/src/content/docs/authenticate/social-sign-in/gitlab.mdx
+++ b/src/content/docs/authenticate/social-sign-in/gitlab.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their GitLab credentials. To enable this, you’ll need some technical know-how and a GitLab app and credentials. Here’s some [GitLab docs](https://docs.gitlab.com/ee/integration/oauth_provider.html) that might help.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get the Kinde callback URL**
 
 1. In Kinde, go to **Settings** > **Authentication**.

--- a/src/content/docs/authenticate/social-sign-in/google.mdx
+++ b/src/content/docs/authenticate/social-sign-in/google.mdx
@@ -7,9 +7,15 @@ sidebar:
 
 You can enable users to sign up and sign in using their Google credentials. To set this up, you need a Google cloud account and project, and a little technical know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 Note that Google has provided a topic about [Google’s Create authorization credentials](https://developers.google.com/identity/sign-in/web/sign-in#create_authorization_credentials), but the steps don’t quite work. Until they update their docs, we recommend you use ours.
 
-<Aside type="warning" title="Google does not allow sign in auth to work in webview">
+<Aside title="Google does not allow sign in auth to work in webview">
 
 Before connecting Google as a sign in option, be aware that Google does not support auth in webview. This means if a user opens a sign in window to your app in a webview (say via Instagram or from Facebook) they will receive an error.
 

--- a/src/content/docs/authenticate/social-sign-in/linkedin.mdx
+++ b/src/content/docs/authenticate/social-sign-in/linkedin.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their LinkedIn credentials. To enable this, you’ll need a LinkedIn app and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get the Kinde Callback URL**
 
 1. Sign in to Kinde.

--- a/src/content/docs/authenticate/social-sign-in/microsoft-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/microsoft-sso.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their Microsoft credentials. To enable this, you’ll need a Microsoft Azure account and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get the Kinde Callback URL**
 
 1. Sign in to Kinde.

--- a/src/content/docs/authenticate/social-sign-in/roblox-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/roblox-sso.mdx
@@ -11,6 +11,12 @@ relatedArticles:
 
 You can enable users to sign up and sign in using their Roblox credentials. To enable this, you’ll need some technical know-how and a Roblox app.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## Get your Kinde callback URL
 
 1. In Kinde, go to **Settings** > **Authentication**.

--- a/src/content/docs/authenticate/social-sign-in/slack.mdx
+++ b/src/content/docs/authenticate/social-sign-in/slack.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their Slack credentials. To enable this, you’ll need some technical know-how and a Slack app.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Copy the callback URL from Kinde**
 
 1. In Kinde, go to **Settings** > **Authentication**.

--- a/src/content/docs/authenticate/social-sign-in/twitch.mdx
+++ b/src/content/docs/authenticate/social-sign-in/twitch.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their Twitch credentials. To enable this, you’ll need a Twitch account and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Before you begin**
 
 **Enable Twitch 2FA** — Sign up for a Twitch account and [enable two-factor authentication](https://help.twitch.tv/s/article/two-factor-authentication?language=en_US) (2FA). You will need your mobile number and an authenticator app e.g. Google authenticator, to do this.

--- a/src/content/docs/authenticate/social-sign-in/twitter.mdx
+++ b/src/content/docs/authenticate/social-sign-in/twitter.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 You can enable users to sign up and sign in using their X credentials. To enable this, you’ll need an X developer platform account and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 <Aside>
 
 You may notice X still has mixed URLs and messaging for the name change from Twitter on their own site. We refer to X in this document.

--- a/src/content/docs/authenticate/social-sign-in/xero-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/xero-sso.mdx
@@ -11,6 +11,12 @@ relatedArticles:
 
 You can enable users to sign up and sign in using their Xero credentials. To enable this, you’ll need a Xero app and some developer know-how.
 
+<Aside type="warning" title="Social sign in for production environments">
+
+Before you make your production environment live, you must add your own social app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
 ## **Get your Kinde callback URL**
 
 1. In Kinde, go to **Settings** > **Authentication**.


### PR DESCRIPTION
Add a note to ALL social sign in setup docs to reference the requirement for third party keys for SSO in prod environments. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced new warning sections in social sign-in guides emphasizing the need for users to configure their own app credentials (Client ID and Client Secret) before going live.
  - Enhanced clarity on the risks associated with using default credentials, highlighting potential security, performance, and service issues.
  - Removed previous warnings to streamline guidance and avoid redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->