### PR TITLE
Fixes on enabling/disabling organization instruction and self-serve portal link 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3430,16 +3430,6 @@
         "win32"
       ]
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",

--- a/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
+++ b/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
@@ -92,8 +92,17 @@ This is the process for end-users to make the connection live. It can also be en
 
 ## Enable or disable a connection
 
+### Disable a connection
+
 1. Navigate to the self-serve portal and select **SSO**.
-2. Select the three dots menu on the connection card, and choose **Enable** or **Disable**.
+2. Select the **three dots** menu on the connection card, and choose **Disable connection**.
+3. Hit **Disable connection** to complete the action.
+
+### Enable a connection
+
+1. Navigate to the self-serve portal and select **SSO**.
+2. Select the **three dots** menu on the connection card, and click **Edit**.
+3. Scroll to **Enable for organization**, then click **Save**.
 
 ## Delete a connection
 

--- a/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
+++ b/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
@@ -96,13 +96,14 @@ This is the process for end-users to make the connection live. It can also be en
 
 1. Navigate to the self-serve portal and select **SSO**.
 2. Select the **three dots** menu on the connection card, and choose **Disable connection**.
-3. Hit **Disable connection** to complete the action.
+3. Hit **Disable connection** button to complete the action.
 
 ### Enable a connection
 
 1. Navigate to the self-serve portal and select **SSO**.
 2. Select the **three dots** menu on the connection card, and click **Edit**.
-3. Scroll to **Enable for organization**, then click **Save**.
+3. Scroll to **Enable for organization**, toggle it on
+4. Click **Save** to apply the changes.
 
 ## Delete a connection
 

--- a/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
+++ b/src/content/docs/authenticate/self-serve-sso/add-sso-self-serve.mdx
@@ -39,7 +39,7 @@ Your business customers who have their own organizations in Kinde can set up and
 
 ## Before an organization can set up an SSO connection
 
-- Ensure that you have switched on the option in the [self-serve portal settings](/build/self-service-portal/self-serve-portal-for-orgs/)
+- Ensure that you have switched on the option in the [self-serve portal settings](/build/set-up-options/self-serve-portal-for-orgs/)
 - Check that the person setting up the connection has the [right role and permissions](/manage-users/roles-and-permissions/user-roles/). They need to be an Admin.
 - Add a domain to the verified domains list for the org (see below). Connections can only be set up for verified domains.
 

--- a/src/content/docs/authenticate/self-serve-sso/manage-self-serve-connections.mdx
+++ b/src/content/docs/authenticate/self-serve-sso/manage-self-serve-connections.mdx
@@ -69,7 +69,7 @@ You might need to disable a connection if you think it has been compromised or a
 1. Open the organization for the customer.
 2. In the left menu, select **Authentication**.
 3. On the connection card, click **Configure**.
-4. Scroll to the **Enable for organization** section.
+4. Scroll to the **Enable for organization** section, and toggle it on.
 5. Click **Save**.
 
 ## Delete a connection

--- a/src/content/docs/authenticate/self-serve-sso/manage-self-serve-connections.mdx
+++ b/src/content/docs/authenticate/self-serve-sso/manage-self-serve-connections.mdx
@@ -58,9 +58,19 @@ If a customer can't sign in using the SSO connection they set up, check these th
 
 You might need to disable a connection if you think it has been compromised or at the customer's request.
 
+### Disable a connection
+
 1. Open the organization for the customer.
 2. In the left menu, select **Authentication**. The customer's connections are shown.
-3. Select the three dots menu on the connection card, and choose **Enable** or **Disable**.
+3. Select the **three dots** menu on the connection card, and choose **Disable**.
+
+### Enable a connection
+
+1. Open the organization for the customer.
+2. In the left menu, select **Authentication**.
+3. On the connection card, click **Configure**.
+4. Scroll to the **Enable for organization** section.
+5. Click **Save**.
 
 ## Delete a connection
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

This PR updates and corrects two instruction sections related to enabling SSO setup for self-serve-sso and corrects a link to the self-serve portal referred to in `add-sso-self-serve.mdx`.

**Changes made:**
- Revised the steps under Enable or disable a connection in `manage-self-serve-connections.mdx` and `add-sso-self-serve.mdx` for accuracy and clarity.
- Updated the **self-serve portal settings** link to point to the correct page:  
  `/build/set-up-options/self-serve-portal-for-orgs/` in `add-sso-self-serve.mdx`