### PR TITLE
Remove references to a missing appendix in the privacy policy

### DIFF
--- a/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
@@ -173,11 +173,11 @@ Our website may contain links to other party’s websites. We do not have any co
 
 ## Additional rights and information for individuals located in the EU or UK
 
-Under the GDPR individuals located in the EU and the UK have extra rights which apply to their personal information. Personal information under the GDPR is often referred to as personal data and is defined as information relating to an identified or identifiable natural person (individual). This 'Additional rights and information for individual located in the EU or UK' section sets out the additional rights we give to individuals located in the EU and UK, as well as information on how we process the personal information of individuals located in the EU and UK. Please read the Privacy Policy above and this 'Additional rights and information for individual located in the EU or UK' section carefully and contact us at the details at the end of the Privacy Policy if you have any questions.
+Under the GDPR individuals located in the EU and the UK have extra rights which apply to their personal information. Personal information under the GDPR is often referred to as personal data and is defined as information relating to an identified or identifiable natural person (individual). This "Additional rights and information for individual located in the EU or UK" section sets out the additional rights we give to individuals located in the EU and UK, as well as information on how we process the personal information of individuals located in the EU and UK. Please read the Privacy Policy above and this "Additional rights and information for individual located in the EU or UK" section carefully and contact us at the details at the end of the Privacy Policy if you have any questions.
 
 ## What personal information is relevant?
 
-This 'Additional rights and information for individual located in the EU or UK' section applies to the personal information set out in the Privacy Policy above. This includes any Sensitive Information also listed in the Privacy Policy above which is known as ‘special categories of data’ under the GDPR.
+This "Additional rights and information for individual located in the EU or UK" section applies to the personal information set out in the Privacy Policy above. This includes any Sensitive Information also listed in the Privacy Policy above which is known as ‘special categories of data’ under the GDPR.
 
 ## Purposes and legal bases for processing
 
@@ -200,7 +200,7 @@ If you have consented to our use of data about you for a specific purpose, you h
 
 ## Data Transfers
 
-The countries to which we send data for the purposes listed above may be less comprehensive that is what is offered in the country in which you initially provided the information. Where we transfer your personal information outside of the country where you are based, we will perform those transfers using appropriate safeguards in accordance with the requirements of applicable data protection laws and we will protect the transferred personal information in accordance with this Privacy Policy and this 'Additional rights and information for individual located in the EU or UK' section. This includes:
+The countries to which we send data for the purposes listed above may be less comprehensive that is what is offered in the country in which you initially provided the information. Where we transfer your personal information outside of the country where you are based, we will perform those transfers using appropriate safeguards in accordance with the requirements of applicable data protection laws and we will protect the transferred personal information in accordance with this Privacy Policy and this "Additional rights and information for individual located in the EU or UK" section. This includes:
 
 - only transferring your personal information to countries that have been deemed by applicable data protection laws to provide an adequate level of protection for personal information
 - standard contractual clauses in our agreements with third parties that are overseas.

--- a/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
@@ -171,13 +171,13 @@ Some of our websites, applications and electronic communications contain electro
 
 Our website may contain links to other party’s websites. We do not have any control over those websites and we are not responsible for the protection and privacy of any personal information which you provide whilst visiting those websites. Those websites are not governed by this Privacy Policy.
 
-## Additional rights and information for individual located in the EU or UK
+## Additional rights and information for individuals located in the EU or UK
 
-Under the GDPR individuals located in the EU and the UK have extra rights which apply to their personal information. Personal information under the GDPR is often referred to as personal data and is defined as information relating to an identified or identifiable natural person (individual). This Appendix 1 sets out the additional rights we give to individuals located in the EU and UK, as well as information on how we process the personal information of individuals located in the EU and UK. Please read the Privacy Policy above and this Appendix carefully and contact us at the details at the end of the Privacy Policy if you have any questions.
+Under the GDPR individuals located in the EU and the UK have extra rights which apply to their personal information. Personal information under the GDPR is often referred to as personal data and is defined as information relating to an identified or identifiable natural person (individual). This 'Additional rights and information for individual located in the EU or UK' section sets out the additional rights we give to individuals located in the EU and UK, as well as information on how we process the personal information of individuals located in the EU and UK. Please read the Privacy Policy above and this 'Additional rights and information for individual located in the EU or UK' section carefully and contact us at the details at the end of the Privacy Policy if you have any questions.
 
 ## What personal information is relevant?
 
-This Appendix applies to the personal information set out in the Privacy Policy above. This includes any Sensitive Information also listed in the Privacy Policy above which is known as ‘special categories of data’ under the GDPR.
+This 'Additional rights and information for individual located in the EU or UK' section applies to the personal information set out in the Privacy Policy above. This includes any Sensitive Information also listed in the Privacy Policy above which is known as ‘special categories of data’ under the GDPR.
 
 ## Purposes and legal bases for processing
 
@@ -200,7 +200,7 @@ If you have consented to our use of data about you for a specific purpose, you h
 
 ## Data Transfers
 
-The countries to which we send data for the purposes listed above may be less comprehensive that is what is offered in the country in which you initially provided the information. Where we transfer your personal information outside of the country where you are based, we will perform those transfers using appropriate safeguards in accordance with the requirements of applicable data protection laws and we will protect the transferred personal information in accordance with this Privacy Policy and Appendix 1. This includes:
+The countries to which we send data for the purposes listed above may be less comprehensive that is what is offered in the country in which you initially provided the information. Where we transfer your personal information outside of the country where you are based, we will perform those transfers using appropriate safeguards in accordance with the requirements of applicable data protection laws and we will protect the transferred personal information in accordance with this Privacy Policy and this 'Additional rights and information for individual located in the EU or UK' section. This includes:
 
 - only transferring your personal information to countries that have been deemed by applicable data protection laws to provide an adequate level of protection for personal information
 - standard contractual clauses in our agreements with third parties that are overseas.
@@ -248,6 +248,6 @@ We may, at any time and at our discretion, vary this Privacy Policy by publishin
 
 For any questions or notices, please contact us at privacy@kinde.com.
 
-Last updated September 2, 2024.
+Last updated May 7, 2025.
 
 Kinde Australia Pty Ltd ([ABN 11 655 096 263](https://abr.business.gov.au/ABN/View?abn=11655096263))


### PR DESCRIPTION
#### Description 

A small housekeeping change to remove references to the appendix, which doesn't exist anymore in the privacy policy. Replaced with a reference to the existing ‘Additional rights and information for individual located in the EU or UK’ section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the privacy policy to clarify section titles and references, ensuring consistent use of the full section name for EU/UK rights and information.
  - Updated the "Last updated" date to May 7, 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->