### PR TITLE
Feat/billing - plan groups and pricing tables

### DIFF
--- a/src/content/docs/billing/billing-user-experience/add-billing-to-url-sdk.mdx
+++ b/src/content/docs/billing/billing-user-experience/add-billing-to-url-sdk.mdx
@@ -6,6 +6,7 @@ sidebar:
 relatedArticles:
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
   - 100f75f1-a0a4-459f-874f-da127f2d0615
+  - c47fa1fb-15e1-4dcf-93d9-59df6acdf6da
 ---
 
 This topic explains how to customize billing flows with Kinde, including URL parameters, direct auth URLs, and SDK usage in React.

--- a/src/content/docs/billing/billing-user-experience/plan-selection.mdx
+++ b/src/content/docs/billing/billing-user-experience/plan-selection.mdx
@@ -52,13 +52,13 @@ You can add and remove plans from the pricing table when it is being worked on.
 
 ## Change the order of plans on a pricing table
 
-The display order of plans from left to right corresponds to the position listed in the **Plans** section of the pricing table.
-
 1. Open the pricing table.
 2. Scroll to the **Plans** section. 
 3. Select the three dots menu on the plan you want to move. 
 4. Select **Move up** or **Move down**, depending on the plan position.
 5. Select **Save**.
+
+This is the order plans will be displayed left to right on the pricing table.
 
 ## Add a features list to a plan on the pricing table
 

--- a/src/content/docs/billing/billing-user-experience/plan-selection.mdx
+++ b/src/content/docs/billing/billing-user-experience/plan-selection.mdx
@@ -23,7 +23,7 @@ A pricing table can only have 4 plans.
 1. Go to **Billing > Pricing tables**.
 2. Select **Add pricing table**. 
 3. Choose an option:
-    1. **Generate** a pricing table from a plan group - this pre-populates the pricing table with basic details and the plans based on the plan group you select. Up to 4 plans can be included on a pricing table. If your plan group contains more, you may want to create a new pricing table.
+    1. **Generate** a pricing table from a [plan group](/billing/manage-plans/add-manage-plan-groups/) - this pre-populates the pricing table with basic details and the plans based on the plan group you select. Up to 4 plans can be included on a pricing table. If your plan group contains more, you may want to create a new pricing table.
     2. **Create new** pricing table. Manually build the pricing table and add plans from a plan group. This gives you a blank slate to start in.
 4. Select **Next**.
     1. **Generated** - select the group and then **Save**.
@@ -103,6 +103,8 @@ We recommend only doing this after your plans are finalized and published.
 1. Open the pricing table.
 2. Select **Make live**. 
 3. Select **Save**. If a user passes the pricing table code in a URL, they will be able to sign up using it.
+
+Here's how to [add the pricing table params to URLs](/billing/billing-user-experience/add-billing-to-url-sdk/).
 
 ## Set pricing table to show as default in register flow
 

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -1,5 +1,5 @@
 ---
-page_id: 
+page_id: c47fa1fb-15e1-4dcf-93d9-59df6acdf6da
 title: Pricing table display defaults
 sidebar:
   order: 4

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -33,7 +33,7 @@ A pricing table is shown when:
 
 You can override which plan or pricing table is shown using URL parameters. See: [Update code and URLs for billing](/billing/billing-user-experience/add-billing-to-url-sdk/).
 
-## Summary of display ffor plan groups
+## Summary of display for plan groups
 
 | Model | Plan group | Pricing table is shown when |
 | --- | --- | --- |

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -8,7 +8,7 @@ relatedArticles:
   - db047df7-d6b6-4d02-843f-dce6000bacbd
 ---
 
-The pricing table that displayed in a particular flow depends on the the [default plan groups and group types](/billing/manage-plans/add-manage-plan-groups/).
+The pricing table that is displayed in a particular flow depends on the the [default plan groups and group types](/billing/manage-plans/add-manage-plan-groups/).
 
 ## B2C (User-based)
 

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -1,6 +1,6 @@
 ---
 page_id: 
