### PR TITLE
Feat/gate email sender per org

### DIFF
--- a/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
+++ b/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
@@ -22,6 +22,7 @@ When you enable advanced organizations features, you can access extended feature
 - Set up [authentication methods per org](/authenticate/manage-authentication/organization-auth-experience/)
 - Additional access control via [policies](/build/organizations/organization-access-policies/)
 - Select [default roles](/manage-users/roles-and-permissions/default-user-roles/#enable-default-roles-in-an-organization) for users who join an organization
+- Set [custom email sender details](/build/organizations/email-sender-organization/), so users in specific orgs receive OTP and other emails from the custom address (requires own SMTP)
 - Organization-level [custom domains](/build/domains/organization-custom-domain/)
 - Organization-level [multi-factor authentication](/authenticate/multi-factor-auth/mfa-per-org/)
 

--- a/src/content/docs/build/organizations/email-sender-organization.mdx
+++ b/src/content/docs/build/organizations/email-sender-organization.mdx
@@ -9,6 +9,12 @@ relatedArticles:
   - 90134c89-16e4-4981-b988-b0cb4f1722c5
 ---
 
+<Aside type="upgrade">
+
+This is an advanced feature that is only available on the [Kinde Scale plan](https://kinde.com/pricing/)
+
+</Aside>
+
 If you want, you can set a unique email address and sender name for each organization you have. Users in the organization will receive emails from the email address and sender name you set, for example one-time passcode emails.
 
 You can change the customer sender name any time, but you must have a [custom email sender](/get-started/connect/customize-email-sender/) set up to change the email sender address. 


### PR DESCRIPTION
Added upgrade banner to custom email sender per org topic
Added custom email to advanced org topic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced advanced organization authentication by introducing the option to configure a custom email sender address. Organizations can now use a dedicated SMTP server to send OTPs and other emails.
- **Documentation**
	- Updated documentation now clarifies that this customizable email feature is available exclusively on the premium Kinde Scale plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->