### PR TITLE
Fix/remove ref to payment gateways

### DIFF
--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -17,7 +17,7 @@ relatedArticles:
 - **Features** - Plan features are the specific capabilities or entitlements included in a plan. They can be chargeable (incurring additional fees) or non-chargeable (included at no extra cost). Features can be metered (usage-based) or unmetered (fixed access).
 - **Fixed charges**- Single chargeable items like the subscription base price and other stand alone recurring charges.
 - **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, per-seat pricing, etc. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when deciding this.
-- **Payments gateway** - A payments gateway is a service that securely processes customer payments via credit cards, ACH, or other methods - such as Stripe.
+- **Payments processor** - A payments processor is a third-party service that securely processes customer payments via credit cards, ACH, or other methods - such as Stripe Billing.
 - **Pricing table** - A pricing table is a visual representation of your different subscription plans, showcasing features and prices to help users compare options. You can build one in Kinde and then show it to your customers in the auth flow or self-service portal.
 - **Self-serve account portal** - Kinde provides a self-serve portal. This allows customers to manage their subscriptions—such as upgrading plans, updating payment information, or cancelling. This reduces support overhead and improves user autonomy. In Kinde, you can decide what your customers can self-manage or remove the functionality completely.
 

--- a/src/content/docs/billing/about-billing/kinde-billing-model.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-model.mdx
@@ -8,7 +8,7 @@ relatedArticles:
   - 9d1daf85-1a2c-4cc5-879a-230c950bed12
 ---
 
-In the Kinde model, we handle everything except the payment processing part of billing. Kinde integrates with a third-party payment gateway (Stripe) for secure payment processing.
+In the Kinde model, we handle everything except the payment processing part of billing. Kinde integrates with a third-party payment processor (Stripe) for secure payment processing.
 
 This involves a continuous sync between Kinde and Stripe, to ensure that products, prices, subscription information, invoices and payments, are accurate in both systems.
 
@@ -24,7 +24,7 @@ Kinde supports billing models for B2B, B2C and even B2B2C. Depending which you a
 
 ## Kinde and Stripe
 
-Kinde integrates a single payment gateway (only Stripe for now) to handle the financial and payment management side of things.
+Kinde integrates a single payment processor (only Stripe Billing for now) to handle the financial and payment management side of things.
 
 Stripe uses the plan data and the customer info to create an agreement in Stripe. The customer is invoiced based on this agreement. Stripe securely stores your customer’s payment details and Kinde never sees credit card or other bank information.
 

--- a/src/content/docs/billing/get-started/connect-to-stripe.mdx
+++ b/src/content/docs/billing/get-started/connect-to-stripe.mdx
@@ -12,7 +12,7 @@ Kinde’s billing feature comes with a dependency on [Stripe](https://stripe.com
 
 <Aside type="warning">
 
-You can’t currently connect your existing Stripe account, but you will be able to copy across your business information from your existing account to the new account. This is a Stripe-imposed limitation for third party payment gateway integrations. We’re working on a migration strategy.
+You can’t currently connect your existing Stripe account, but you will be able to copy across your business information from your existing account to the new account. This is a Stripe-imposed limitation for third party integrations. We’re working on a migration strategy.
 
 </Aside>
 

--- a/src/content/docs/billing/payment-management/payment-processor.mdx
+++ b/src/content/docs/billing/payment-management/payment-processor.mdx
@@ -1,19 +1,19 @@
 ---
 page_id: acdd8b64-d5b7-43ab-b47b-6244d8f5b82e
-title: Connect payment gateway
+title: Connect payment processor (Stripe)
 sidebar:
   order: 1
   relatedArticles:
     - d980a089-d9c1-447b-930a-de0f2c00d3bf
 ---
 
-Kinde’s billing feature comes with a dependency on third party payment gateways. These services hold credit card details, process payments, apply tax, and generally handle all the financial side of billing.
+Kinde’s billing feature comes with a dependency on third party payment processor, specifically [Stripe Billing](https://stripe.com/au/billing). A payment processor holds credit card details, processes payments, applies tax, and generally handles all the financial side of billing.
 
 For now, only [Stripe](https://stripe.com), a known and reliable payments processing platform, is supported. A new Stripe account is automatically created for you when you set up billing in Kinde. 
 
 <Aside type="warning">
 
-You can’t currently connect your existing Stripe account, but you will be able to copy across your business information from your existing account to the new account. This is a Stripe-imposed limitation for third party payment gateway integrations. We’re working on a migration strategy.
+You can’t currently connect your existing Stripe account, but you will be able to copy across your business information from your existing account to the new account. This is a Stripe-imposed limitation for third party integrations. We’re working on a migration strategy.
 
 </Aside>
 


### PR DESCRIPTION
Removal of ALL references to "payment gateway" replaced with "payment processor" and specific references to "Stripe Billing" where appropriate.