### PR TITLE
Fix/api keys in other docs refs

### DIFF
--- a/src/content/docs/developer-tools/your-apis/access-to-your-api.mdx
+++ b/src/content/docs/developer-tools/your-apis/access-to-your-api.mdx
@@ -6,6 +6,7 @@ sidebar:
 relatedArticles:
   - 6bf993fc-a195-4836-8eaf-133812be8876
   - cffc17b9-2d10-4f42-8c84-a12b263a6040
+  - 8f7a2b1c-3d4e-4f6a-8b8c-9d0e1f2a3b4c
 topics:
   - developer-tools
   - your-apis
@@ -30,9 +31,11 @@ deprecated: false
 ai_summary: Guide to providing programmatic access to APIs for third parties using M2M applications and tokens
 ---
 
-Although we do not currently have a dedicated feature for it, there is a way to provide your users with programmatic access to your API and applications via Kinde.
+There are a number of ways to provide your users with programmatic access to your API and applications via Kinde.
 
 You need to [register your API with Kinde](/developer-tools/your-apis/register-manage-apis/) before you begin.
+
+## API access via an M2M application
 
 Here’s the process:
 
@@ -40,7 +43,7 @@ Here’s the process:
 - Connect the application to your API
 - Provide access to the user via token or app keys
 
-## Create a M2M application
+### Create a M2M application
 
 You will want to create a separate M2M application for each user, system, or business who needs to access your API. It is not secure to share access via the same tokens or app keys.
 
@@ -49,7 +52,7 @@ You will want to create a separate M2M application for each user, system, or bus
 3. In the dialog that opens, give the application a name, and select **Machine to Machine** as the **Application type**.
 4. Select **Save**. App keys - including **Domain** details, **Client ID** and **Client Secret** - are issued for the application.
 
-## Authorize the API to access the application
+### Authorize the API to access the application
 
 1. In the application list, find the M2M app you created and select **View details**.
 2. Select **APIs** in the menu. A list of all available APIs shows.
@@ -58,17 +61,13 @@ You will want to create a separate M2M application for each user, system, or bus
 
 If you need to cut off access to your API for a user, select the three dots menu and select **Revoke authorization**.
 
-## Get a token to test API access
+## API access via API keys
 
-Follow this guide to [quickly generate a test token](/developer-tools/your-apis/test-token-from-kinde/) to test access to your API. 
+Allow users to manage their own API keys to access your API, including initializing the request, rotating, and deleting keys. Follow this [quickstart guide](/manage-your-apis/about-api-keys/api-keys-quick-start/). This is much more secure and preferable than manually copying the app keys from the M2M application and providing them to the third-party. 
 
-## Provide access to third parties
+## Provide access via a token
 
-There are two ways you can provide access to your API: via token or app keys.
-
-### Via token
-
-The third party can request a token using the relevant `audience` in the claim, for example:
+A third party can request a token using the relevant `audience` in the claim, for example:
 
 ```jsx
 POST https://yourbusiness.kinde.com/oauth2/token
@@ -81,6 +80,6 @@ POST https://yourbusiness.kinde.com/oauth2/token
 ```
 Granting access this way means you don't have to share the Client ID and Secret with anyone.
 
-### Via app keys
+## Get a test token to test API access
 
-Copy the app keys: **Domain**, **Client ID**, and **Client secret** from the M2M application and provide them to the third-party. This enables them access to the end point, e.g. `http://api.example.com/api`. Providing app keys authorizes access unless the Client secret is rotated or revoked.
+Follow this guide to [quickly generate a test token](/developer-tools/your-apis/test-token-from-kinde/) to test access to your API. 

--- a/src/content/docs/developer-tools/your-apis/protect-your-api.mdx
+++ b/src/content/docs/developer-tools/your-apis/protect-your-api.mdx
@@ -7,6 +7,7 @@ sidebar:
 relatedArticles:
   - 684fc526-a338-4a67-9af6-742a39b66aff
   - 4ed081b0-7853-49be-b5fd-22a84a86bdad
+  - 9e8b7c6d-5f4e-4a2b-8c0d-9e8f7a6b5c4d
 topics:
   - developer-tools
   - your-apis
@@ -78,10 +79,6 @@ Now that the token is being passed from the front end you will need to verify it
 ### **Libraries**
 
 We recommend that you use a library to verify your token. If you are using ExpressJS you can use [our library](/developer-tools/sdks/backend/express-sdk/#verify-jwt) or the OpenID Foundation has [a list of libraries for working with JWT tokens](https://openid.net/developers/jwt/).
-
-### **Rolling your own**
-
-We strongly recommend against doing this, but if you have opted to go down this path, this doc provides you all the info about our JWTs.
 
 ### **JSON Web Key**
 

--- a/src/content/docs/developer-tools/your-apis/register-manage-apis.mdx
+++ b/src/content/docs/developer-tools/your-apis/register-manage-apis.mdx
@@ -91,6 +91,10 @@ If you are using Postman, you can include the `audience` claim in a token reques
     }
 ```
 
+## Create API keys
+
+If you want, you can also give access to your API via [API keys](/manage-your-apis/add-manage-api-keys/create-an-api-key/). These can be created by you and then managed by your customer via the [self-serve portal](/build/set-up-options/self-serve-portal-for-orgs/) (optional). You can also [scope API keys to an organization](/manage-your-apis/about-api-keys/organization-api-keys/).
+
 ## Authorize or revoke authorization of an app from the API
 
 1. Go to **Settings** > **APIs**.


### PR DESCRIPTION
Update to a few docs to reference API keys as alternatives to access/manage own API.
Included related topics from new doc set