### PR TITLE
Fix incorrect redirect

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,7 +93,7 @@ export default defineConfig({
     "/workflows/":
       "/workflows/about-workflows/",
     "manage-your-apis/":
-      "manage-your-apis/about-api-keys/index/",
+      "manage-your-apis/about-api-keys/",
     
     // Authenticate section subfolder redirects
     "/authenticate/about-auth/":
@@ -156,8 +156,6 @@ export default defineConfig({
       "/design/pages/page-layout/",
 
     // Your APIs section subfolder redirects
-    "/manage-your-apis/about-api-keys/":
-      "/manage-your-apis/about-api-keys/index/",
     "/manage-your-apis/add-manage-api-keys/":
       "/manage-your-apis/add-manage-api-keys/create-an-api-key/",
     "/manage-your-apis/troubleshoot-api-keys/":


### PR DESCRIPTION
Minor fix to make page load work for index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the redirect for “manage-your-apis/” to point to the canonical “manage-your-apis/about-api-keys/”.
  * Removed a redundant subfolder redirect that pointed to an “/index/” path.
  * Reduces redirect hops and eliminates potential 404s from outdated URLs.
  * Improves navigation, preserves existing bookmarks, and enhances SEO with cleaner, canonical URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->