### PR TITLE
Add custom OAuth2 connection documentation

### DIFF
--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -106,3 +106,7 @@ See the [individual social sign in](/authenticate/social-sign-in/add-social-sig
 ## Enterprise authentication
 
 Kinde supports the use of [Microsoft Entra ID](/authenticate/enterprise-connections/azure/) and [SAML](/authenticate/enterprise-connections/custom-saml/) as an enterprise-level single sign on (SSO) authentication methods. These methods are more suited to big corporate and government organizations.
+
+## Custom OAuth 2.0 connections
+
+You can add any OAuth 2.0 compatible identity provider as an authentication method. You should check compatibility thoroughly and test these types of connections in a non-production environment. Here are the instructions for getting set up with [custom OAuth 2.0](/authenticate/custom-configurations/custom-oauth2-connection/). Note there may be variations in field names and terms depending on the provider you use.

--- a/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
@@ -22,12 +22,6 @@ deprecated: false
 
 You can enable users to sign up and sign in using their credentials from any OAuth2-compatible identity provider. To set this up, you need access to your OAuth2 provider's developer console and a little technical know-how. We recommend setting this up in a non-production environment first, to test the connection thoroughly.
 
-<Aside type="warning" title="Custom OAuth2 connections for production environments">
-
-Before you make your production environment live, you must add your own OAuth2 app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
-
-</Aside>
-
 Custom OAuth 2.0 connections allow you to integrate with any OAuth2-compatible identity provider that isn't natively supported by Kinde. This includes custom identity providers, enterprise solutions, or specialized authentication services.
 
 ## OAuth 2.0 provider requirements
@@ -47,7 +41,7 @@ Disclaimer: the following steps are a guide to what needs to happen on the custo
 3. Configure your OAuth2 application settings:
 
    1. Set the application type to **Web Application** or **Confidential Client**.
-   2. Add your **Authorized redirect URIs**. These is your Kinde domain or custom domain callback URLs. For example, `account.customdomain.com/login/callback`. If you don't have this, you can copy it from the Kinde connection and add it later.
+   2. Add your **Authorized redirect URIs**. These are your Kinde domain or custom domain callback URLs. For example, `account.customdomain.com/login/callback`. If you don't have this, you can copy it from the Kinde connection and add it later.
    3. Configure the required OAuth2 scopes. At minimum, you'll need scopes to access user profile information and email address. Common scopes are: `openid`, `profile`, `email`. Add any other provider-specific ones you want.
    4. Set any additional configuration options required by your provider. These might include key attributes or upstream parameters.
 

--- a/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
@@ -1,0 +1,120 @@
+---
+page_id: custom-oauth2-connection-001
+title: Custom OAuth2 connection
+sidebar:
+  order: 20
+description: Step-by-step guide to setting up custom OAuth2 connections including OAuth provider setup, credentials configuration, and Kinde integration.
+metadata:
+  topics: [authenticate]
+  sdk: []
+  languages: []
+  audience: [developer, integration-engineer]
+  complexity: advanced
+  keywords: [custom OAuth2, OAuth provider, client ID, client secret, callback URL, custom connection, identity provider]
+  updated: 2025-01-16
+featured: false
+deprecated: false
+---
+
+You can enable users to sign up and sign in using their credentials from any OAuth2-compatible identity provider. To set this up, you need access to your OAuth2 provider's developer console and a little technical know-how.
+
+<Aside type="warning" title="Custom OAuth2 connections for production environments">
+
+Before you make your production environment live, you must add your own OAuth2 app's Client ID and Client secret in the Kinde connection (as per below). Do not use Kinde's app credentials by leaving the fields blank, as this poses a security and performance risk, and makes it difficult to change auth providers without service disruptions for your users.
+
+</Aside>
+
+Custom OAuth2 connections allow you to integrate with any OAuth2-compatible identity provider that isn't natively supported by Kinde. This includes custom identity providers, enterprise solutions, or specialized authentication services.
+
+<Aside title="OAuth2 provider requirements">
+
+Before connecting your custom OAuth2 provider, ensure it supports the OAuth2 authorization code flow and can provide user profile information including email address. The provider must also support HTTPS for all endpoints.
+
+</Aside>
+
+## **Before you begin**
+
+1. Access your OAuth2 provider's developer console or admin panel.
+2. Create a new OAuth2 application or client.
+3. Get your custom connection credentials (see below).
+
+### **Get the Kinde Callback URL**
+
+1. Sign in to Kinde.
+2. Go to the **Settings** page and select **Authentication**.
+3. In the **Social connections** section, select **Add connection.**
+4. In the window that opens, select **Custom OAuth2**, then select **Next**.
+5. In the **Callback URL** section:
+   1. If you use Kinde's domain as your default, copy the Kinde domain URL.
+   2. If you use custom domains, select the **Use custom domain instead** switch.
+   3. If you have only one custom domain, copy the Custom domain URL. If you have custom domains for multiple organizations, select each one from the list and copy the callbacks for each. You need to enter all custom domain callbacks in your OAuth2 app.
+6. Select **Save**.
+7. Use the copied Callback URL to set up your OAuth2 app, see below.
+
+## **Get your custom connection credentials**
+
+1. Navigate to your OAuth2 provider's developer console or admin panel.
+2. Create a new OAuth2 application or client.
+3. Configure your OAuth2 application settings:
+   1. Set the application type to **Web Application** or **Confidential Client**.
+   2. Add your **Authorized redirect URIs**. These are the Callback URLs you copied in the previous procedure. Add entries for all your organization custom domain callbacks, e.g. `account.customdomainone.com/login/callback`, `account.customdomaintwo.com/login/callback`, etc.
+   3. Configure the required OAuth2 scopes. At minimum, you'll need scopes to access user profile information and email address.
+   4. Set any additional configuration options required by your provider.
+
+<Aside title="Required OAuth2 scopes">
+
+Your custom OAuth2 provider must support scopes that allow access to:
+- User profile information (name, etc.)
+- User email address
+- Any additional user attributes you want to capture
+
+Common scope examples: `openid`, `profile`, `email`, `user:read`, or provider-specific equivalents.
+
+</Aside>
+
+4. Complete all the required application details (noting that you may need to go through a verification process depending on your provider).
+5. Save your application configuration.
+6. Copy your **Client ID** and **Client Secret** from the application details.
+
+## **Add your custom connection credentials to Kinde**
+
+1. In Kinde, go to **Settings** and select **Authentication**.
+2. On the Custom OAuth2 tile, select the **Configure** link.
+3. Enter your OAuth2 provider details:
+   - **Provider Name**: A descriptive name for your connection
+   - **Authorization URL**: The OAuth2 authorization endpoint URL
+   - **Token URL**: The OAuth2 token endpoint URL
+   - **User Info URL**: The endpoint to retrieve user profile information
+   - **Client ID**: Your OAuth2 application's client ID
+   - **Client Secret**: Your OAuth2 application's client secret
+4. Configure the user profile mapping:
+   - **Email Field**: The field name in the user info response that contains the email address
+   - **First Name Field**: The field name for the user's first name
+   - **Last Name Field**: The field name for the user's last name
+   - **ID Field**: The field name for the unique user identifier
+5. Select if you want to treat this connection as a trusted provider. A [trusted provider](/authenticate/about-auth/identity-and-verification/) is one that guarantees the email they issue is verified. We recommend leaving this off for maximum security.
+6. Add any [upstream params](/authenticate/auth-guides/pass-params-idp/) that you want to pass to your OAuth2 provider.
+7. Select which applications to switch this on for.
+8. Select **Save**. Your users will now be able to sign in using their credentials from your custom OAuth2 provider.
+
+<Aside title="Testing your custom OAuth2 connection">
+
+After configuring your custom OAuth2 connection, test it thoroughly in a non-production environment before going live. Verify that:
+- Users can successfully authenticate
+- User profile information is correctly mapped
+- Email addresses are properly captured
+- Any custom claims or attributes are accessible
+
+</Aside>
+
+## **Troubleshooting custom OAuth2 connections**
+
+If you encounter issues with your custom OAuth2 connection:
+
+1. **Verify endpoint URLs**: Ensure all OAuth2 endpoint URLs are correct and accessible
+2. **Check scopes**: Confirm that your OAuth2 provider supports the required scopes
+3. **Validate callback URLs**: Ensure all callback URLs are properly configured in your OAuth2 application
+4. **Review user info response**: Verify that the user info endpoint returns data in the expected format
+5. **Check field mappings**: Ensure the field names for user profile data match what your provider returns
+
+For additional support, contact Kinde support or refer to your OAuth2 provider's documentation.

--- a/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
@@ -3,6 +3,10 @@ page_id: 94765d42-4f2d-4691-8877-8e67b7435be1
 title: Custom OAuth 2.0 connections
 sidebar:
   order: 9
+relatedArticles:
+  - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
+  - 64079be6-be72-4b63-a9d1-4466af4d49be
+  - a5225946-27ad-41c0-a3c1-9a6d735e3efb
 description: Step-by-step guide to setting up custom OAuth2 connections including OAuth provider setup, credentials configuration, and Kinde integration.
 metadata:
   topics: [authenticate]

--- a/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
@@ -1,8 +1,8 @@
 ---
-page_id: custom-oauth2-connection-001
-title: Custom OAuth2 connection
+page_id: 94765d42-4f2d-4691-8877-8e67b7435be1
+title: Custom OAuth 2.0 connections
 sidebar:
-  order: 20
+  order: 9
 description: Step-by-step guide to setting up custom OAuth2 connections including OAuth provider setup, credentials configuration, and Kinde integration.
 metadata:
   topics: [authenticate]
@@ -11,12 +11,12 @@ metadata:
   audience: [developer, integration-engineer]
   complexity: advanced
   keywords: [custom OAuth2, OAuth provider, client ID, client secret, callback URL, custom connection, identity provider]
-  updated: 2025-01-16
+  updated: 2025-09-19
 featured: false
 deprecated: false
 ---
 
-You can enable users to sign up and sign in using their credentials from any OAuth2-compatible identity provider. To set this up, you need access to your OAuth2 provider's developer console and a little technical know-how.
+You can enable users to sign up and sign in using their credentials from any OAuth2-compatible identity provider. To set this up, you need access to your OAuth2 provider's developer console and a little technical know-how. We recommend setting this up in a non-production environment first, to test the connection thoroughly.
 
 <Aside type="warning" title="Custom OAuth2 connections for production environments">
 
@@ -24,80 +24,72 @@ Before you make your production environment live, you must add your own OAuth2 a
 
 </Aside>
 
-Custom OAuth2 connections allow you to integrate with any OAuth2-compatible identity provider that isn't natively supported by Kinde. This includes custom identity providers, enterprise solutions, or specialized authentication services.
+Custom OAuth 2.0 connections allow you to integrate with any OAuth2-compatible identity provider that isn't natively supported by Kinde. This includes custom identity providers, enterprise solutions, or specialized authentication services.
 
-<Aside title="OAuth2 provider requirements">
+## OAuth 2.0 provider requirements
 
 Before connecting your custom OAuth2 provider, ensure it supports the OAuth2 authorization code flow and can provide user profile information including email address. The provider must also support HTTPS for all endpoints.
 
+<Aside>
+
+Disclaimer: the following steps are a guide to what needs to happen on the custom OAuth 2.0 identity provider side. You may need to adapt some steps to suit the way different providers are configured.
+
 </Aside>
 
-## **Before you begin**
-
-1. Access your OAuth2 provider's developer console or admin panel.
-2. Create a new OAuth2 application or client.
-3. Get your custom connection credentials (see below).
-
-### **Get the Kinde Callback URL**
-
-1. Sign in to Kinde.
-2. Go to the **Settings** page and select **Authentication**.
-3. In the **Social connections** section, select **Add connection.**
-4. In the window that opens, select **Custom OAuth2**, then select **Next**.
-5. In the **Callback URL** section:
-   1. If you use Kinde's domain as your default, copy the Kinde domain URL.
-   2. If you use custom domains, select the **Use custom domain instead** switch.
-   3. If you have only one custom domain, copy the Custom domain URL. If you have custom domains for multiple organizations, select each one from the list and copy the callbacks for each. You need to enter all custom domain callbacks in your OAuth2 app.
-6. Select **Save**.
-7. Use the copied Callback URL to set up your OAuth2 app, see below.
-
-## **Get your custom connection credentials**
+## Step 1: Get the custom connection credentials
 
 1. Navigate to your OAuth2 provider's developer console or admin panel.
 2. Create a new OAuth2 application or client.
 3. Configure your OAuth2 application settings:
+
    1. Set the application type to **Web Application** or **Confidential Client**.
-   2. Add your **Authorized redirect URIs**. These are the Callback URLs you copied in the previous procedure. Add entries for all your organization custom domain callbacks, e.g. `account.customdomainone.com/login/callback`, `account.customdomaintwo.com/login/callback`, etc.
-   3. Configure the required OAuth2 scopes. At minimum, you'll need scopes to access user profile information and email address.
-   4. Set any additional configuration options required by your provider.
-
-<Aside title="Required OAuth2 scopes">
-
-Your custom OAuth2 provider must support scopes that allow access to:
-- User profile information (name, etc.)
-- User email address
-- Any additional user attributes you want to capture
-
-Common scope examples: `openid`, `profile`, `email`, `user:read`, or provider-specific equivalents.
-
-</Aside>
+   2. Add your **Authorized redirect URIs**. These is your Kinde domain or custom domain callback URLs. For example, `account.customdomain.com/login/callback`. If you don't have this, you can copy it from the Kinde connection and add it later.
+   3. Configure the required OAuth2 scopes. At minimum, you'll need scopes to access user profile information and email address. Common scopes are: `openid`, `profile`, `email`. Add any other provider-specific ones you want.
+   4. Set any additional configuration options required by your provider. These might include key attributes or upstream parameters.
 
 4. Complete all the required application details (noting that you may need to go through a verification process depending on your provider).
 5. Save your application configuration.
-6. Copy your **Client ID** and **Client Secret** from the application details.
-
-## **Add your custom connection credentials to Kinde**
-
-1. In Kinde, go to **Settings** and select **Authentication**.
-2. On the Custom OAuth2 tile, select the **Configure** link.
-3. Enter your OAuth2 provider details:
-   - **Provider Name**: A descriptive name for your connection
+6. Copy the following information, which is required to set up the Kinde connection:
+   
    - **Authorization URL**: The OAuth2 authorization endpoint URL
    - **Token URL**: The OAuth2 token endpoint URL
    - **User Info URL**: The endpoint to retrieve user profile information
    - **Client ID**: Your OAuth2 application's client ID
    - **Client Secret**: Your OAuth2 application's client secret
-4. Configure the user profile mapping:
-   - **Email Field**: The field name in the user info response that contains the email address
-   - **First Name Field**: The field name for the user's first name
-   - **Last Name Field**: The field name for the user's last name
-   - **ID Field**: The field name for the unique user identifier
-5. Select if you want to treat this connection as a trusted provider. A [trusted provider](/authenticate/about-auth/identity-and-verification/) is one that guarantees the email they issue is verified. We recommend leaving this off for maximum security.
-6. Add any [upstream params](/authenticate/auth-guides/pass-params-idp/) that you want to pass to your OAuth2 provider.
-7. Select which applications to switch this on for.
-8. Select **Save**. Your users will now be able to sign in using their credentials from your custom OAuth2 provider.
 
-<Aside title="Testing your custom OAuth2 connection">
+## Step 2: Set up the Kinde connection
+
+1. Sign in to Kinde.
+2. Go to the **Settings** page and select **Authentication**.
+3. In the **Social connections** section, select **Add connection.**
+4. In the window that opens, select **Custom OAuth 2.0**, then select **Next**.
+5. Enter a **Connection name** for internal identification. If you maintain a lot of external connections, you might want to include the customer's name.
+6. Enter an **External name**. This is what appears on the sign up and sign in screens of your app. 
+7. Enter all the relevant URLs and credentials from the previous step in the corresponding fields:
+   
+   - Authorization URL
+   - Token URL
+   - User Info URL
+   - Client ID
+   - Client Secret
+
+8. Enter any additional configuration options required by your provider, e.g. key attributes and upstream parameters.
+
+9. In the **Callback URL** section:
+   1. If you use Kinde's domain as your default, copy the Kinde domain URL.
+   2. If you use custom domains, select the **Use custom domain instead** switch.
+   3. If you have only one custom domain, copy the Custom domain URL. If you have custom domains for multiple organizations, select each one from the list and copy the callbacks for each. You need to enter all custom domain callbacks in your OAuth2 app.
+10. Select which applications to switch this on for. If you are in a prod environment, this makes the connection live.
+11. Select **Save**.
+12. Use the copied Callback URL to finish setting up your OAuth2 app, see below.
+
+## Step 3: Add the callback URL to your custom connection
+
+1. Navigate to your OAuth2 provider's developer console or admin panel.
+2. Enter the callback URL you copied from the Kinde configuration window.
+3. Save.
+
+## Test your custom OAuth2 connection
 
 After configuring your custom OAuth2 connection, test it thoroughly in a non-production environment before going live. Verify that:
 - Users can successfully authenticate
@@ -105,16 +97,13 @@ After configuring your custom OAuth2 connection, test it thoroughly in a non-pro
 - Email addresses are properly captured
 - Any custom claims or attributes are accessible
 
-</Aside>
+## Troubleshoot custom OAuth2 connections
 
-## **Troubleshooting custom OAuth2 connections**
-
-If you encounter issues with your custom OAuth2 connection:
+If you encounter issues with your custom OAuth2 connection, here's some things to try.
 
 1. **Verify endpoint URLs**: Ensure all OAuth2 endpoint URLs are correct and accessible
 2. **Check scopes**: Confirm that your OAuth2 provider supports the required scopes
 3. **Validate callback URLs**: Ensure all callback URLs are properly configured in your OAuth2 application
 4. **Review user info response**: Verify that the user info endpoint returns data in the expected format
-5. **Check field mappings**: Ensure the field names for user profile data match what your provider returns
 
 For additional support, contact Kinde support or refer to your OAuth2 provider's documentation.

--- a/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
+++ b/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
@@ -50,6 +50,8 @@ Follow the docs below for each social provider you want to use. This will give y
 - [Twitter](/authenticate/social-sign-in/twitter/)
 - [Xero](/authenticate/social-sign-in/xero-sso/)
 
+You can also add [Custom OAuth 2.0 connections](/authenticate/custom-configurations/custom-oauth2-connection/) via the same **Social connections** area.
+
 ### When an email is not provided
 
 Some social providers don't require an email for sign up, e.g. X. When a user signs up or in with one of these providers, Kinde will ask for an email (just once). This is so we can verify the user's identity and be sure it's a genuine sign up.


### PR DESCRIPTION
- Created new topic for custom OAuth2 connections based on Google social sign-in template
- Moved to custom-configurations folder for better organization
- Includes step-by-step setup guide for OAuth2 providers
- Covers credential configuration, user profile mapping, and troubleshooting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Custom OAuth 2.0 connections” section under Enterprise authentication.
  * Introduced a new guide detailing provider requirements, setup steps (credentials, URLs, callback handling), enabling apps, and adding callback URLs to providers.
  * Included testing recommendations (auth flow, profile mapping, email capture, custom claims) and troubleshooting tips (endpoints, scopes, callbacks, user info).
  * Updated Social sign-in documentation to link to the new custom OAuth 2.0 guide for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->