### PR TITLE
Feat/billing bug fixes

### DIFF
--- a/src/content/docs/billing/get-started/setup-overview.mdx
+++ b/src/content/docs/billing/get-started/setup-overview.mdx
@@ -32,7 +32,7 @@ If you are using billing for the first time, make sure you use a Kinde non-produ
 
 When you use a non-production environment, Stripe automatically creates a test Stripe environment. This test environment allows you to create customers and billing subscriptions without actually charging customers. You can also use Stripe’s test credit card details.
 
-When using a test environment and a test stripe account, you will not incur any billing-related fees from Stripe or Kinde.
+When using a Kinde test environment and a test Stripe account, you will not incur any billing-related fees from Stripe or Kinde.
 
 ## Before setting up billing
 

--- a/src/content/docs/billing/get-started/setup-overview.mdx
+++ b/src/content/docs/billing/get-started/setup-overview.mdx
@@ -32,6 +32,8 @@ If you are using billing for the first time, make sure you use a Kinde non-produ
 
 When you use a non-production environment, Stripe automatically creates a test Stripe environment. This test environment allows you to create customers and billing subscriptions without actually charging customers. You can also use Stripe’s test credit card details.
 
+When using a test environment and a test stripe account, you will not incur any billing-related fees from Stripe or Kinde.
+
 ## Before setting up billing
 
 - Make a list of all your app’s features - with names, descriptions, prices, metered rates, limits, inclusions, etc. You might consider doing this in a spreadsheet to make it easier and faster to add features in the Kinde plan builder. Include plan variations for prices, limits, etc.

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -82,3 +82,13 @@ Plans can be in two states:
 - Published plans must be included in a pricing table for self-sign ups.
 
 Plan versioning is being worked on, but is not currently available.
+
+## When a plan feature price syncs to Stripe
+
+Feature prices sync to Stripe when you are successfully connected to Strip and you publish the plan containing that feature. When you are creating a plan, you may notice that some features show `price synced` or `price not synced`.
+
+- Price synced - The price in Kinde and Stripe are the same. A plan with this feature is published.
+- Price not synced - The price in Kinde has not yet synced to Stripe. When you publish or re-publish the plan, this will change.
+
+If you see a mix of synced and not synced feature prices on a plan, this might be because the synced ones are in a plan that is published.
+Unmetered (non-chargeable) features do not have a price sync status badge.

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -105,7 +105,6 @@ You cannot change the Name, the Key or the Type of feature once you have created
     
 15. Select **Save.**
 16. In the **Plan** window, select **Save** to commit your changes.
-17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan.
+17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan. Note that features on published plans show as `price synced` or otherwise show `price not synced`.
 
 **Next:** [Step 5 Publish plans](/billing/get-started/publish-plans/)
-

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -63,6 +63,12 @@ You need to create a $0.00 charge for Free plans. This ensures the plan is added
 5. Select **Save draft**.
 6. Repeat from step 1 for each fixed charge you want to add, or start adding features.
 
+<Aside title="Feature price sync">
+
+If you are successfully connected to Stripe and the charge is part of a published plan, it will show as `price synced`. Otherwise the charge will show as `price not synced`.
+
+</Aside>
+
 ## Add features (entitlements) to a plan
 
 Features describe the individual functions or entitlements that users get with their plan. These can be of the type metered (chargeable) or unmetered (included).
@@ -105,6 +111,12 @@ You cannot change the Name, the Key or the Type of feature once you have created
     
 15. Select **Save.**
 16. In the **Plan** window, select **Save** to commit your changes.
-17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan. Note that features on published plans show as `price synced` or otherwise show `price not synced`.
+17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan. 
+
+<Aside title="Feature price sync">
+
+If you are successfully connected to Stripe and the feature is part of a published plan, it will show as `price synced`. Otherwise the feature will show as `price not synced`.
+
+</Aside>
 
 **Next:** [Step 5 Publish plans](/billing/get-started/publish-plans/)


### PR DESCRIPTION
Fixed issues raised during bug bash
- clarity on no fees to test billing
- clarified the pricing sync badge on plan features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that using both a Kinde test environment and a test Stripe account incurs no billing-related fees.
  * Added explanations about the synchronization status of plan feature prices with Stripe, including the meaning of "price synced" and "price not synced" statuses.
  * Introduced informational notes in the plan creation guide to explain how price sync statuses are displayed for fixed charges and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->