### PR TITLE
Update about-self-serve-portal.mdx

### DIFF
--- a/src/content/docs/build/set-up-options/about-self-serve-portal.mdx
+++ b/src/content/docs/build/set-up-options/about-self-serve-portal.mdx
@@ -44,10 +44,10 @@ In the organization portal, you can allow org members to manage:
 
 - Account details
 - Payment details (if you have billing set up)
-- API Keys
-- Members and roles
+- API Keys (Paid plans)
+- Members and roles (Paid plans)
 - Multi-factor auth settings (coming soon)
-- SSO enterprise connections (almost here)
+- SSO enterprise connections (almost here - Kinde Scale plan only)
 
 You can enable all functions or limit them to what you offer. [Set up a self-serve portal for an org](/build/set-up-options/self-serve-portal-for-orgs/)
 
@@ -64,6 +64,8 @@ In the user portal, you can allow users to manage:
 - Account details
 - Payment details (if you have billing set up)
 - API Keys
+
+[Set up a self-serve portal for users](/build/set-up-options/self-serve-portal-for-users/)
 
 ## Self-serve portal settings
 


### PR DESCRIPTION
Quick fix to add plan levels for the functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Organization portal features “API Keys” and “Members and roles” are available on paid plans.
  * Updated SSO enterprise connections status and availability: “almost here” and limited to the Kinde Scale plan.
  * Added a new link to “Set up a self-serve portal for users” for easier navigation to self-serve setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->