### PR TITLE
chore: fix ambiguous wording about API audience claim in tokens

### DIFF
--- a/src/content/docs/developer-tools/your-apis/register-manage-apis.mdx
+++ b/src/content/docs/developer-tools/your-apis/register-manage-apis.mdx
@@ -15,7 +15,8 @@ If you manage your application’s data using APIs, you can register them with K
 
 Doing this facilitates authentication between your back-end code framework and front-end application where users sign in.
 
-When you register your API with Kinde and link it to a Kinde application, the API will be in the audience (`aud`) claim of the token. The token can then be used to make a request from the front-end to the back-end, which verifies the token and checks the `aud` claim.
+When you register your API with Kinde and link it to a Kinde application, the API can be included in the audience (`aud`) claim of the token. To have it included, your front-end must request the audience by passing it when initializing the SDK or making a token request. Once included, the token can be used to make a request from the front-end to the back-end, which verifies the token and checks the `aud` claim.
+
 
 ## To register an API in Kinde
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

This PR updates the documentation for registering and managing APIs in Kinde. It clarifies that while registering and linking an API to an application is required, the audience (aud) claim will only be included in tokens if the frontend explicitly requests it by passing the audience parameter during SDK initialization or token requests.

This clarification was added because a customer was misled by the existing wording, which implied that the audience would be included automatically once the API was linked to the application. The update removes this ambiguity and better aligns the explanation with later sections of the docs.
