### PR TITLE
Fix/change acs url refs

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -63,7 +63,7 @@ You can make a connection available only to a specific organization, or you can 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
 11. Copy the reply relevant URL: 
-    1. If you don't use a custom domain, copy the **Assertion customer service (ACS) URL**.
+    1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.
 12. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -62,7 +62,7 @@ You can make a connection available only to a specific organization, or you can 
 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
-11. Copy the reply relevant URL: 
+11. Copy the relevant reply URL: 
     1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -61,7 +61,7 @@ You can make a connection available only to a specific organization, or you can 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
 11. Copy the reply relevant URL: 
-    1. If you don't use a custom domain, copy the **Assertion customer service (ACS) URL**.
+    1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.
 12. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -60,7 +60,7 @@ You can make a connection available only to a specific organization, or you can 
 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
-11. Copy the reply relevant URL: 
+11. Copy the relevant reply URL: 
     1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -82,7 +82,7 @@ Depending on your SAML set up, you may need to include advanced configurations f
 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
-12. Copy the reply relevant URL: 
+12. Copy the relevant reply URL: 
     1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -83,7 +83,7 @@ Depending on your SAML set up, you may need to include advanced configurations f
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
 12. Copy the reply relevant URL: 
-    1. If you don't use a custom domain, copy the **Assertion customer service (ACS) URL**.
+    1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.
 13. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -78,7 +78,7 @@ You can make a connection available only to a specific organization, or you can 
 
 10. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option. 
 11. Copy the reply relevant URL: 
-    1. If you don't use a custom domain, copy the **Assertion customer service (ACS) URL**.
+    1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.
 

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -77,7 +77,7 @@ You can make a connection available only to a specific organization, or you can 
    ![SAML configuration screen](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/dbdccca5-2e6c-4dd8-eaec-e029574daf00/public)
 
 10. If you use home realm domains, the sign in button is hidden on the auth screen by default. To show the SSO button, select the **Always show sign-in button** option. 
-11. Copy the reply relevant URL: 
+11. Copy the relevant reply URL: 
     1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -60,8 +60,8 @@ Depending on your SAML set up, you may need to include advanced configurations f
 
     ![ACS URL and custom domain option](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/885eda9c-ca4f-4340-db17-224023b8c300/public)
 
-11. Copy the reply relevant URL: 
-    1. If you don't use a custom domain, copy the **Assertion customer service (ACS) URL**.
+11. Copy the relevant reply URL: 
+    1. If you don't use a custom domain, copy the **ACS URL**.
     2. If you do use a custom domain, select the **Use custom domain instead** option and copy the custom domain URL. 
     Later, add this URL to your identity provider configuration.
 12. If you want to enable just-in-time (JIT) provisioning for users, select the **Create a user record in Kinde** option. This saves time adding users manually or via API later.


### PR DESCRIPTION
fix minor issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and consistency in SAML connection setup instructions by updating terminology from "Assertion customer service (ACS) URL" to "ACS URL" and refining related instructional text across multiple guides. No procedural changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->