### PR TITLE
Fix/api billing entitlements for orgs

### DIFF
--- a/src/content/docs/developer-tools/account-api/about-account-api.mdx
+++ b/src/content/docs/developer-tools/account-api/about-account-api.mdx
@@ -10,7 +10,13 @@ relatedArticles:
 
 Kinde's [Account API](https://docs.kinde.com/kinde-apis/frontend/) uses a users access token to grab data like roles, permissions, profile, billing entitlements, etc. These details can be called from a browser as the call is scoped to the user who the token is for.
 
-## Examples for using the Account API
+<Aside>
+
+Some data is intentially not available via the Accounts API. For example, plan entitlements information for organizations. This is because Accounts API data is surfaced via a browser token and passing data this way is less secure. Access the Kinde Management API to access secure data. Or contact support for guidance.
+
+</Aside>
+
+## When to use the Kinde Account API
 
 - `properties` - show a specific promotion for users in certain regions or industries
 - `feature flags` - roll out beta features for a subset of users

--- a/src/content/docs/developer-tools/account-api/about-account-api.mdx
+++ b/src/content/docs/developer-tools/account-api/about-account-api.mdx
@@ -16,6 +16,7 @@ Kinde's [Account API](https://docs.kinde.com/kinde-apis/frontend/) uses a users 
 - `feature flags` - roll out beta features for a subset of users
 - `permissions` - only give access to certtain parts of your app based on permissions
 - `roles` - restrict access to functions by role, e.g. admins.
+- `entitlements` - to enable individual users to see plan entitlements
 
 ## Access the Account API
 


### PR DESCRIPTION
Update to Accounts API doc to clarify the type of data that is surfaced via the Accounts API (scoped to users)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that sensitive data like organizational plan entitlements is not available via the Account API and provided guidance on accessing secure data.
  * Updated section title to "When to use the Kinde Account API."
  * Added "entitlements" as a use case for enabling users to view plan entitlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->