### PR TITLE
Add banner to point to custom UI

### DIFF
--- a/src/content/docs/authenticate/custom-configurations/custom-authentication-pages.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-authentication-pages.mdx
@@ -10,9 +10,15 @@ relatedArticles:
   - 8b9376c4-308c-4eaa-a990-606fb8bbf770
 ---
 
-You can bring your own custom sign up and sign in pages to use with Kinde. Integrate your own designs for the initial sign up and sign in page, and still get the security of Kinde’s auth (and verification) process.
+You can host your own custom sign up and sign in pages to use with Kinde. Integrate your own designs for the initial sign up and sign in page, and still get the security of Kinde’s auth (and verification) process.
 
-This gives you the best of both worlds: the security of hosted auth, and the ability to customize the sign-up experience for your users.
+This gives you the best of both worlds: the security of hosted auth, and the ability to customize the initial sign-up experience for your users.
+
+<Aside title="Customizing the entire authentication experience">
+
+Bring your own HTML / CSS and JavaScript to our hosted pages [with Kinde's custom UI feature](/design/customize-with-code/customize-with-css-html/).
+
+</Aside>
 
 ## Custom sign in for social authentication
 
@@ -104,14 +110,14 @@ Here is an example using React.
 
 ```jsx
 <button
-    onClick={() =>
-      login({
-        connectionId: "conn_e5f80aa5258e4685bf629b38003ee954",
-        loginHint: "dave@kinde.com"
-      })
-    }
+  onClick={() =>
+    login({
+      connectionId: "conn_e5f80aa5258e4685bf629b38003ee954",
+      loginHint: "dave@kinde.com"
+    })
+  }
 >
-    Sign in with email
+  Sign in with email
 </button>
 ```
 


### PR DESCRIPTION
#### Description 

Provide a shortcut for users to be able to access custom UI from the custom sign in / sign up pages doc 

@clairekinde11 feel free to modify this however works best but I think we should encourage people to use custom UI over faceless


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified language regarding hosting custom authentication pages and standardized terminology.
  - Added an informational aside about fully customizing authentication experiences.
  - Improved formatting in the React example for email sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->