-title: Pricing tables for plan group types
+title: Pricing table display defaults
 sidebar:
   order: 4
 relatedArticles:

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -1,0 +1,44 @@
+---
+page_id: 
+title: Pricing tables for plan group types
+sidebar:
+  order: 4
+relatedArticles:
+  - 37d5ae8e-cfd1-4e5d-8333-387b6967ec23
+  - db047df7-d6b6-4d02-843f-dce6000bacbd
+---
+
+The pricing table that displayed in a particular flow depends on the the [default plan groups and group types](/billing/manage-plans/add-manage-plan-groups/).
+
+## B2C (User-based)
+
+A pricing table is shown when:
+
+- A new user registers
+- An existing user, marked as a billing customer, signs in but isn’t on a plan yet
+
+## B2B (Org-based)
+
+A pricing table is shown when:
+
+- A new organization registers (`is_create_org` parameter)
+- An org member with `org:write:billing` permission signs in and the org is a billing customer but not on a plan yet
+
+## B2B2C (Platforms - uses both)
+
+- Organization plan selection = B2B logic
+- User plan selection = B2C logic
+
+## Override the default plan display
+
+You can override which plan or pricing table is shown using URL parameters. See: [Update code and URLs for billing](/billing/billing-user-experience/add-billing-to-url-sdk/).
+
+## Summary of display ffor plan groups
+
+| Model | Plan group | Pricing table is shown when |
+| --- | --- | --- |
+| B2C | User plan group | New user registers / logs in |
+| B2B | Org plan group | New org registers / billing admin |
+| B2B2C | Both | Depends on flow context |
+
+

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -36,7 +36,7 @@ Plan groups are a collection of related plans, tied to either users or organizat
 - You can create multiple pricing tables for one plan group (but only one is the default). 
 - Only one plan group can be included in a pricing table.
 
-For more information see [add and manage plan groups](TBC)
+For more information see [add and manage plan groups](/billing/manage-plans/add-manage-plan-groups/)
 
 ## Parts of a plan
 

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -32,7 +32,7 @@ These are known limitations that we are actively working on to add.
 Plan groups are a collection of related plans, tied to either users or organizations. 
 
 - You can create as many plan groups as you need. 
-- Each group can only contain plans for user OR plans for orgs.
+- Each group can only contain plans for users OR plans for orgs.
 - You can create multiple pricing tables for one plan group (but only one is the default). 
 - Only one plan group can be included in a pricing table.
 

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -27,6 +27,17 @@ These are known limitations that we are actively working on to add.
 - No alterations to billing cycle or invoice methods.
 - Add-ons and discounts that can be applied to individual subscriptions.
 
+## About plan groups
+
+Plan groups are a collection of related plans, tied to either users or organizations. 
+
+- You can create as many plan groups as you need. 
+- Each group can only contain plans for user OR plans for orgs.
+- You can create multiple pricing tables for one plan group (but only one is the default). 
+- Only one plan group can be included in a pricing table.
+
+For more information see [add and manage plan groups](TBC)
+
 ## Parts of a plan
 
 There are a number of concepts and elements involved in building a plan.

--- a/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
+++ b/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
@@ -23,7 +23,7 @@ When you first add a plan in Kinde, you select the plan type and a plan group wi
 
 1. Go to **Billing > Plans**.
 2. Select **Add group**.
-3. Enter a **Name** and select the of plan the group contains.
+3. Enter a **Name** and select the type of plan the group contains.
 4. Choose a colour. This only applies to how the group appears on the **Plans** page.
 5. Select **Save**.
 6. Repeat for all the groups you want to add. 

