### PR TITLE
Feat/portal settings per org

### DIFF
--- a/src/content/docs/build/organizations/self-serve-portal-per-org.mdx
+++ b/src/content/docs/build/organizations/self-serve-portal-per-org.mdx
@@ -33,7 +33,7 @@ If an organization requires a unique setup for the self-service portal, you can 
 4. Switch on the **Override environment settings** option.
    ![Switch to override](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/9461ff2f-0c8e-4f2a-0dbb-f6db420bb400/public)
 5. Select the options you want to be available in the self-serve portal for this org. 
-5. Select any additional changes you want to make for members of the org (users) to access. Note that individual access is still controlled via system roles.
-6. Select **Save**.
+6. Select any additional changes you want to make for members of the org (users) to access. Note that individual access is still controlled via system roles.
+7. Select **Save**.
 
 Learn more about [setting up the self-serve portal for an organization](/build/set-up-options/self-serve-portal-for-orgs/).


### PR DESCRIPTION
New topic - SSP per org


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Introduced a new guide on customizing the self-serve portal per organization using Advanced Organizations.
  - Includes an upgrade warning for Kinde Scale.
  - Provides step-by-step instructions: enable Advanced Organizations, override environment settings, choose portal options per org, adjust member access rights, and save.
  - Adds a screenshot placeholder and a “Learn more” link to related per-org setup resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->