### PR TITLE
Update astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,7 +49,9 @@ export default defineConfig({
     "/developer-tools/kinde-api/get-access-token-for-connecting-securely-to-kindes-api/":
       "/developer-tools/kinde-api/access-token-for-api/",
     "/developer-tools/kinde-api/test-the-connection-to-kindes-api/":
-      "/developer-tools/kinde-api/troubleshoot-kinde-api/"
+      "/developer-tools/kinde-api/troubleshoot-kinde-api/",
+    "/developer-tools/sdks/native/expo-react-native/": 
+    "/developer-tools/sdks/native/expo/"
   },
   markdown: {
     rehypePlugins: [


### PR DESCRIPTION
Added expo SDK redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated URL redirects to ensure "/developer-tools/sdks/native/expo-react-native/" now points to "/developer-tools/sdks/native/expo/".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->