### PR TITLE
Update marketing-tags-properties.mdx

### DIFF
--- a/src/content/docs/properties/work-with-properties/marketing-tags-properties.mdx
+++ b/src/content/docs/properties/work-with-properties/marketing-tags-properties.mdx
@@ -78,7 +78,7 @@ For example in the React SDK:
   properties={{
     utm_source: "my source",
     utm_medium: "some medium",
-    utm_campaign: "awesome campaing",
+    utm_campaign: "awesome campaign",
     utm_content: "something else",
     utm_term: "my terms",
     click_id: "1234"

--- a/src/content/docs/properties/work-with-properties/marketing-tags-properties.mdx
+++ b/src/content/docs/properties/work-with-properties/marketing-tags-properties.mdx
@@ -75,14 +75,14 @@ For example in the React SDK:
 ```jsx
 <RegisterLink
   className="btn btn-dark"
-  authUrlParams={{
+  properties={{
     utm_source: "my source",
-   utm_medium: "some medium",
-   utm_campaign: "awesome campaing",
-   utm_content: "something else",
-   utm_term: "my terms",
-   click_id: "1234",
-}}
+    utm_medium: "some medium",
+    utm_campaign: "awesome campaing",
+    utm_content: "something else",
+    utm_term: "my terms",
+    click_id: "1234"
+  }}
 >Register</RegisterLink>
 ```
 


### PR DESCRIPTION
#### Description (required)

This updates to the use the `properties` property of the Register component instead of the `authUrlParams` which does not exist in latest version of the SDK

Blocked by: https://github.com/kinde-oss/js-utils/pull/112

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated example code to use the `properties` prop instead of `authUrlParams` when passing marketing tag properties in the React SDK.
  - Corrected a typo in the marketing tag example for the `utm_campaign` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->