### PR TITLE
emphasis on saving before switching

### DIFF
--- a/src/content/docs/design/content-customization/update-auth-page-content.mdx
+++ b/src/content/docs/design/content-customization/update-auth-page-content.mdx
@@ -1,6 +1,6 @@
 ---
 page_id: a643d22e-c26c-4c14-9b95-76aea37352ef
-title: Update page content in the auth flow
+title: Update page content
 sidebar:
   order: 2
 relatedArticles:
@@ -16,10 +16,16 @@ This lets you update the copy on most screens, which you can do via the **Page c
 
 ### Update page content
 
-If your application is built for [multiple languages](https://docs.kinde.com/design/pages/internationalization), select these first in Kinde. 
+If your application is built for [multiple languages](https://docs.kinde.com/design/pages/set-language-for-pages/), select these first in Kinde. 
+
+<Aside type="warning">
+
+Make sure you hit save each time you finish updating a language or page. If you switch between without saving, you may lose changes. 
+
+</Aside>
 
 1. In Kinde, go to **Design > Page content**.
-2. Select the language you want (only applicable if multiple languages are configured).
+2. Select the language you want (only applicable if multiple languages are configured). 
 3. Select the page you want to edit. The list of content shown corresponds with page elements such as headings, field labels, helper text, error messages, etc.
 4. Make the changes to the content. If you want, you can use text variables, explained below.
 5. When you’ve finished, select **Save**. The save only applies to the current language and page selected. You need to select **Save** again if you edit in different languages.


### PR DESCRIPTION
Added note about saving before switching pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Shortened the document title for clarity.
  - Updated the language guidance link to the correct reference.
  - Added a warning note advising users to save changes to prevent potential data loss when switching languages.
  - Made a minor formatting adjustment for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->