### PR TITLE
docs: fix incorrect portal link endpoint path

### DIFF
--- a/src/content/docs/build/set-up-options/self-serve-portal-for-orgs.mdx
+++ b/src/content/docs/build/set-up-options/self-serve-portal-for-orgs.mdx
@@ -87,7 +87,7 @@ import {PortalLink} from "@kinde-oss/kinde-auth-react";
 If you're not using a Kinde SDK, you can manually call the Account API:
 
 ```js
-const response = await fetch("/api/v1/account_api/portal_link", {
+const response = await fetch("/account_api/v1/portal_link", {
   headers: {
     Authorization: `Bearer ${userAccessToken}`
   }

--- a/src/content/docs/build/set-up-options/self-serve-portal-for-users.mdx
+++ b/src/content/docs/build/set-up-options/self-serve-portal-for-users.mdx
@@ -68,7 +68,7 @@ import {PortalLink} from "@kinde-oss/kinde-auth-react";
 If you're not using a Kinde SDK, you can manually call the Account API:
 
 ```js
-const response = await fetch("/api/v1/account_api/portal_link", {
+const response = await fetch("/account_api/v1/portal_link", {
   headers: {
     Authorization: `Bearer ${userAccessToken}`
   }


### PR DESCRIPTION
#### Description (required)

Corrects the portal link generation endpoint of Account API in both  "Self-serve portal for users" and "Self-serve portal for orgs" pages. 
The correct path is `/account_api/v1/portal_link` instead of `/api/v1/account_api/portal_link`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-serve portal setup guides for organizations and users to reflect the corrected API endpoint path for generating portal links.
  * Refreshed example steps to match the current API behavior, ensuring the instructions align with production.
  * Improved consistency across examples without altering the described authentication or redirect flow.
  * Helps developers avoid errors when generating self-serve portal links without SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->