### PR TITLE
Updating the Entra ID SAML doc with attribute clarification

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -127,7 +127,7 @@ You can make a connection available only to a specific organization, or you can 
 2. Paste in the data you got from the SAML app:
    - IdP metadata URL
 3. Update the attributes
-   - Email key attribute (Principal name), such as `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
+   - Email key attribute (Email), such as `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
    - First name attribute (Given name), such as `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
    - Last name attribute (Surname), such as `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
 4. (Optional) if you want to sign the SAML httpRequest:


### PR DESCRIPTION
#### Description (required)

Updating the suggested attribute for the Entra ID SAML doc to help ensure pre-provisioning is more reliable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description of the "Email key attribute" in the SAML connection setup instructions to clarify that it should use the "Email" attribute with the correct example URI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->