### PR TITLE
Fix/auth gating org

### DIFF
--- a/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
+++ b/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
@@ -19,7 +19,7 @@ This topic explains how to create a simple, unified experience for both groups.
 
 ## You’ll need the Kinde Scale plan
 
-To set up authentication for a mixed B2B and B2C business, you need to be on the [Kinde Scale plan](https://kinde.com/pricing/). This is the only Kinde plan that gives you access to the features you need:
+To set up authentication for a mixed B2B and B2C business that includes multiple enterprise connections, you need to be on the [Kinde Scale plan](https://kinde.com/pricing/). This is the only Kinde plan that gives you access to the features you need:
 
 - Multiple enterprise connections (e.g. SAML)
 - Advanced organizations - for managing users and access for business customers

--- a/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
+++ b/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
@@ -19,7 +19,6 @@ Only businesses on the [Kinde Scale plan](https://kinde.com/pricing/) can enable
 
 When you enable advanced organizations features, you can access extended features for individual organizations. Customizations include:
 
-- Set up [authentication methods per org](/authenticate/manage-authentication/organization-auth-experience/)
 - Additional access control via [policies](/build/organizations/organization-access-policies/)
 - Select [default roles](/manage-users/roles-and-permissions/default-user-roles/#enable-default-roles-in-an-organization) for users who join an organization
 - Set [custom email sender details](/build/organizations/email-sender-organization/), so users in specific orgs receive OTP and other emails from the custom address (requires own SMTP)

--- a/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
@@ -12,7 +12,7 @@ relatedArticles:
 
 <Aside type="upgrade">
 
-You need to be on a [Scale plan](https://kinde.com/pricing/) to get authentication control at the organization level.
+For multiple enterprise connections and other advanced organization features, you may need to [upgrade your plan](https://kinde.com/pricing/)
 
 </Aside>
 

--- a/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
+++ b/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
@@ -11,7 +11,7 @@ relatedArticles:
 
 <Aside type="upgrade">
 
-This is an advanced feature that is only available on the [Kinde Scale plan](https://kinde.com/pricing/). Charges also apply for each organization that uses advanced org features.
+Depending what auth you set up in an organization, you may need to [upgrade your Kinde plan](https://kinde.com/pricing/), for example, for enterprise connections. Charges also apply for each organization that uses advanced org features.
 
 </Aside>
 

--- a/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
+++ b/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
@@ -11,7 +11,7 @@ relatedArticles:
 
 <Aside type="upgrade">
 
-Depending what auth you set up in an organization, you may need to [upgrade your Kinde plan](https://kinde.com/pricing/), for example, for enterprise connections. Charges also apply for each organization that uses advanced org features.
+Depending what auth you set up in an organization, you may need to [upgrade your Kinde plan](https://kinde.com/pricing/), for example, for enterprise connections. Charges also apply for each organization that uses [advanced org features](/authenticate/custom-configurations/advanced-organization/).
 
 </Aside>
 


### PR DESCRIPTION
Fixes to clarify auth per org is on all plans, but enterprise and advanced org features are scale only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified authentication setup requirements for mixed B2B/B2C scenarios to emphasize cases with multiple enterprise connections.
	- Updated advanced organization guides by removing references to per-organization authentication customization.
	- Refined messaging about plan upgrades, now indicating a broader need for an upgrade when using advanced organization features.
	- Adjusted organization authentication instructions to conditionally recommend an upgrade based on specific authentication setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->