### PR TITLE
Create docs for self-serve portal links for nextjs-sdk

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
@@ -1616,18 +1616,7 @@ To use our self-serve portal API please see [Get self-serve portal link](https:/
 ```jsx
 import {PortalLink} from "@kinde-oss/kinde-auth-nextjs/components";
 
-<PortalLink></PortalLink>
-```
-
-### children
-
-When setting up your portal link, `children=""` must be set, as that will be what your link is called.
-
-
-```jsx
-import {PortalLink} from "@kinde-oss/kinde-auth-nextjs/components";
-
-<PortalLink children="Portal Link Name"></PortalLink>
+<PortalLink>Portal Link Name</PortalLink>
 ```
 ### subNav
 
@@ -1635,17 +1624,9 @@ The  `subNav=""` property allows you to set the area of the portal you want the 
 
 ```jsx
 import {PortalLink} from "@kinde-oss/kinde-auth-nextjs/components";
-/**
- * Valid subNav values are: 
- * profile
- * organization_details 
- * organization_payment_details
- * organization_plan_selection 
- * payment_details 
- * plan_details 
- * plan_selection
-*/
-<PortalLink subNav="organization_payment_details"></PortalLink>
+import { PortalPage } from "@kinde/js-utils";
+
+<PortalLink subNav={PortalPage.organizationPaymentDetails}></PortalLink>
 ```
 
 ### returnUrl


### PR DESCRIPTION
#### Description (required)
Add in documentation for setting up the `PortalLink` components in the nextjs-sdk. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section detailing how to use the PortalLink component for directing users to the Kinde portal.
  * Included examples for setting link text, specifying portal subsections with the subNav prop, and configuring post-action redirects with the returnUrl prop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->