### PR TITLE
fix: webhook multi-endpoint order and SSO inactivity docs (gap report)

### DIFF
--- a/src/content/docs/authenticate/manage-authentication/session-management-per-organization.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management-per-organization.mdx
@@ -18,7 +18,7 @@ metadata:
   audience: [developer, enterprise-admin, product-manager]
   complexity: intermediate
   keywords: [organization session management, SSO session, session cookies, inactivity timeout, enterprise auth]
-  updated: 2025-01-16
+  updated: 2026-04-03
 featured: false
 deprecated: false
 ---
@@ -29,7 +29,7 @@ You may need to upgrade your plan to use this feature
 
 </Aside>
 
-If you are on the Kinde Scale plan, you can change Kinde authenticated session configuration at the organization level as well as the environment level. An authenticated session (or SSO session) is the time during which a user is authenticated via Kinde, regardless of their activity. You can define if a session persists even after a browser is closed, and how long can lapse before making the organization's user re-authenticate.
+If you are on the Kinde Scale plan, you can change Kinde authenticated session configuration at the organization level as well as the environment level. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting the organization’s users to re-authenticate.
 
 These settings only apply to Kinde sessions and not sessions you maintain through your own application.
 
@@ -49,6 +49,10 @@ When you change session settings at the organization level, this overrides sessi
 5. When you're finished, select **Save**.
 
 The session settings will now be applied to members of this organization.
+
+## What counts as activity for SSO session inactivity?
+
+Organization-level **Session inactivity timeout** follows the **same rules** as environment-level session settings. For what Kinde treats as activity (including how token refresh and API traffic relate to the timer), see [Session management](/authenticate/manage-authentication/session-management/).
 
 ## Manage organization session behavior via API
 

--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -15,12 +15,12 @@ metadata:
   audience: [developer, product-manager]
   complexity: intermediate
   keywords: [session management, SSO session, session cookies, inactivity timeout, browser session]
-  updated: 2025-01-16
+  updated: 2026-04-03
 featured: false
 deprecated: false
 ---
 
-You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the time during which a user is authenticated via Kinde, regardless of their activity. You can define if a session persists even after a browser is closed, and how long can lapse before making a user re-authenticate.
+You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.
 
 These settings only apply to Kinde sessions and not sessions you maintain through your own application.
 If you want, you can [change session settings for an organization](/authenticate/manage-authentication/session-management-per-organization/), without affecting other organizations. 
@@ -38,3 +38,11 @@ If you want, you can [change session settings for an organization](/authenticate
 4. In the **SSO sessions** section, decide on the policy for session cookies. A persistent session leaves the cookie active when the browser is closed. A non-persistent session is terminated when the browser window closes (unless the limitations listed above apply). 
 5. In the **Session inactivity timeout** section, set how long a session can be inactive before prompting re-authentication. This setting is applied in seconds - where 3,600 seconds is one hour; 86,400 seconds is one day.
 6. When you're finished, select **Save**.
+
+## What counts as activity for SSO session inactivity?
+
+Kinde measures inactivity **on the server**. Browsing your own app—switching pages or using the UI—does not reset the timer **unless** that work leads to **authenticated calls to Kinde** for the signed-in user. **Token refresh** is a familiar example: when your app or SDK exchanges a refresh token at Kinde, that interaction can count as activity for this timeout.
+
+There is **no public list of every action** that resets inactivity. In practice, treat **authenticated, end-user-facing traffic to Kinde** as the model, rather than assuming every client-side event is visible to Kinde.
+
+**Machine-to-machine (M2M)** integrations and the **Management API** use separate credentials and contexts. They are **not** equivalent to activity on a specific person’s browser SSO session when you interpret this setting.

--- a/src/content/docs/build/tokens/configure-tokens.mdx
+++ b/src/content/docs/build/tokens/configure-tokens.mdx
@@ -30,7 +30,7 @@ keywords:
   - refresh tokens
   - access tokens
   - ID tokens
-updated: 2026-03-26
+updated: 2026-04-03
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide for configuring token and session expiry times including security best practices, token lifetime management, and risk mitigation strategies for different token types.
@@ -59,7 +59,7 @@ You can define the lifetime (expiry time) of ID tokens, access tokens, refresh t
 - **ID Tokens**: Contain identity information about a user. These do not need to last long as identity info is only needed at the moment of authentication, and is unrelated to session lifetimes.
 - **Access tokens**: Contain access permissions for a user during authentication. These are the most vulnerable token for attacks, and we do not recommend extending the access token lifetime beyond 1 day.
 - **Refresh tokens**: Are issued at the same time as an access token, and extend a user's session without them having to reauthenticate. If you want a user to stay authenticated without having to sign in daily or more frequently - set a high lifetime for refresh tokens.
-- **Session inactivity timeout**: A user can be requested to re-authenticate if they do not sustain activity in the current session. We recommend setting a fairly short limit  for inactivity - e.g. up to one day. If you extend the session inactivity timeout, a user's data may become vulnerable, for example if they sign in on a public device and forget to sign out. 
+- **Session inactivity timeout**: After a period with no **server-visible** activity on the user’s Kinde SSO session, the user may need to sign in again. Local navigation in your app does not reset the timer on its own; activity usually means **authenticated requests from your app to Kinde** for that user (for example, during token refresh). See [Session management](/authenticate/manage-authentication/session-management/) for a full explanation. We recommend a fairly short limit (for example, up to one day).
 
 Token and session expiry should be approached with priority for system and user security. The aim is to reduce risks such as:
 - Token theft through man-in-the-middle attacks

--- a/src/content/docs/integrate/webhooks/about-webhooks.mdx
+++ b/src/content/docs/integrate/webhooks/about-webhooks.mdx
@@ -30,7 +30,7 @@ keywords:
   - security
   - retry policy
   - endpoints
-updated: 2026-02-04
+updated: 2026-04-03
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to Kinde webhooks including event monitoring, security best practices, JWT handling, and retry policies for real-time notifications.
@@ -205,6 +205,10 @@ Webhooks that fail consistently for 72 hours are automatically disabled, and you
 ## Does Kinde support organization-scoped webhooks?
 
 No. Kinde does not support organization-scoped webhooks. You cannot configure different webhook endpoints per organization (tenant) within the same environment. Webhooks can only be configured at the environment level.
+
+## Do multiple webhook endpoints for the same event run in a defined order?
+
+No. Kinde delivers webhooks using an **asynchronous job** model. If you register **more than one endpoint** for the **same event**, delivery work is typically **queued per endpoint** and may run **in parallel or near-parallel**. **Order between endpoints is not guaranteed**—do not rely on one endpoint being called before another. Make handlers **idempotent** (see **Webhooks security** and **Webhooks best practices** above) so retries and unordered deliveries do not corrupt your data.
 
 ## Next steps
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SSO session definitions and session inactivity timeout behavior across authentication documentation
  * Added guidance on what constitutes server-side activity for session inactivity timeout detection
  * Documented webhook endpoint execution behavior and ordering for multiple endpoints handling the same event

<!-- end of auto-generated comment: release notes by coderabbit.ai -->