### PR TITLE
Update about-enterprise-connections.mdx

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -58,7 +58,14 @@ Many businesses have businesses for customers (B2B), and use Kinde organizations
 
 ## Session sign out behavior 
 
-When enterprise connection users sign out, they are only signed out of the Kinde session, they are not signed out of the identity provider. We do not force sign out of the IdP because this could break existing sessions the user is signed into, for other applications. This behavior also applies for social connections, where a third party is the identity provider.
+Unless you are using a Microsoft Entra ID SAML connection with single logout switched on, when enterprise connection users sign out, they are only signed out of the Kinde session and are not signed out of the identity provider. We do not force sign out of the IdP because this could break existing sessions the user is signed into, for other applications. This behavior also applies for social connections, where a third party is the identity provider.
+
+## Trust email addresses provided by this connection option
+
+When you set up a connection, you can choose to trust email addresses provided by the identity provider you are using, e.g. your SAML provider.
+
+- If you switch this on - Kinde will look for a user with the same email address and match the record as part of authentication. This can make for a more seamless sign in experience.
+- If you do not switch this on - Kinde does not try to match the user's email to an existing account, even if one exists. Instead, a new user identity is created in Kinde. 
 
 ## Routing in enterprise connections
 


### PR DESCRIPTION
Added clear info about what the trusted provider switch does in enterprise connections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise Connections guide to clarify session sign-out behavior, adding an exception for Microsoft Entra ID SAML connections when single logout is enabled.
  * Added a new section explaining the “Trust email addresses provided by this connection” option, detailing outcomes when enabled versus disabled.
  * Improves configuration clarity for logout flows and email trust handling, helping admins make informed setup decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->