### PR TITLE
Fix/sp vs idp signin for ECs

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -80,6 +80,11 @@ If you would prefer users explicitly choose to sign in with SSO, you can add a u
 
 Users click the universal button, enter their credentials, and get routed silently to the IdP for verification. 
 
+## Enterprise connections only allow service provider log in, not identity provider log in
+
+If you run a B2B business, you might allow your business customers to use their own identity provider setup (like Okta SAML) to access your app. When you set up an enterprise connection to support this, make them aware they can only sign in via your app's auth gateway, with Kinde as the auth service provider.
+The customer cannot sign in to your app via their own connection setup - also known as IdP-initiated login.
+
 ## Disable an enterprise connection
 
 <Aside type="danger">

--- a/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
@@ -57,3 +57,8 @@ Here’s what happens:
 If both enterprise connection and domain restrictions are in place, both checks must be successful.
 
 </Aside>
+
+## Enterprise connections only allow service provider log in, not identoity provider log in
+
+If you set up an enterprise connection for a customer using their IdP credentials, they can only sign in to your app via your app, with Kinde as the auth service provider.
+The customer cannot sign in to your app via their own connection setup - known as IdP-initiated login.

--- a/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
@@ -58,7 +58,7 @@ If both enterprise connection and domain restrictions are in place, both checks 
 
 </Aside>
 
-## Enterprise connections only allow service provider log in, not identoity provider log in
+## Enterprise connections only allow service provider log in, not identity provider log in
 
 If you set up an enterprise connection for a customer using their IdP credentials, they can only sign in to your app via your app, with Kinde as the auth service provider.
 The customer cannot sign in to your app via their own connection setup - known as IdP-initiated login.


### PR DESCRIPTION
Added section to Enterprise auth and B2B enterprise auth topics to be clear that we only support SP-initiated sign in, and not IDP initiated sign in. Address two recent customer queries.