### PR TITLE
Added a note about phone numbers and shared devices

### DIFF
--- a/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
+++ b/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
@@ -107,6 +107,12 @@ If you are migrating from Auth0, see the **Prepare JSON data (for Auth0 imports)
 - `email` or `phone` - minimum required identity information
 - `external_organization_id` - assign users to organizations, optional unless you are importing roles and permissions
 
+<Aside>
+
+There are special considerations if you are importing users who will share a phone number to authenticate via a mobile device. Contact support@kinde.com for advice on the best way to import users where the phone is the primary identity and numbers are shared. 
+
+</Aside>
+
 ### **Other user data**
 
 <Aside>


### PR DESCRIPTION
Based on customer feedback, there's an edge case where imported user records are auto merged when the same phone number is detected for different users and it stuffs up the import and establishment of correct identities.

Added a note to address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an informational note explaining special considerations when importing users who share a phone number as their primary identity, with guidance to contact support for assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->