### PR TITLE
Don't open inkeep modal with `/` when input is focused

### DIFF
--- a/src/components/Inkeep.astro
+++ b/src/components/Inkeep.astro
@@ -127,16 +127,23 @@
     }
 
     document.addEventListener("keydown", function (event) {
-        // Check if the `/` key is pressed
-        if (event.key === "/" && !event.metaKey && !event.ctrlKey) {
+        const target = event.target;
+        const isInputFocused =
+            target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable;
+    
+        // Check if `/` key is pressed, and we are NOT focused on an input
+        if (!isInputFocused && event.key === "/" && !event.metaKey && !event.ctrlKey) {
             event.preventDefault();
             handleOpen();
         }
-
+    
         // Check if Cmd (Meta) + K or Ctrl + K is pressed
         if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
             event.preventDefault();
             handleOpen();
         }
     });
+
 </script>


### PR DESCRIPTION
Don't open inkeep modal with `/` when input is focused. We wdon't want to prevent entering `/` in inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut behavior so that pressing `/` will not open the search modal when typing in input fields, textareas, or content editable areas. The shortcut now only works when these elements are not focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->