### PR TITLE
fix/default org sign up switch

### DIFF
--- a/src/content/docs/build/organizations/allow-user-signup-org.mdx
+++ b/src/content/docs/build/organizations/allow-user-signup-org.mdx
@@ -53,7 +53,7 @@ Users must belong to an organization to be assigned roles and permissions
 </Aside>
 
 1. Go to **Organizations** and open the default organization.
-2. Scroll down and switch off the **Sign users up to the default organization if one can’t be detected** option.
+2. Go to **Policies**, then switch off the **Sign users up to the default organization if one can’t be detected** option.
 3. Select **Save**.
 
 ## Disable user self-sign up


### PR DESCRIPTION
Minor fix to instruction nav


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the guidance for disabling the automatic sign-up feature by directing users to the "Policies" section instead of instructing them to scroll down.
  - These changes provide clearer navigation and improved user experience when configuring account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->