### PR TITLE
Remove Stripe customer number

### DIFF
--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -25,7 +25,6 @@ deprecated: false
 
 - **Customer ID** - A `customer_id` uniquely identifies a user or org who has signed up to a plan. This is different to a `user_id` or `org_id` that identifies the user or org as an entity. 
 - **Customer Agreement ID** - A `customer_agreement_id` identifies the contract or agreement created in Stripe when a plan is signed up to. The agreement ID is then associated with the `customer_id` in Kinde.
-- **Stripe customer number** - A customer number is automatcially generated in Stripe when a customer signs up to a plan. You don't need this number to interact or do anything in Kinde. The Stripe customer number looks like this - `cus_SobqVb484c2xxx`.
 
 ## Key concepts
 


### PR DESCRIPTION

<!-- Thank you for opening a PR -->

#### Description (required)

Remove Stripe customer number from billing concept terms



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the description of the "Stripe customer number" from the billing identifiers section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->