### PR TITLE
React SDK - migration and version reference moved to top

### DIFF
--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -14,9 +14,9 @@ The Kinde React SDK allows developers to quickly and securely integrate a new or
 
 You can also view the [React package](https://github.com/kinde-oss/kinde-auth-react) and [React starter kit](https://github.com/kinde-starter-kits/react-starter-kit) in GitHub.
 
-This SDK is optimized for React version 18+, and is designed to use with version 5 of the Kinde React package.
+This new SDK (v5) is optmized to work with React version 18+.
 
-If you are currently using version 4, refer to this [migration information](/developer-tools/sdks/frontend/react-sdk/#migration-from-v4-to-v5) to update to v5.
+If you are currently using v4, refer to this [migration information](/developer-tools/sdks/frontend/react-sdk/#migration-from-v4-to-v5) to update to v5.
 
 ## **Register for Kinde**
 

--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -12,9 +12,11 @@ head:
 
 The Kinde React SDK allows developers to quickly and securely integrate a new or an existing React application to the Kinde platform.
 
-You can also view the [React docs](https://github.com/kinde-oss/kinde-auth-react) and [React starter kit](https://github.com/kinde-starter-kits/react-starter-kit) in GitHub.
+You can also view the [React package](https://github.com/kinde-oss/kinde-auth-react) and [React starter kit](https://github.com/kinde-starter-kits/react-starter-kit) in GitHub.
 
-This SDK is optimized for React version 18+.
+This SDK is optimized for React version 18+, and is designed to use with version 5 of the Kinde React package.
+
+If you are currently using version 4, refer to this [migration information](/developer-tools/sdks/frontend/react-sdk/#migration-from-v4-to-v5) to update to v5.
 
 ## **Register for Kinde**
 


### PR DESCRIPTION
Clarify that v4 users of react need to be aware of some changes if they are migrating to v5. Add reference to top of page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Kinde React SDK documentation to clarify that the references are specifically to the React package.
  - Specified that the SDK is designed for version 5 and included a migration guide to support users transitioning from version 4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->