### PR TITLE
fix: documentation about url binding in workflows

### DIFF
--- a/src/content/docs/workflows/bindings/url-binding.mdx
+++ b/src/content/docs/workflows/bindings/url-binding.mdx
@@ -24,7 +24,9 @@ The `url` binding allows you to access the native JavaScript `URLSearchParams` A
 ```js
 export const workflowSettings = {
   // ...other settings
-  bindings: {"kinde.url": {}}
+  bindings: {
+    url: {}
+  }
 };
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)
Currently in the documentation page https://docs.kinde.com/workflows/bindings/url-binding/ in the configuration example is used the property `"kinde.url"`, but in the latest `@kinde/infrastructure` package v0.4.1, this property doesn't exist on the type `WorkflowSettings`, the correct property is `url`.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated example configuration for enabling the URL binding in workflow settings to use a simplified key format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->