### PR TITLE
Add small section for passing login hint and connection ID

### DIFF
--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -171,6 +171,16 @@ Both login and register support passing a url param `post_login_redirect_url` wh
 </a>
 ```
 
+### Support for custom sign in pages
+
+To build a custom login screen, you need to pass in the `login_hint` and `connection_id` to the URL. You can use the following:
+
+```html
+<li>
+    <a href="/api/auth/login?login_hint=name@domain.com&connection_id=conn_01996ec8fe62d014cc093caf3e23xxxx">Sign in</a>
+  </li>
+```
+
 ## Log out
 
 This is implemented in much the same way as signing up or signing in. An API route is provided for you


### PR DESCRIPTION
See https://www.notion.so/kinde/SvelteKit-doc-add-authurlparam-details-1aa35eb337a8449190622bf9de4108ee?source=copy_link



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new subsection, “Support for custom sign-in pages,” to the SvelteKit SDK backend docs.
  - Explains building a custom login screen by appending login_hint and connection_id to the login URL.
  - Includes an HTML example showing a sign-in link using these parameters and outlines expected behavior.
  - No functional changes; content-only addition to guide implementing tailored sign-in experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->