### PR TITLE
fix: document getToken vs getAccessToken and silent refresh (gap report)

### DIFF
--- a/src/content/docs/build/tokens/refresh-tokens.mdx
+++ b/src/content/docs/build/tokens/refresh-tokens.mdx
@@ -31,7 +31,7 @@ keywords:
   - session management
   - token security
   - auto-update
-updated: 2026-03-26
+updated: 2026-04-03
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to refresh tokens including how they work, implementation with offline scope, token rotation, security best practices, and SDK integration.
@@ -122,7 +122,11 @@ You should store the refresh token you get with your initial `/token` request. O
 
 ## Use the SDK `getToken` function to silently refresh tokens
 
-If you’re using a front-end SDK like [JavaScript](/developer-tools/sdks/frontend/javascript-sdk/) or [React](/developer-tools/sdks/frontend/react-sdk/), the `getToken` function stores an in-memory cache of the access token, which it returns by default. If the token is about to expire it will use a refresh token to get a new access token from Kinde silently in the background so additional network requests to Kinde are only made when absolutely necessary.
+Front-end packages do **not** all behave the same way:
+
+- **[JavaScript (PKCE) SDK](/developer-tools/sdks/frontend/javascript-sdk/):** `getToken()` uses the cached access token when it is still considered active; otherwise it **attempts a silent refresh** via the refresh token before resolving. On failure it returns **`undefined`** (it does not throw). See [When does the JavaScript SDK refresh access tokens in the background?](/developer-tools/sdks/frontend/javascript-sdk/#when-does-the-javascript-sdk-refresh-access-tokens-in-the-background) and [Does getToken throw or return an error object when refresh fails?](/developer-tools/sdks/frontend/javascript-sdk/#does-gettoken-throw-or-return-an-error-object-when-refresh-fails).
+
+- **[React SDK](/developer-tools/sdks/frontend/react-sdk/):** Use **`getAccessToken()`** on the hook. It **only reads** the cached JWT from session storage and **does not** refresh it. Silent refresh runs on provider init, on a **pre-expiry timer** (about **10 seconds** before access token expiry by default), and optionally when **`refreshOnFocus`** is enabled; when those succeed, the next `getAccessToken()` reads the updated value. See [Does getAccessToken throw or return an error object when something goes wrong?](/developer-tools/sdks/frontend/react-sdk/#does-getaccesstoken-throw-or-return-an-error-object-when-something-goes-wrong) and [When does the React SDK refresh tokens silently?](/developer-tools/sdks/frontend/react-sdk/#when-does-the-react-sdk-refresh-tokens-silently).
 
 ## How long does a refresh token last?
 

--- a/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
@@ -33,7 +33,7 @@ keywords:
   - organizations
   - access tokens
   - JWT
-updated: 2026-04-01
+updated: 2026-04-03
 featured: false
 deprecated: false
 ai_summary: Complete guide for JavaScript SDK including PKCE authentication, login/register flows, organization management, and API integration for single-page applications.
@@ -225,6 +225,9 @@ The `getToken` method lets you securely call your API and pass the bearer token 
 (async () => {
   try {
     const token = await kinde.getToken();
+    if (!token) {
+      return;
+    }
     const response = await fetch(YOUR_API, {
       headers: new Headers({
         Authorization: "Bearer " + token
@@ -519,7 +522,9 @@ kinde.getClaim("given_name", "id_token");
 // {name: "given_name", "value": "David"}
 ```
 
-## **Persisting authentication state on page refresh or new tab**
+## JavaScript SDK FAQs
+
+### How to prevent authentication state from being lost on page refresh or new tab?
 
 You will find that when you refresh the browser while using a front-end SDK, the authentication state is lost. This is because there is no secure way to persist this in the front-end.
 
@@ -530,7 +535,7 @@ There are two ways to work around this.
 
 Once you implement one of the above, you don’t need to do anything else.
 
-## **Persisting application state**
+### How to persist application state after authentication?
 
 The options argument passed into the `login` and `register` methods accepts an `app_state` key where you can pass in the current application state prior to redirecting to Kinde. This is then returned to you in the second argument of the `on_redirect_callback` as seen above.
 
@@ -561,7 +566,7 @@ const kinde = await createKindeClient({
 });
 ```
 
-## Token storage in the authentication state
+### How to store the refresh token in the authentication state?
 
 By default the JWTs provided by Kinde are stored in memory. This protects you from both [CSRF](https://owasp.org/www-community/attacks/csrf) attacks (possible if stored as a client-side cookie) and [XSS](https://owasp.org/www-community/attacks/xss/) attacks (possible if persisted in local storage).
 
@@ -578,6 +583,19 @@ const kinde = await createKindeClient({
   is_dangerously_use_local_storage: true
 });
 ```
+
+### When does the JavaScript SDK refresh access tokens in the background?
+
+The PKCE client refreshes the access token in two main situations:
+
+- **Initial load:** If you use Kinde’s **httpOnly cookie** refresh flow (custom domain) or local storage for the refresh token (`is_dangerously_use_local_storage`), initialization may call the token endpoint to restore a session.
+- **When you call `getToken()` or `getIdToken()`:** If the cached access token is missing or the SDK treats it as no longer active (it uses a **short buffer before the JWT `exp`** so the token is refreshed before it actually expires), the client attempts a refresh using the refresh token.
+
+The [React SDK](/developer-tools/sdks/frontend/react-sdk/) uses `@kinde/js-utils` for additional timer- and focus-driven refresh on the provider. With this JavaScript client, calling `getToken()` before API requests is the reliable way to obtain a token that has been refreshed when needed.
+
+### Does getToken throw or return an error object when refresh fails?
+
+No. `getToken()` resolves to **`Promise<string | undefined>`**. You receive the JWT string on success and **`undefined`** if the token cannot be obtained (for example, refresh failed or there is no refresh token). It **does not throw** for those cases and **does not** return a structured error object. Always check for a missing value before using the token in an `Authorization` header.
 
 ## API References - createKindeClient
 
@@ -794,9 +812,9 @@ redirect;
 
 ### `getToken`
 
-Returns the raw access token from memory.
+Returns the access token JWT. If the cached token is missing or inactive, the client **attempts a silent refresh** via the refresh token before resolving.
 
-Type: `Promise<string | undefined>`
+Type: `Promise<string | undefined>` — JWT string on success, **`undefined`** if no token can be returned. Failures **do not throw** and **do not** yield an error object.
 
 Usage:
 
@@ -811,6 +829,8 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4
 ```
 
 Use the [Kinde Online JWT decoder](https://www.kinde.com/tools/online-jwt-decoder/?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c) to decode this token.
+
+For background refresh timing and the difference from the React SDK’s `getAccessToken()`, see [When does the JavaScript SDK refresh access tokens in the background?](#when-does-the-javascript-sdk-refresh-access-tokens-in-the-background) and [Does getToken throw or return an error object when refresh fails?](#does-gettoken-throw-or-return-an-error-object-when-refresh-fails).
 
 ### `getIdToken`
 

--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -32,7 +32,7 @@ keywords:
   - register
   - logout
   - access tokens
-updated: 2026-01-30
+updated: 2026-04-03
 featured: false
 deprecated: false
 ai_summary: Complete guide for React SDK including installation, provider setup, authentication hooks, callback handling, and API integration for React 18+ applications.
@@ -621,6 +621,9 @@ const { getAccessToken } = useKindeAuth();
 const fetchData = async () => {
   try {
     const accessToken = await getAccessToken();
+    if (!accessToken) {
+      return;
+    }
     const res = await fetch(`<your-api>`, {
       headers: {
         Authorization: `Bearer ${accessToken}`
@@ -852,7 +855,9 @@ await getClaim("given_name", "idToken");
 // {name: "given_name", "value": "David"}
 ```
 
-## Persisting authentication state on page refresh or new tab
+## React SDK FAQs
+
+### How to prevent authentication state from being lost on page refresh or new tab?
 
 You will find that when you refresh the browser using a front-end based SDK that the authentication state is lost. This is because there is no secure way to persist this in the front-end.
 
@@ -865,7 +870,7 @@ Once you implement one of the above, you don’t need to do anything else.
 
 <YoutubeVideo videoId="5_8jlrepCkI"/>
 
-## Persisting application state
+### How to persist application state after authentication?
 
 The options argument passed into the `login` and `register` methods accepts a `state` key where you can pass in the current application state prior to redirecting to Kinde. This is then returned to you in the second argument of the `onSuccess` callback as seen above.
 
@@ -899,7 +904,7 @@ Redirect handler:
 >
 ```
 
-## Token storage in the authentication state
+### How to store the refresh token in the authentication state?
 
 By default the JWTs provided by Kinde are stored in memory. This protects you from both [CSRF](https://owasp.org/www-community/attacks/csrf) attacks (possible if stored as a client-side cookie) and [XSS](https://owasp.org/www-community/attacks/xss/) attacks (possible if persisted in local storage).
 
@@ -915,6 +920,24 @@ The trade-off with this approach, however, is that if a page is refreshed or a n
   ...
 >
 ```
+
+### Does getAccessToken read storage only, or does it refresh the token?
+
+It **only reads** session storage. **`getAccessToken()`** returns whatever access token JWT is currently cached—**including if it is expired**—and it **does not** call Kinde’s token endpoint. To **force** a refresh before calling your API, use **`refreshToken()`** from `useKindeAuth()`.
+
+### When does the React SDK refresh tokens silently?
+
+Silent refresh is handled by **`@kinde/js-utils`** while the user stays on your app:
+
+- **Provider initialization:** **`checkAuth`** runs on load and may refresh when the access token is expired or within about **10 seconds** of expiry.
+- **After sign-in:** A timer schedules refresh about **10 seconds before** the access token expires. This automatic refresh is **on by default** for sessions established through the SDK’s auth flows.
+- **Returning to the tab (optional):** Set **`refreshOnFocus={true}`** on **`KindeProvider`** so a refresh is attempted when the document becomes visible again.
+
+The cache that **`getAccessToken()`** reads is updated when those flows succeed. For more detail on the JavaScript (PKCE) client’s different `getToken()` behavior, see the [JavaScript SDK](/developer-tools/sdks/frontend/javascript-sdk/#when-does-the-javascript-sdk-refresh-access-tokens-in-the-background).
+
+### Does `getAccessToken` throw or return an error object when something goes wrong?
+
+No. **`getAccessToken()`** resolves to **`Promise<string | undefined>`**. You get the JWT when a value exists in storage and **`undefined`** when there is nothing to read (for example, the user is signed out). It **does not throw** and **does not** return an error object for refresh failures, because it **does not perform refresh**. Use **`refreshToken()`** when you need an explicit refresh and handle its outcome separately.
 
 ## API References - KindeProvider
 
@@ -953,6 +976,16 @@ Required: No
 ### `useInsecureForRefreshToken`
 
 An escape hatch for storing the refresh in local storage for local development.
+
+Type: `boolean`
+
+Required: No
+
+Default: `false`
+
+### `refreshOnFocus`
+
+When **`true`**, the SDK attempts a **token refresh** when the browser tab or window becomes visible again (`visibilitychange` to visible). Use this if users leave your app open in the background and you want to reduce the chance they call your API with an expired JWT before the scheduled pre-expiry refresh runs.
 
 Type: `boolean`
 
@@ -1158,7 +1191,9 @@ Output:
 
 ### `getAccessToken`
 
-Returns the raw Access token from memory. This is the recommended method for accessing tokens.
+Returns the raw access token JWT **from session storage** (memory or configured store). This is the recommended hook method for reading the token to call your API.
+
+Type: `Promise<string | undefined>` — the cached JWT, or **`undefined`** if none is stored. This method **does not refresh** the token; the value may be **expired**. It **does not throw** and **does not** return an error object. See [Does getAccessToken read storage only, or does it refresh the token?](#does-getaccesstoken-read-storage-only-or-does-it-refresh-the-token) and [When does the React SDK refresh tokens silently?](#when-does-the-react-sdk-refresh-tokens-silently).
 
 Usage:
 
@@ -1206,7 +1241,7 @@ eyJhbGciOiJIUzI1NiIsInR5c...
 
 **Deprecated:** Use [getAccessToken](#getaccesstoken) instead.
 
-Returns the raw Access token from memory.
+Same behavior as **`getAccessToken`**: a **storage read** only, **`Promise<string | undefined>`**, no refresh, no thrown errors, no error object.
 
 Usage:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `refreshOnFocus` option to React provider (default: false) to optionally trigger silent token refresh when tab becomes visible.

* **Documentation**
  * Clarified JavaScript and React SDK token behavior: token-read APIs return Promise<string | undefined> (do not throw), background silent refresh timing (~10s before expiry) and optional focus-triggered refresh documented.
  * Example snippets now guard against missing tokens to avoid unauthenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->