### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/docs/workflows/about-workflows/index.mdx
+++ b/src/content/docs/workflows/about-workflows/index.mdx
@@ -34,6 +34,7 @@ We will add more triggers (and allow you to create your own) as we develop the f
 ## Basic workflow rules
 
 - Workflow actions need to be written in TypeScript or plain JavaScript
+- Filenames must end in the word 'Workflow' for Kinde to recognize them as containing workflow code. For example, `MFAWorkflow.ts` or `PreauthorizationWorkflow.jsx` 
 - File extensions should be .ts, .js, .tsx or .jsx
 - Each trigger can only have one workflow
 - Only Kinde-defined triggers are available (for now)


### PR DESCRIPTION
Clarifying filenames in rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Basic workflow rules" section to specify that workflow filenames must end with "Workflow" for recognition. Added examples to illustrate the required naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->