### PR TITLE
Add sveltekit cloudflare docs

### DIFF
--- a/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
@@ -1,0 +1,251 @@
+---
+page_id: 4f3a9e2a-12eb-4b4c-8790-48b6e09a224d
+title: "Integrating Kinde Authentication with SvelteKit on Cloudflare Pages"
+description: "A step-by-step guide to implement Kinde authentication in a SvelteKit application deployed to Cloudflare Pages"
+---
+
+
+This guide walks you through implementing Kinde authentication in a SvelteKit application deployed to Cloudflare Pages using KV storage for state management.
+
+## Prerequisites
+
+- A Cloudflare account
+- A Kinde account (register at [kinde.com](https://kinde.com))
+- SvelteKit project ready for Cloudflare Pages deployment
+
+## 1. Set Up a Kinde Application
+
+1. Log in to your Kinde account
+2. Go to **Settings > Applications**
+3. Create a new Sveltekit application
+4. Configure the callback URLs:
+   - Allowed callback URL: `https://your-domain.pages.dev/api/auth/kinde_callback`
+   - Allowed logout redirect URL: `https://your-domain.pages.dev`
+5. Note your Client ID and Client Secret
+
+## 2. Install Required Dependencies
+
+```bash
+npm install @kinde-oss/kinde-auth-sveltekit
+```
+
+## 3. Configure Cloudflare KV Storage
+
+1. Go to **Workers & Pages > KV**
+2. Create a new namespace (e.g., `AUTH_STORAGE`)
+3. Copy the namespace ID
+
+## 4. Set Up Wrangler Configuration
+
+Update your `wrangler.toml`:
+
+```toml
+name = "your-project-name"
+compatibility_date = "2023-06-28"
+compatibility_flags = ["nodejs_compat_v2"]
+pages_build_output_dir = "./svelte-kit/cloudflare"
+
+kv_namespaces = [
+  { binding = "AUTH_STORAGE", id = "your-namespace-id" }
+]
+
+[vars]
+KINDE_ISSUER_URL = "https://your-kinde-domain.kinde.com"
+KINDE_CLIENT_ID = "your-client-id"
+KINDE_CLIENT_SECRET = "your-client-secret"
+KINDE_REDIRECT_URL = "https://your-domain.pages.dev/api/auth/kinde_callback"
+KINDE_POST_LOGOUT_REDIRECT_URL = "https://your-domain.pages.dev"
+KINDE_POST_LOGIN_REDIRECT_URL = "https://your-domain.pages.dev/dashboard"
+KINDE_AUTH_WITH_PKCE = "true"
+```
+
+## 5. Create a KV Storage Adapter
+
+Create `src/lib/kindeCloudflareStorage.ts`:
+
+```typescript
+import type { RequestEvent } from '@sveltejs/kit';
+
+export const createKindeStorage = (event: RequestEvent) => {
+  const platform = event.platform as any;
+  const env = platform?.env;
+  const AUTH_STORAGE = env?.AUTH_STORAGE;
+ 
+  if (!AUTH_STORAGE) {
+	return null;
+  }
+ 
+  return {
+	setState: async (stateId: string, stateData: any) => {
+  	try {
+    	const key = `kinde:state:${stateId}`;
+    	const value = typeof stateData === 'string'
+      	? stateData
+      	: JSON.stringify(stateData);
+   	 
+    	await AUTH_STORAGE.put(key, value, { expirationTtl: 600 });
+    	return true;
+  	} catch (error) {
+    	return false;
+  	}
+	},
+    
+	getState: async (stateId: string) => {
+  	try {
+    	const key = `kinde:state:${stateId}`;
+    	const value = await AUTH_STORAGE.get(key);
+   	 
+    	if (!value) return null;
+   	 
+    	try {
+      	return JSON.parse(value);
+    	} catch {
+      	return value;
+    	}
+  	} catch (error) {
+    	return null;
+  	}
+	},
+    
+	deleteState: async (stateId: string) => {
+  	try {
+    	const key = `kinde:state:${stateId}`;
+    	await AUTH_STORAGE.delete(key);
+    	return true;
+  	} catch (error) {
+    	return false;
+  	}
+	}
+  };
+};
+```
+
+## 6. Set Up SvelteKit Hooks
+
+Update `src/hooks.server.ts`:
+
+```typescript
+import { sessionHooks, type Handler } from '@kinde-oss/kinde-auth-sveltekit';
+import { createKindeStorage } from '$lib/kindeCloudflareStorage';
+
+export const handle: Handler = async ({ event, resolve }) => {
+  const storage = createKindeStorage(event);
+ 
+  sessionHooks({
+	event,
+	...(storage ? { storage } : {})
+  });
+ 
+  return await resolve(event);
+};
+```
+
+## 7. Implement Authentication Routes
+
+Create `src/routes/api/auth/[...kindeAuth]/+server.ts`:
+
+```typescript
+import { json, redirect } from '@sveltejs/kit';
+import type { RequestEvent } from "@sveltejs/kit";
+import { createKindeStorage } from '$lib/kindeCloudflareStorage';
+
+export async function GET(event: RequestEvent) {
+  // Get environment variables from platform
+  const platform = event.platform as any;
+  const env = platform?.env;
+  
+  // Simplified config access
+  const config = {
+    issuerUrl: env?.KINDE_ISSUER_URL || process.env.KINDE_ISSUER_URL,
+    clientId: env?.KINDE_CLIENT_ID || process.env.KINDE_CLIENT_ID,
+    clientSecret: env?.KINDE_CLIENT_SECRET || process.env.KINDE_CLIENT_SECRET,
+    redirectUrl: env?.KINDE_REDIRECT_URL || process.env.KINDE_REDIRECT_URL,
+    postLoginUrl: env?.KINDE_POST_LOGIN_REDIRECT_URL || process.env.KINDE_POST_LOGIN_REDIRECT_URL,
+    postLogoutUrl: env?.KINDE_POST_LOGOUT_REDIRECT_URL || process.env.KINDE_POST_LOGOUT_REDIRECT_URL,
+    scope: 'openid profile email offline',
+    usePkce: (env?.KINDE_AUTH_WITH_PKCE || process.env.KINDE_AUTH_WITH_PKCE) === 'true'
+  };
+  
+  const storage = createKindeStorage(event);
+  const path = new URL(event.request.url).pathname.split('/').pop() || '';
+  
+  if (!storage) {
+    return json({ error: 'KV storage not available' }, { status: 500 });
+  }
+  
+  // Handle authentication routes
+  switch (path) {
+    case 'login':
+      return handleLogin(config.issuerUrl, config.clientId, config.redirectUrl, 
+                        config.scope, config.postLoginUrl, config.usePkce, 
+                        event, storage, false);
+    case 'register':
+      return handleLogin(config.issuerUrl, config.clientId, config.redirectUrl, 
+                        config.scope, config.postLoginUrl, config.usePkce, 
+                        event, storage, true);
+    case 'kinde_callback':
+      return handleCallback(config.issuerUrl, config.clientId, config.clientSecret, 
+                          config.redirectUrl, config.usePkce, event, storage);
+    case 'logout':
+      return handleLogout(config.issuerUrl, config.clientId, config.postLogoutUrl, 
+                         event, storage);
+    default:
+      return json({ error: 'Unknown auth endpoint' }, { status: 404 });
+  }
+}
+
+// Include implementations of handleLogin, handleCallback, and handleLogout functions
+```
+## 8. Check Authentication Status
+
+Create `src/routes/+layout.server.ts`:
+
+```typescript
+import type { LayoutServerLoad } from './$types';
+import { createKindeStorage } from '$lib/kindeCloudflareStorage';
+
+export const load: LayoutServerLoad = async (event) => {
+  const storage = createKindeStorage(event);
+ 
+  if (!storage) {
+	return { authenticated: false };
+  }
+ 
+  try {
+	const tokens = await storage.getState('tokens');
+	return { authenticated: !!tokens?.access_token };
+  } catch (error) {
+	return { authenticated: false };
+  }
+};
+```
+
+## 9. Protect Routes
+
+For protected routes like a dashboard:
+
+```typescript
+// src/routes/dashboard/+page.server.ts
+import type { PageServerLoad } from './$types';
+import { createKindeStorage } from '$lib/kindeCloudflareStorage';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async (event) => {
+  const storage = createKindeStorage(event);
+ 
+  if (!storage) {
+	throw redirect(302, '/login');
+  }
+ 
+  const tokens = await storage.getState('tokens');
+ 
+  if (!tokens?.access_token) {
+	throw redirect(302, '/login');
+  }
+ 
+  return { authenticated: true };
+};
+```
+
+Your Kinde authentication is now working with SvelteKit on Cloudflare Pages!
+

--- a/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
@@ -7,6 +7,9 @@ description: "A step-by-step guide to implement Kinde authentication in a Svelte
 
 This guide walks you through implementing Kinde authentication in a SvelteKit application deployed to Cloudflare Pages using KV storage for state management.
 
+
+> **Note**: This implementation is more complex than ideal due to the unique constraints of Cloudflare's serverless environment. The most challenging aspect is handling environment variables, which work differently on Cloudflare Pages than in standard SvelteKit deployments. We're actively exploring more elegant solutions, but this guide provides a robust working implementation for your immediate needs.
+
 ## Prerequisites
 
 - A Cloudflare account
@@ -27,6 +30,7 @@ This guide walks you through implementing Kinde authentication in a SvelteKit ap
 
 ```bash
 npm install @kinde-oss/kinde-auth-sveltekit
+npm install -D @sveltejs/adapter-cloudflare
 ```
 
 ## 3. Configure Cloudflare KV Storage
@@ -57,6 +61,7 @@ KINDE_REDIRECT_URL = "https://your-domain.pages.dev/api/auth/kinde_callback"
 KINDE_POST_LOGOUT_REDIRECT_URL = "https://your-domain.pages.dev"
 KINDE_POST_LOGIN_REDIRECT_URL = "https://your-domain.pages.dev/dashboard"
 KINDE_AUTH_WITH_PKCE = "true"
+KINDE_SCOPE = 'openid profile email offline'
 ```
 
 ## 5. Create a KV Storage Adapter
@@ -148,53 +153,320 @@ Create `src/routes/api/auth/[...kindeAuth]/+server.ts`:
 import { json, redirect } from '@sveltejs/kit';
 import type { RequestEvent } from "@sveltejs/kit";
 import { createKindeStorage } from '$lib/kindeCloudflareStorage';
+import { KINDE_ISSUER_URL, KINDE_CLIENT_ID, KINDE_CLIENT_SECRET, KINDE_REDIRECT_URL, KINDE_POST_LOGIN_REDIRECT_URL, KINDE_POST_LOGOUT_REDIRECT_URL, KINDE_AUTH_WITH_PKCE } from '$env/static/private';
+
+// Get environment variables
+const SECRET = KINDE_CLIENT_SECRET;
+const ISSUER_URL = KINDE_ISSUER_URL;
+const CLIENT_ID = KINDE_CLIENT_ID;
+const REDIRECT_URL = KINDE_REDIRECT_URL;
+const POST_LOGIN_REDIRECT_URL = KINDE_POST_LOGIN_REDIRECT_URL;
+const POST_LOGOUT_REDIRECT_URL = KINDE_POST_LOGOUT_REDIRECT_URL;
+const SCOPE = 'openid profile email offline'
+const USE_PKCE = KINDE_AUTH_WITH_PKCE === 'true';
 
 export async function GET(event: RequestEvent) {
-  // Get environment variables from platform
-  const platform = event.platform as any;
-  const env = platform?.env;
-  
-  // Simplified config access
-  const config = {
-    issuerUrl: env?.KINDE_ISSUER_URL || process.env.KINDE_ISSUER_URL,
-    clientId: env?.KINDE_CLIENT_ID || process.env.KINDE_CLIENT_ID,
-    clientSecret: env?.KINDE_CLIENT_SECRET || process.env.KINDE_CLIENT_SECRET,
-    redirectUrl: env?.KINDE_REDIRECT_URL || process.env.KINDE_REDIRECT_URL,
-    postLoginUrl: env?.KINDE_POST_LOGIN_REDIRECT_URL || process.env.KINDE_POST_LOGIN_REDIRECT_URL,
-    postLogoutUrl: env?.KINDE_POST_LOGOUT_REDIRECT_URL || process.env.KINDE_POST_LOGOUT_REDIRECT_URL,
-    scope: 'openid profile email offline',
-    usePkce: (env?.KINDE_AUTH_WITH_PKCE || process.env.KINDE_AUTH_WITH_PKCE) === 'true'
-  };
-  
   const storage = createKindeStorage(event);
-  const path = new URL(event.request.url).pathname.split('/').pop() || '';
+  const url = new URL(event.request.url);
+  const path = url.pathname.split('/').pop() || '';
+  
+  console.log(`Auth request: ${path}`, {
+    hasStorage: !!storage,
+    hasState: !!url.searchParams.get('state'),
+    hasCode: !!url.searchParams.get('code')
+  });
   
   if (!storage) {
+    console.error('KV storage not available');
     return json({ error: 'KV storage not available' }, { status: 500 });
   }
   
-  // Handle authentication routes
+  // Handle various auth endpoints
   switch (path) {
     case 'login':
-      return handleLogin(config.issuerUrl, config.clientId, config.redirectUrl, 
-                        config.scope, config.postLoginUrl, config.usePkce, 
-                        event, storage, false);
+      return handleLogin(event, storage, false);
+    
     case 'register':
-      return handleLogin(config.issuerUrl, config.clientId, config.redirectUrl, 
-                        config.scope, config.postLoginUrl, config.usePkce, 
-                        event, storage, true);
+      return handleLogin(event, storage, true);
+    
     case 'kinde_callback':
-      return handleCallback(config.issuerUrl, config.clientId, config.clientSecret, 
-                          config.redirectUrl, config.usePkce, event, storage);
+      return handleCallback(event, storage);
+    
     case 'logout':
-      return handleLogout(config.issuerUrl, config.clientId, config.postLogoutUrl, 
-                         event, storage);
+      return handleLogout(event, storage);
+    
     default:
       return json({ error: 'Unknown auth endpoint' }, { status: 404 });
   }
 }
 
-// Include implementations of handleLogin, handleCallback, and handleLogout functions
+// Generate crypto-secure random string for state
+function generateRandomString(length = 32) {
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let text = '';
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
+// Add this at the top of your file
+async function sha256(plain: string): Promise<ArrayBuffer> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  return await crypto.subtle.digest('SHA-256', data);
+}
+
+function base64URLEncode(buffer: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// Handle login or registration
+async function handleLogin(event: RequestEvent, storage: any, isRegister: boolean) {
+  // Generate state parameter
+  const state = generateRandomString(24);
+  console.log(KINDE_CLIENT_ID, KINDE_CLIENT_SECRET, KINDE_ISSUER_URL, KINDE_REDIRECT_URL, KINDE_POST_LOGIN_REDIRECT_URL, KINDE_POST_LOGOUT_REDIRECT_URL, KINDE_AUTH_WITH_PKCE, SCOPE)
+  // For PKCE, generate code challenge
+  let codeVerifier: string | undefined;
+  let codeChallenge: string | undefined;
+  
+  if (USE_PKCE) {
+    codeVerifier = generateRandomString(64);
+    
+    // Create proper code challenge with SHA-256
+    const challengeBuffer = await sha256(codeVerifier);
+    codeChallenge = base64URLEncode(challengeBuffer);
+  }
+  
+  // Store state (and code verifier if using PKCE)
+  await storage.setState(state, codeVerifier || 'true');
+  
+  // Get additional parameters from URL
+  const url = new URL(event.request.url);
+  const orgCode = url.searchParams.get('org_code');
+  const postLoginRedirect = url.searchParams.get('post_login_redirect_url') || POST_LOGIN_REDIRECT_URL;
+  
+  // Build auth URL
+  const authUrl = new URL(isRegister ? '/oauth2/auth/register' : '/oauth2/auth', ISSUER_URL);
+  
+  // Add standard OAuth parameters
+  authUrl.searchParams.append('client_id', CLIENT_ID);
+  authUrl.searchParams.append('redirect_uri', REDIRECT_URL);
+  authUrl.searchParams.append('response_type', 'code');
+  authUrl.searchParams.append('scope', SCOPE);
+  authUrl.searchParams.append('state', state);
+  
+  // Add optional parameters
+  if (orgCode) {
+    authUrl.searchParams.append('org_code', orgCode);
+  }
+  
+  // Store post-login redirect
+  await storage.setState(`redirect:${state}`, postLoginRedirect);
+  
+  // Add PKCE parameters if enabled
+  if (USE_PKCE && codeChallenge) {
+    authUrl.searchParams.append('code_challenge', codeChallenge);
+    authUrl.searchParams.append('code_challenge_method', 'S256');
+  }
+  
+  // Redirect to Kinde auth URL
+  console.log(`Redirecting to Kinde auth: ${authUrl.toString()}`);
+  return redirect(302, authUrl.toString());
+}
+
+// Handle OAuth callback
+async function handleCallback(event: RequestEvent, storage: any) {
+  const url = new URL(event.request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+  
+  // Check for OAuth errors
+  if (error) {
+    console.error('OAuth error:', error);
+    return json({ error: `OAuth error: ${error}` }, { status: 400 });
+  }
+  
+  // Validate required parameters
+  if (!code || !state) {
+    console.error('Missing code or state parameter');
+    return json({ error: 'Missing code or state parameter' }, { status: 400 });
+  }
+  
+  // Verify state parameter
+  const storedState = await storage.getState(state);
+  if (!storedState) {
+    console.error('State not found:', state);
+    
+    // Store error for debugging
+    await storage.setState('last_error', {
+      time: new Date().toISOString(),
+      error: 'State not found',
+      state
+    });
+    
+    return json({ error: 'Invalid state parameter' }, { status: 401 });
+  }
+  
+  // Get code verifier for PKCE if it exists
+  const codeVerifier = storedState === 'true' ? undefined : storedState;
+  
+  // Get post-login redirect URL
+  const redirectUrl = await storage.getState(`redirect:${state}`) || POST_LOGIN_REDIRECT_URL;
+  
+  // Clean up stored state
+  await storage.deleteState(state);
+  await storage.deleteState(`redirect:${state}`);
+  
+  try {
+    // Exchange code for tokens
+    const tokenResponse = await fetchTokens(code, codeVerifier);
+    
+    // Store tokens in KV storage
+    await storage.setState('tokens', {
+      access_token: tokenResponse.access_token,
+      refresh_token: tokenResponse.refresh_token || null,
+      id_token: tokenResponse.id_token || null,
+      expires_in: tokenResponse.expires_in || 3600,
+      timestamp: Date.now()
+    });
+    
+    console.log('Tokens stored successfully');
+    
+    // Log the redirect URL for debugging
+    console.log('Redirecting to:', redirectUrl);
+    
+    // Create a redirect response with proper headers
+    return new Response(null, {
+      status: 302,
+      headers: {
+        'Location': redirectUrl,
+        'Cache-Control': 'no-store'
+      }
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Token exchange error:', errorMessage);
+    
+    // Store error for debugging
+    await storage.setState('token_error', {
+      time: new Date().toISOString(),
+      error: safeStringify(error)
+    });
+    
+    return json({ error: 'Token exchange failed' }, { status: 500 });
+  }
+}
+
+// Exchange authorization code for tokens
+async function fetchTokens(code: string, codeVerifier?: string) {
+  const tokenUrl = new URL('/oauth2/token', ISSUER_URL);
+  const params = new URLSearchParams();
+  
+  params.append('grant_type', 'authorization_code');
+  params.append('code', code);
+  params.append('redirect_uri', REDIRECT_URL);
+  params.append('client_id', CLIENT_ID);
+  
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/json'
+  };
+  
+  // The key fix: Always include client_secret with Kinde, even with PKCE
+  if (USE_PKCE && codeVerifier && codeVerifier !== 'true') {
+    console.log('Using PKCE flow with code verifier');
+    params.append('code_verifier', codeVerifier);
+    
+    // CRITICAL FIX: Kinde requires client_secret even with PKCE flow for server-side apps
+    params.append('client_secret', SECRET);
+  } else {
+    console.log('Using standard authorization code flow with client secret');
+    params.append('client_secret', SECRET);
+  }
+  
+  console.log('Token exchange request:', {
+    url: tokenUrl.toString(),
+    isPKCE: USE_PKCE && codeVerifier && codeVerifier !== 'true',
+    hasClientSecret: true
+  });
+  
+  try {
+    const response = await fetch(tokenUrl.toString(), {
+      method: 'POST',
+      headers,
+      body: params
+    });
+    
+    const responseText = await response.text();
+    console.log('Token response status:', response.status);
+    
+    // Try to parse the response as JSON
+    let responseData;
+    try {
+      responseData = JSON.parse(responseText);
+      console.log('Token response parsed successfully');
+    } catch (parseError) {
+      console.error('Failed to parse token response as JSON:', responseText);
+      throw new Error(`Invalid JSON response: ${responseText}`);
+    }
+    
+    // Check for errors in the response
+    if (!response.ok) {
+      console.error('Token exchange error details:', {
+        status: response.status,
+        error: responseData.error,
+        description: responseData.error_description
+      });
+      
+      throw new Error(`Token exchange failed: ${response.status} - ${responseData.error}: ${responseData.error_description}`);
+    }
+    
+    // Check if the response has the expected tokens
+    if (!responseData.access_token) {
+      console.error('Token response missing access_token:', responseData);
+      throw new Error('Token response missing required fields');
+    }
+    
+    // Log success
+    console.log('Token exchange successful');
+    
+    return responseData;
+  } catch (error) {
+    console.error('Token exchange error:', error instanceof Error ? error.message : 'Unknown error');
+    throw error;
+  }
+}
+
+// Handle logout
+async function handleLogout(event: RequestEvent, storage: any) {
+  // Clear tokens from KV storage
+  await storage.deleteState('tokens');
+  console.log('Tokens deleted during logout');
+  
+  // Redirect to Kinde's logout endpoint
+  const logoutUrl = new URL('/logout', ISSUER_URL);
+  logoutUrl.searchParams.append('redirect', POST_LOGOUT_REDIRECT_URL);
+  
+  return redirect(302, logoutUrl.toString());
+}
+
+// Helper function to safely stringify errors
+function safeStringify(obj: any): string {
+  try {
+    if (obj instanceof Error) {
+      return obj.message + (obj.stack ? `\n${obj.stack}` : '');
+    }
+    
+    return JSON.stringify(obj);
+  } catch (e) {
+    return `[Unstringifiable object: ${typeof obj}]`;
+  }
+} 
 ```
 ## 8. Check Authentication Status
 

--- a/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-sveltekit-with-cloudflare.mdx
@@ -8,7 +8,7 @@ description: "A step-by-step guide to implement Kinde authentication in a Svelte
 This guide walks you through implementing Kinde authentication in a SvelteKit application deployed to Cloudflare Pages using KV storage for state management.
 
 
-> **Note**: This implementation is more complex than ideal due to the unique constraints of Cloudflare's serverless environment. The most challenging aspect is handling environment variables, which work differently on Cloudflare Pages than in standard SvelteKit deployments. We're actively exploring more elegant solutions, but this guide provides a robust working implementation for your immediate needs.
+> Note: This implementation is more complex than ideal due to Cloudflare's serverless environment constraints. We're working on more elegant solutions, but this guide provides a robust working implementation.
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR adds documentation for integrating Kinde authentication with SvelteKit on Cloudflare Pages.


I've created this guide based on my implementation experience, and while it's functional, I recognize that it's more complex than ideal. The current solution requires more code than I'd like, especially in the server handler, due to the unique constraints of Cloudflare's serverless environment and how it interacts with OAuth flows.

I would greatly appreciate feedback on:

1. How to further simplify this implementation while maintaining security and functionality
2. Any Cloudflare-specific best practices I might have missed
3. Opportunities to reduce the code footprint, particularly in the auth handler
4. Alternative approaches that might provide a more elegant solution



I'm very open to suggestions on how to make this guide more concise and maintainable.

