### PR TITLE
Fix/enterprise connection for kinde

### DIFF
--- a/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
+++ b/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 4
 relatedArticles:
   - b1e5506a-d378-4b73-a6f5-f96bd45b56f1
+  - 1338a25d-7e81-4793-8c68-57fb273c5df7
+  - f0bc688b-a817-42ab-9a20-8e09cec06f37
 description: Guide to setting up enterprise access to Kinde using SAML connections for team member authentication via Identity Provider.
 topics:
   - get-started

--- a/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
+++ b/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
@@ -34,12 +34,24 @@ ai_summary: Guide to setting up enterprise access to Kinde using SAML connection
 
 If you want your team members to sign in to the Kinde dashboard using an enterprise connection (such as SAML) instead of via our default sign up flow, you can contact us to request it. You must be on a Kinde Scale or Enterprise plan to request this.
 
-Email your business name and email ID to support@kinde.com and provide the following from your Identity Provider (IdP):
+Email your business name and email ID to support@kinde.com and provide the following from your Identity Provider (IdP). 
+
+For SAML connections:
 - Entity ID
 - IdP metadata URL
+- Home realm domains
 - Email key attribute
 - First name key attribute
 - Last name key attribute
-- Home realm domains
+- Upstream params (if applicable)
 
-Once we have these, we can set up the connection and send you an ACS url (also known as a **reply url**), for example: `https://app.kinde.com/login/saml/callback`, to complete the setup with your IdP.
+For Entra ID connections:
+- Client ID
+- Client Secret^
+- Microsoft Entra domain
+- Home realm domains (if applicable)
+- Upstream params (if applicable)
+
+^Contact us to discuss the most secure way to provide this information
+
+Once we have these, we can set up the connection and send you an ACS url (also known as a **reply url**), for example: `https://app.kinde.com/login/saml/callback`, to complete the setup with your IdP. 

--- a/src/content/docs/get-started/team-and-account/mfa-for-kinde-access.mdx
+++ b/src/content/docs/get-started/team-and-account/mfa-for-kinde-access.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 5
 relatedArticles:
   - f4b911df-cc23-4eb9-b3ff-56cd2bb7e378
+  - c2a21e18-b542-4c07-a3b3-206ed4ce9508
 description: Guide to setting up multi-factor authentication for team access to Kinde including role-based MFA and authentication factors.
 topics:
   - get-started


### PR DESCRIPTION
Update to include Entra details for EC for Kinde access
Update to cross reference pages 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded enterprise access guide with clearer requirements for SAML and Entra ID connections, including required fields (e.g., Entity ID, IdP metadata URL, Client ID/Secret) and updated ordering for clarity.
  * Added guidance on providing IdP details, including a security note on sharing sensitive credentials.
  * Clarified terminology and punctuation; improved ACS URL example context.
  * Enhanced related articles in enterprise access and MFA docs to aid discovery with additional references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->