### PR TITLE
docs(no-sdk): add extra auth params

### DIFF
--- a/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
+++ b/src/content/docs/developer-tools/about/using-kinde-without-an-sdk.mdx
@@ -282,6 +282,54 @@ Type: `string`
 
 Required: No (but recommended)
 
+### nonce
+
+Single use code to prevent replay attacks, this will be included in the signed id token 
+
+Type: `string`
+
+Required: No (but recommended)
+
+### workflow_deployment_id
+
+workflow deployment to test, password will be requested on login
+
+Type: string
+
+Required: No
+
+### supports_reauth
+
+When this is set to true, users state will be stored encrypted and returned back to application when accessing an expired link.
+
+Type: boolean
+
+Required: false
+
+### reauth_state
+
+The `supports_reauth` is true, state will be returned with error, pass this back to the auth flow to restart flow.
+
+Type: string
+
+Required: No
+
+### plan_interest
+
+Indicates which plan the user has expressed interest in to be signed up to.
+
+Type: String
+
+Required: No
+
+### pricing_table_key
+
+Defines which pricing table to show in billing flow
+
+Type: String
+
+Required: No
+
 ## **Verifying the Kinde access token**
 
 It’s likely you will be using a library to validate your JWTs and they will require the URL for your public JSON Web Key (also known as a jwks file).


### PR DESCRIPTION
#### Description (required)

Add extra params to no SDK gude



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation for Kinde's OAuth 2.0 authorization URL with new optional parameters, including enhanced security and user flow options. Parameters detailed include `nonce`, `workflow_deployment_id`, `supports_reauth`, `reauth_state`, `plan_interest`, and `pricing_table_key`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->