### PR TITLE
feat(expo): update utility import locations for each expo version

### DIFF
--- a/src/content/docs/developer-tools/sdks/native/expo.mdx
+++ b/src/content/docs/developer-tools/sdks/native/expo.mdx
@@ -115,7 +115,10 @@ Note: The `<myapp://localhost:3000>` is used as an example of local URL Scheme, 
 
 ## Token Utilities
 
-All utility functions from `@kinde/js-utils` are available through `@kinde/expo/utils` and also through the `useKindeAuth` hook. This allows you to use these utilities directly in your Expo application.
+A selction of utility functions are available. 
+
+*Expo 53+*: Importable from from `@kinde/expo/utils` and from `useKindeAuth` hook
+*Expo 51 and 52*: Importable from from `@kinde/js-utils` and from `useKindeAuth` hook
 
 ```ts
 import { getUserProfile, getFlag, getRoles } from "@kinde/expo/utils";

--- a/src/content/docs/developer-tools/sdks/native/expo.mdx
+++ b/src/content/docs/developer-tools/sdks/native/expo.mdx
@@ -115,10 +115,10 @@ Note: The `<myapp://localhost:3000>` is used as an example of local URL Scheme, 
 
 ## Token Utilities
 
-A selction of utility functions are available. 
+A selection of utility functions are available. 
 
-*Expo 53+*: Importable from from `@kinde/expo/utils` and from `useKindeAuth` hook
-*Expo 51 and 52*: Importable from from `@kinde/js-utils` and from `useKindeAuth` hook
+*Expo 53+*: Import from `@kinde/expo/utils` and `useKindeAuth` hook
+*Expo 51 and 52*: Import from `@kinde/js-utils` and `useKindeAuth` hook
 
 ```ts
 import { getUserProfile, getFlag, getRoles } from "@kinde/expo/utils";


### PR DESCRIPTION
#### Description (required)

Due to the underlying version of node under earlier version of Expo, different way to import the token helpers is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Clarified which token utility functions are available in the Expo SDK documentation.
	- Updated information about utility function availability based on different Expo SDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->