--- a/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
+++ b/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
@@ -1,0 +1,51 @@
+---
+page_id: adee7343-3d87-4045-9d62-5db57fce6596
+title: Add and manage plan groups
+sidebar:
+  order: 5
+relatedArticles:
+  - 88e1773a-b681-441f-b4c7-d7d339116867
+  - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
+  - 37d5ae8e-cfd1-4e5d-8333-387b6967ec23
+---
+
+Plan groups are a way of organizing sets of related plans together. 
+
+A plan group can be defined as an 'organization' or 'user' type, depending who you are selling to. For (B2B) businesses, use the organization type. For (B2C) individual customers, use the 'user' type. If you are a B2B2C business, create one group of each type. 
+
+How you set up plans in the group impacts how you present feature bundles on a pricing table.
+
+## Default plan groups
+
+When you first add a plan in Kinde, you select the plan type and a plan group will be automatically created for you. You can later change the name of the group, or make a different group the default group. There can only be one default group for organizations and one for users. The default group is what is displayed by default on a pricing table.
+
+## Add a plan group
+
+1. Go to **Billing > Plans**.
+2. Select **Add group**.
+3. Enter a **Name** and select the of plan the group contains.
+4. Choose a colour. This only applies to how the group appears on the **Plans** page.
+5. Select **Save**.
+6. Repeat for all the groups you want to add. 
+
+## Organize plans within a group
+
+The order of plans within a group is important, as it represent the order plans will appear on the pricing table. You don't have to set them up in order when you are first adding them, but you will need to move them into order before showing users the pricing table. 
+
+To move a plan up or down in a group, select the three dots menu and select a moving option:
+
+![Plan card overflow menu](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/787e431f-c73c-44b4-b245-222f9a4cf200/public)
+
+## Delete a plan group
+
+<Aside type="warning">
+
+If you delete a plan group that is associated with a pricing table, the pricing table will also be deleted. These actions are not reversible.
+
+</Aside>
+
+1. Go to **Billing > Plans**.
+2. Select the three dots menu near the plan group name.
+   ![Plan group overflow menu](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1ba1256c-d3cf-4b80-e7b0-8422d3866100/public)
+3. Select **Delete**.
+4. In the confirmation window that appears, confirm you want to delete.

--- a/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
+++ b/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
@@ -30,7 +30,7 @@ When you first add a plan in Kinde, you select the plan type and a plan group wi
 
 ## Organize plans within a group
 
-The order of plans within a group is important, as it represent the order plans will appear on the pricing table. You don't have to set them up in order when you are first adding them, but you will need to move them into order before showing users the pricing table. 
+The order of plans within a group represents the order they are shown in the Kinde Admin. This does not impact the order they are shown on the pricing table. 
 
 To move a plan up or down in a group, select the three dots menu and select a moving option:
 

--- a/src/content/docs/billing/pricing/pricing-models.mdx
+++ b/src/content/docs/billing/pricing/pricing-models.mdx
@@ -23,7 +23,7 @@ In Kinde, create a **Fixed charge** and call it something like `Subscription fee
 
 - Example - Basic plan 5.00, Team plan 20.00, Business plan 75.00.
 
-## Usage-based (metered) pricing
+## Usage-based (metered or tiered) pricing
 
 Where you charge customers for what they use. For example, monthly active users, data storage, transactions, etc. For each individual plan you can treat this as fully pay-as-you-go, or charge volume prices so the price goes down the more units are used. You can set limits for usage based pricing or leave as limitless. Limits can make plan upgrade more attractive. 
 


### PR DESCRIPTION
Updates to cover:
Plan group creation, deletion, etc.
Relationship between plan groups and pricing table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new page explaining how to add and manage plan groups, including instructions for creating, organizing, and deleting plan groups.
  - Introduced a new section describing plan groups and their usage in managing related plans.
  - Added a new page detailing pricing table display defaults across B2C, B2B, and B2B2C billing contexts.
  - Enhanced cross-referencing by adding hyperlinks between relevant documentation pages.
  - Updated a heading to clarify that usage-based pricing includes both metered and tiered models.
  - Included a new related article link in billing SDK documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->