### PR TITLE
Only apply inkeep modal animation when modal is not full screen

### DIFF
--- a/public/vendors/inkeep.css
+++ b/public/vendors/inkeep.css
@@ -6,9 +6,11 @@
   background: rgba(0,0,0,0.4);
 }
 
-.ikp-modal__content {
-  opacity: 0;
-  animation: showInkeepModal .4s ease forwards !important;
+@media (min-width: 769px) {
+  .ikp-modal__content {
+    opacity: 0;
+    animation: showInkeepModal .4s ease forwards !important;
+  }
 }
 
 @keyframes showInkeepModal {


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Fixes an issue where the modal was being cut off on screen sizes < 769px.
<img width="420" alt="Screenshot 2025-05-19 at 9 25 53 AM" src="https://github.com/user-attachments/assets/45d7da87-998e-4a44-9f4a-de4c9a4092a0" />

I have made a change to only apply the transform animation when the screen is > 768px. The modal will now look like this on smaller screen widths:
<img width="419" alt="Screenshot 2025-05-19 at 9 25 34 AM" src="https://github.com/user-attachments/assets/8a8b1182-9438-4b4f-88c1-e0e3a77ca191" />



#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated modal appearance so that certain styles and animations are only applied on screens wider than 768 pixels, improving responsiveness for smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->