### PR TITLE
feat: billing free trials feature doc + tax information

### DIFF
--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -17,8 +17,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: beginner
-  keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions, trial]
-  updated: 2026-04-07
+  keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions, trial, tax, VAT, sales tax, invoicing]
+  updated: 2026-04-08
 featured: false
 deprecated: false
 ---
@@ -39,13 +39,11 @@ As part of using this feature, you can:
 
 Billing makes the Kinde platform _the_ essential development infrastructure for managing the customer lifecycle across every part of your business. From registration to plan selection, authorization to provisioning, releases to upgrades.
 
-## This is our first billing release
+## How is sales tax or VAT handled in Kinde billing?
 
-Billing is a really complex area of app development, so while this release is tested and ready, we are actively working on improvements from day one.
+Subscription charges and invoices are processed through **Stripe** as part of Kinde billing. How tax is calculated, shown on invoices, and collected depends on your **Stripe account** configuration—for example tax registrations, [Stripe Tax](https://stripe.com/tax), and invoice settings—not on separate tax controls in the Kinde plan builder.
 
-### How to send feedback
-
-It would be amazing if you can send any feedback you have [support@kinde.com](mailto:support@kinde.com) so we can quickly collect and prioritize improvements.
+Use the Stripe Dashboard for your connected account to align tax behavior with your regions and compliance needs (including whether prices are tax-inclusive or tax-exclusive). If you need help mapping this to your Kinde plans, contact [support@kinde.com](mailto:support@kinde.com).
 
 ## Known limitations
 
@@ -54,3 +52,11 @@ These are current limitations that we are aware of and are working on adding.
 - Custom billing intervals (e.g., quarterly) are not supported. Fixed charges are limited to daily, weekly, monthly, or yearly intervals.
 - Changes to the billing cycle (e.g. choose billing anniversaries, etc.)
 - Add-ons and discounts that can be applied to individual subscriptions
+
+## This is our first billing release
+
+Billing is a really complex area of app development, so while this release is tested and ready, we are actively working on improvements from day one.
+
+### How to send feedback
+
+It would be amazing if you can send any feedback you have [support@kinde.com](mailto:support@kinde.com) so we can quickly collect and prioritize improvements.

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -18,7 +18,7 @@ metadata:
   audience: [developer, product-manager, business-owner]
   complexity: beginner
   keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions, trial, tax, VAT, sales tax, invoicing]
-  updated: 2026-04-08
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -59,4 +59,4 @@ Billing is a really complex area of app development, so while this release is te
 
 ### How to send feedback
 
-It would be amazing if you can send any feedback you have [support@kinde.com](mailto:support@kinde.com) so we can quickly collect and prioritize improvements.
+We’d appreciate your feedback—please send it to [support@kinde.com](mailto:support@kinde.com) so we can quickly collect and prioritize improvements.

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -17,8 +17,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: beginner
-  keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions]
-  updated: 2025-01-16
+  keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions, trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -30,6 +30,7 @@ As part of using this feature, you can:
 - Create and manage plans, and make them visible to your customers
 - Create and customize a pricing table for plan selection
 - Implement specific pricing models to suit your product
+- Offer free trial periods that automatically convert to paid subscriptions
 - Use Stripe for secure handling of payments and invoicing
 - Link organizations (B2B) and individual customers (B2C) to a plan
 - Handle plan upgrade, downgrade, and cancellation
@@ -50,7 +51,6 @@ It would be amazing if you can send any feedback you have [support@kinde.com](ma
 
 These are current limitations that we are aware of and are working on adding.
 
-- Support for plan models with free trial periods
 - Custom billing intervals (e.g., quarterly) are not supported. Fixed charges are limited to daily, weekly, monthly, or yearly intervals.
 - Changes to the billing cycle (e.g. choose billing anniversaries, etc.)
 - Add-ons and discounts that can be applied to individual subscriptions

--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -13,8 +13,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: beginner
-  keywords: [billing concepts, plan groups, features, pricing models, metered usage, fixed charges, billing interval, offer as annual, multi-currency]
-  updated: 2025-11-27
+  keywords: [billing concepts, plan groups, features, pricing models, metered usage, fixed charges, billing interval, offer as annual, multi-currency, trial, trial period, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -31,6 +31,7 @@ deprecated: false
 - **Plan groups** - Plan groups organize multiple plans under a common category, helping segment offerings by use case, customer size, or market. A group is scoped to either organizations (B2B) or individual customers (B2C). You can have multiple plan groups, but each plan must belong to a group.
 - **Plans** - Plans define the specific features, usage limits, and pricing tiers offered to customers in a SaaS product.
 - **Plan settings** - Configuration options that control subscription behavior, such as whether to require credit card details during signup. The "Ask for credit card" setting allows free plans to skip payment collection for a frictionless experience.
+- **Trial period** - An optional setting on paid plans that lets customers try the plan for a set number of days before being charged. During the trial, the customer has full access to the plan's features. Kinde creates the trial using Stripe's subscription trial. Plans with a trial enabled show a badge on the pricing table.
 - **Features** - Plan features are the specific capabilities or entitlements included in a plan. They can be chargeable (incurring additional fees) or non-chargeable (included at no extra cost). Features can be metered (usage-based) or unmetered (fixed access).
 - **Fixed charges** – Single chargeable items like the subscription base price and other standalone recurring charges. You can set billing intervals (daily, weekly, monthly, or yearly) and optionally offer one charge per plan as annual at a custom yearly price.
 - **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, per-seat pricing, etc. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when deciding this.
@@ -45,6 +46,7 @@ deprecated: false
 - **Chargeable / Non-chargeable feature** –
   - **Chargeable feature**: Incurs an additional fee when used. Might be metered or per unit price.
   - **Non-chargeable feature**: Add non-chargeable features for any included features which aren't independently chargeable, but need to be gated in your product.
+- **Credit card prompt (trial)** – The number of days before a trial ends when the customer is prompted to add payment details. This helps ensure payment information is collected before the trial expires and the subscription converts to a paid subscription.
 - **Feature** – A specific function or capability of your SaaS product that you provision for app users. In context with a plan, these are chargeable or non-chargeable features that are provisioned to customers.
 - **Fixed charge** – A recurring fee that does not change based on usage. You can bill at daily, weekly, monthly, or yearly intervals. Use this for a plan’s base price or other flat recurring fees. Optionally, one fixed charge per plan can be offered as annual at a predefined yearly price.
 - **Metered and unmetered feature** – Metered features are provisioned in units, often with pricing per unit, e.g. MAU. An unmetered feature is like a boolean, and is a basic feature with no pricing attached.
@@ -54,5 +56,18 @@ deprecated: false
 - **Pricing model** – The structure used to determine how features in a plan are priced. E.g. fixed charge, tiered, per-user, or usage-based pricing. Kinde lets you use multiple pricing models within one plan.
 - **Subscription** – The ongoing agreement where a customer pays for access to a SaaS product via a recurring plan. This is referred to as an agreement in Stripe.
 - **Tiered pricing** – This refers to unit pricing that has different unit costs based on the volume of units purchased. E.g. $10 per unit for 1–10 units, $8 per unit for 11–50 units, $5 per unit over 51 units.
+- **Trial expires on** – The date and time when a customer's trial period ends. This value is available in billing-related access token claims as `trial_expires_on` when a trial is active.
+- **Trial period** – A configurable window of time during which a customer can use a paid plan for free. At the end of the trial, the subscription automatically converts to a paid subscription via Stripe. Trial length is set in days.
 - **Unit price** – Where a price is set per unit of usage, e.g. a seat or license. Unit prices can also be applied to metered features, e.g. x per unit. Unit prices can also be tiered, e.g. x per unit up to 10 units, then y for 10+ units.
 - **Usage-based** **price** – A billing method where charges vary based on the metered consumption of resources or services (e.g., API calls, storage).
+
+## What trial-related claims appear in access tokens?
+
+When a customer is on a plan with Kinde billing trials enabled, access tokens can include the following billing trial fields:
+
+| Claim | Type | Description |
+| --- | --- | --- |
+| `has_trial_period` | boolean | Whether the customer's current plan includes an active trial period |
+| `trial_expires_on` | string (ISO 8601 datetime) | The date and time when the trial period ends. Typically present when `has_trial_period` is `true` |
+
+For general access token structure, see [Access tokens](/build/tokens/about-access-tokens/).

--- a/src/content/docs/billing/about-billing/billing-faq.mdx
+++ b/src/content/docs/billing/about-billing/billing-faq.mdx
@@ -16,8 +16,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner, support]
   complexity: beginner
-  keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support]
-  updated: 2025-11-27
+  keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support, trial, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -115,11 +115,16 @@ Yes, Kinde allows you to configure whether credit card collection is required fo
 <details>
 <summary>Can I set up free trial periods that automatically convert to paid plans?</summary>
 
-Not yet. Kinde billing does not currently support built-in free trial periods or automatic trial-to-paid conversion logic.
+Yes. Kinde billing supports free trial periods on paid plans. When you enable a trial on a plan, customers can use the plan for a configurable number of days before being charged. At the end of the trial, the subscription automatically converts to a paid subscription via Stripe.
 
-If you need trial-like onboarding today, create a free plan and then move customers to a paid plan through your upgrade flow (self-serve or API), with reminder emails or in-app prompts before upgrade.
+You configure trials in plan settings:
 
-**Learn more:** [About plans](/billing/manage-plans/about-plans/) | [Top questions about Kinde billing](/billing/about-billing/kinde-billing-faqs/)
+- **Trial length** — how many days the trial lasts (default 30, minimum 1).
+- **Credit card prompt** — how many days before the trial ends to prompt the customer for payment details (default 3).
+
+Plans with a trial display a "Free trial for N day(s)" badge on the pricing table. The **Ask for credit card** option must be on for trial plans.
+
+**Learn more:** [Create plans — Configure trial period](/billing/manage-plans/create-plans/#configure-trial-period)
 </details>
 
 ## Payment Processing & Management

--- a/src/content/docs/billing/about-billing/billing-faq.mdx
+++ b/src/content/docs/billing/about-billing/billing-faq.mdx
@@ -17,7 +17,7 @@ metadata:
   audience: [developer, product-manager, business-owner, support]
   complexity: beginner
   keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support, trial, free trial, tax, VAT]
-  updated: 2026-04-08
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---

--- a/src/content/docs/billing/about-billing/billing-faq.mdx
+++ b/src/content/docs/billing/about-billing/billing-faq.mdx
@@ -16,8 +16,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner, support]
   complexity: beginner
-  keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support, trial, free trial]
-  updated: 2026-04-07
+  keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support, trial, free trial, tax, VAT]
+  updated: 2026-04-08
 featured: false
 deprecated: false
 ---
@@ -128,6 +128,14 @@ Plans with a trial display a "Free trial for N day(s)" badge on the pricing tabl
 </details>
 
 ## Payment Processing & Management
+
+<details>
+<summary>How is tax (sales tax or VAT) handled in Kinde billing?</summary>
+
+Kinde billing does not provide separate tax settings in the plan builder. Payments and invoices are processed through your connected **Stripe** account, so tax behavior depends on how you configure **Stripe**—for example registrations, Stripe Tax, and invoice settings. Use the Stripe Dashboard to set this up for the regions where you sell.
+
+**Learn more:** [About billing](/billing/about-billing/about-billing/) | [Manage Stripe connection](/billing/payment-management/manage-stripe-connection/)
+</details>
 
 <details>
 <summary>What payment methods does Kinde support through Stripe?</summary>

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -13,7 +13,7 @@ metadata:
   audience: [frontend-developer]
   complexity: beginner
   keywords: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe]
-  updated: 2026-03-13
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ai-summary: >
@@ -79,6 +79,15 @@ Draft plans can be updated freely without affecting subscribers. When a plan is 
 
 Yes, when creating or editing a plan, you'll find an **Ask for credit card** toggle in the Plan settings section. For plans with no charges, you can disable this toggle so users can subscribe without entering payment information. This is great for reducing friction on free tiers. However, if your plan includes any fixed charges or metered/usage-based billing, credit card collection is always required regardless of this setting.
 [Create and configure plans](/billing/manage-plans/create-plans/) | [About plans](/billing/manage-plans/about-plans/)
+</details>
+
+<details>
+<summary><strong>How do I offer a free trial period on a Kinde billing plan?</strong></summary>
+
+Enable the trial period toggle in the plan settings when creating or editing a plan. Set the trial length in days and configure how many days before the trial ends to prompt for payment details. When a trial is enabled, customers can use the plan without being charged until the trial ends, at which point their subscription automatically converts to a paid subscription via Stripe.
+
+Trial plans require the **Ask for credit card** option to be enabled. Plans with an active trial display a "Free trial for N day(s)" badge on the pricing table.
+[Configure trial periods](/billing/manage-plans/create-plans/#configure-trial-period) | [About plans](/billing/manage-plans/about-plans/)
 </details>
 
 ## Stripe integration
@@ -224,7 +233,7 @@ Start by reviewing billing history in the organization portal to verify charge t
 <details>
 <summary><strong>What are current Kinde billing limitations?</strong></summary>
 
-Current limitations include custom billing period support (forthnightly, etc.), no free-trial option, and limited plan-versioning options. Workarounds include annual-equivalent plans and free-plan onboarding with upgrade automation. Share product feedback through support channels to help prioritize roadmap improvements.
+Current limitations include custom billing period support (fortnightly, etc.) and limited plan-versioning options. Workarounds include annual-equivalent plans. Share product feedback through support channels to help prioritize roadmap improvements.
 [Current billing limitations](/billing/manage-plans/about-plans/) | [Alternative approaches](/billing/pricing/pricing-models/)
 </details>
 

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -13,7 +13,7 @@ metadata:
   audience: [frontend-developer]
   complexity: beginner
   keywords: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe, tax, VAT]
-  updated: 2026-04-08
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ai-summary: >

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -12,8 +12,8 @@ metadata:
   topics: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe]
   audience: [frontend-developer]
   complexity: beginner
-  keywords: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe]
-  updated: 2026-04-07
+  keywords: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe, tax, VAT]
+  updated: 2026-04-08
 featured: false
 deprecated: false
 ai-summary: >
@@ -91,6 +91,13 @@ Trial plans require the **Ask for credit card** option to be enabled. Plans with
 </details>
 
 ## Stripe integration
+
+<details>
+<summary><strong>How is tax handled for Kinde billing subscriptions?</strong></summary>
+
+Tax is not configured inside Kinde’s plan editor. Charges and invoices run through your connected **Stripe** account, so tax calculation, collection, and invoice presentation follow your **Stripe** setup (registrations, Stripe Tax, invoice options, and regional rules). Configure those details in the Stripe Dashboard. If you need guidance for your use case, contact [support@kinde.com](mailto:support@kinde.com).
+[About billing](/billing/about-billing/about-billing/) | [Manage Stripe connection](/billing/payment-management/manage-stripe-connection/)
+</details>
 
 <details>
 <summary><strong>Why does Kinde create a new Stripe account instead of connecting to my existing one?</strong></summary>

--- a/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
+++ b/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
@@ -14,8 +14,8 @@ metadata:
   languages: [html, css, javascript]
   audience: [developer, product-manager, ux-designer]
   complexity: intermediate
-  keywords: [plan sign-up, billing customization, plan selection, payment flow, billing screens, HTML CSS customization]
-  updated: 2025-11-27
+  keywords: [plan sign-up, billing customization, plan selection, payment flow, billing screens, HTML CSS customization, trial, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -51,9 +51,9 @@ This is ideal for:
 
 Depending on how you choose to onboard customers, users will see up to three different billing screens during the authentication flow. These screens can be customized:
 
-1. **Plan selection** - Displayed when a user signs up for the first time and multiple plans are available.
+1. **Plan selection** - Displayed when a user signs up for the first time and multiple plans are available. Plans with a trial enabled show a "Free trial for N day(s)" badge.
 
-2. **Payment details** - Shown after a user selects a plan—or if a plan was pre-selected before redirecting to Kinde. This screen only appears if the plan requires credit card details. Plans with no charges can optionally skip this screen if "Ask for credit card" is disabled in the [plan settings](/billing/manage-plans/create-plans/#configure-plan-settings).
+2. **Payment details** - Shown after a user selects a plan—or if a plan was pre-selected before redirecting to Kinde. This screen only appears if the plan requires credit card details. Plans with no charges can optionally skip this screen if "Ask for credit card" is disabled in the [plan settings](/billing/manage-plans/create-plans/#configure-plan-settings). For trial plans, this screen may appear later — when prompted for payment details before the trial ends — and includes a message explaining the trial window.
 
 3. **Success** - Shown when sign up and payment are successfully completed (or when a free plan subscription is confirmed).
 

--- a/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
+++ b/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
@@ -53,7 +53,7 @@ Depending on how you choose to onboard customers, users will see up to three dif
 
 1. **Plan selection** - Displayed when a user signs up for the first time and multiple plans are available. Plans with a trial enabled show a "Free trial for N day(s)" badge.
 
-2. **Payment details** - Shown after a user selects a plan—or if a plan was pre-selected before redirecting to Kinde. This screen only appears if the plan requires credit card details. Plans with no charges can optionally skip this screen if "Ask for credit card" is disabled in the [plan settings](/billing/manage-plans/create-plans/#configure-plan-settings). For trial plans, this screen may appear later — when prompted for payment details before the trial ends — and includes a message explaining the trial window.
+2. **Payment details** - Shown after a user selects a plan—or if a plan was pre-selected before redirecting to Kinde. This screen only appears if the plan requires credit card details. Plans with no charges can optionally skip this screen if "Ask for credit card" is disabled in the [plan settings](/billing/manage-plans/create-plans/#configure-plan-settings). For trial plans, this screen may appear later — when prompted for payment details before the trial ends — and includes a message explaining the trial window. This skip behavior does not apply to trial-enabled paid plans.
 
 3. **Success** - Shown when sign up and payment are successfully completed (or when a free plan subscription is confirmed).
 

--- a/src/content/docs/billing/billing-user-experience/free-trials.mdx
+++ b/src/content/docs/billing/billing-user-experience/free-trials.mdx
@@ -1,0 +1,74 @@
+---
+page_id: 7c2e8f1a-9b4d-4e6c-a3f0-1d8e5c7b2a90
+title: Offer a free trial
+sidebar:
+  order: 5
+relatedArticles:
+  - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
+  - c47fa1fb-15e1-4dcf-93d9-59df6acdf6da
+  - 06bb544c-1b84-4660-ac55-ac80b50ae5be
+  - 88e1773a-b681-441f-b4c7-d7d339116867
+description: How to offer free trials on paid plans with Kinde Billing, what customers see in the auth and pricing flow, and how trials convert to paid subscriptions via Stripe.
+metadata:
+  topics: [billing]
+  sdk: []
+  languages: []
+  audience: [developer, product-manager, business-owner]
+  complexity: beginner
+  keywords:
+    - free trial
+    - trial period
+    - SaaS billing
+    - Stripe trial
+    - pricing table
+    - subscription conversion
+  updated: 2026-04-08
+featured: false
+deprecated: false
+ai_summary: How to offer free trials on paid plans with Kinde Billing, what customers see in the auth and pricing flow, and how trials convert to paid subscriptions via Stripe.
+---
+
+You can offer a free trial to your customers with Kinde Billing.
+
+Free trials let customers use a **paid** plan for a limited time before they are charged. They are a common way to reduce signup friction while still moving toward a paid subscription. With Kinde Billing, trials are implemented using **Stripe** subscription trials: the customer gets plan entitlements during the trial window, and the subscription can convert to paid automatically when the trial ends.
+
+This page describes the **end-to-end experience** and points to detailed plan settings in [Create plans](/billing/manage-plans/create-plans/).
+
+## Configure free trials
+
+Go to **Billing > Plans** and edit the plan you want to configure:
+
+1. Turn on **Trial period**.
+2. Set **Trial length in days** (default 30, minimum 1).
+3. Set **Days before trial end to prompt for credit card** (default 3; must be less than the trial length).
+
+For step-by-step instructions, see [Create plans — Configure trial period](/billing/manage-plans/create-plans/#configure-trial-period).
+
+## What do customers get during a trial?
+
+When someone subscribes to a plan that has a trial enabled:
+
+- They receive **full access** to the plan’s features for the **trial length** you configure (in days).
+- **No charge** is made while the trial is active.
+- Near the end of the trial, they are **prompted for payment details** (if your plan is set up to collect a card before conversion). The timing of that prompt is configurable.
+- When the trial ends, Stripe **converts the subscription to paid** according to your plan’s pricing, provided payment details are in place.
+
+To see how this maps to billing screens (plan selection, payment details, and trial messaging), see [Customize the plan sign-up experience](/billing/billing-user-experience/customize-billing-pages/).
+
+## What do I need before offering a trial?
+
+- **Billing trials** must be enabled for your business. If you do not see trial options in plan settings, contact Kinde support or check your feature settings.
+- **Stripe** must be connected and working for Kinde Billing, because trials are created as Stripe subscriptions with a trial period.
+- **Ask for credit card** must be **on** for the plan. Trials cannot be enabled on plans where credit card collection is turned off. You can still use a **No credit card required** message in your own marketing; see below.
+
+## Can I advertise "No credit card required" for a trial?
+
+Yes. You can show a **No credit card required** message on your landing page or elsewhere in your product. In Kinde, **Ask for credit card** must still be **on** so that trials are allowed, but customers are **not** asked for payment details at signup. They are prompted later, based on **Days before trial end to prompt for credit card** (by default, **3** days before the trial ends).
+
+## What will customers see on the pricing table?
+
+Plans with a trial show a **"Free trial for N day(s)"** badge on the plan card. You do not configure the badge separately; it appears when the plan’s trial period is enabled. For when pricing tables appear (B2C vs B2B), see [Pricing table display defaults](/billing/billing-user-experience/pricing-table-display/).
+
+## Can I use trial information in my application?
+
+Yes. Billing-related access tokens can include trial fields (for example, whether the subscriber is in a trial and when it ends). See [What trial-related claims appear in access tokens?](/billing/about-billing/billing-concepts-terms/#what-trial-related-claims-appear-in-access-tokens) in [Billing concepts and terms](/billing/about-billing/billing-concepts-terms/).

--- a/src/content/docs/billing/billing-user-experience/free-trials.mdx
+++ b/src/content/docs/billing/billing-user-experience/free-trials.mdx
@@ -22,7 +22,7 @@ metadata:
     - Stripe trial
     - pricing table
     - subscription conversion
-  updated: 2026-04-08
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ai_summary: How to offer free trials on paid plans with Kinde Billing, what customers see in the auth and pricing flow, and how trials convert to paid subscriptions via Stripe.

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -13,13 +13,13 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: beginner
-  keywords: [pricing table display, B2C, B2B, B2B2C, plan groups, default display, URL parameters]
-  updated: 2025-01-16
+  keywords: [pricing table display, B2C, B2B, B2B2C, plan groups, default display, URL parameters, trial, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
 
-The pricing table that is displayed in a particular flow depends on the the [default plan groups and pricing table order](/billing/manage-plans/add-manage-plan-groups/).
+The pricing table that is displayed in a particular flow depends on the [default plan groups and pricing table order](/billing/manage-plans/add-manage-plan-groups/).
 
 ## B2C (User-based)
 
@@ -43,6 +43,10 @@ A pricing table is shown when:
 ## Here's a video showing the user experience for billing
 
 <YoutubeVideo videoId="xxVwZW8OxIA" videoTitle="Billing user experience"/>
+
+## Trial period badges
+
+Plans that have a trial period enabled display a **"Free trial for N day(s)"** badge on the plan card in the pricing table. This badge is shown automatically — no additional configuration is needed. It helps customers identify which plans offer a risk-free trial before committing to a paid subscription.
 
 ## Override the default plan display
 

--- a/src/content/docs/billing/get-started/build-plans.mdx
+++ b/src/content/docs/billing/get-started/build-plans.mdx
@@ -16,8 +16,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: intermediate
-  keywords: [plan strategy, B2B, B2C, B2B2C, plan features, pricing models, plan limits, feature planning]
-  updated: 2025-01-16
+  keywords: [plan strategy, B2B, B2C, B2B2C, plan features, pricing models, plan limits, feature planning, trial, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -33,7 +33,8 @@ If you have not created plans before, here’s a list of tasks to help you prepa
 
 1. Are you creating B2B or B2C or B2B2C plans? B2B plan types are for business customers (organizations), B2C plan types are for individual users, B2B2C is a platform model, where you have a customer who is an organization, and then users who are customers of that organization. 
 2. Decide how many plans you want and the name of each plan. E.g. `Free, Pro, Plus` or `Solo, Team, Enterprise`.
-3. Make a list of each [plan’s features](/billing/manage-plans/create-plans). For each feature, decide on:
+3. Decide if any paid plans should offer a [free trial period](/billing/manage-plans/create-plans/#configure-trial-period). If so, decide the trial length and how many days before the trial ends to prompt for payment details.
+4. Make a list of each [plan’s features](/billing/manage-plans/create-plans). For each feature, decide on:
     - the [pricing model](/billing/pricing/pricing-models/) that applies
     - limits and inclusions for a feature
     
@@ -43,7 +44,7 @@ If you have not created plans before, here’s a list of tasks to help you prepa
 
     ![example spreadsheet for plan planning](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/401ff633-c6c8-45ba-9502-1a29274b4400/public)
     
-4. Identify which features are common across plans. You don’t need to add a new feature every time, you can [re-use features](/billing/manage-plans/about-plans/) across plans and change the details.
+5. Identify which features are common across plans. You don’t need to add a new feature every time, you can [re-use features](/billing/manage-plans/about-plans/) across plans and change the details.
 
 **See [Create plans](/billing/manage-plans/create-plans)** for step-by-step instructions.
 

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -16,8 +16,8 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: intermediate
-  keywords: [plans, plan groups, features, pricing models, fixed charges, metered features, unmetered features, plan versioning]
-  updated: 2025-11-27
+  keywords: [plans, plan groups, features, pricing models, fixed charges, metered features, unmetered features, plan versioning, trial, free trial]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
@@ -33,7 +33,6 @@ We recommend creating your basic or simplest plan first (e.g. your Free plan), t
 
 These are known limitations that we are actively working on to add.
 
-- Support for plan models with free trial periods.
 - No alterations to billing cycle or invoice methods.
 - Add-ons and discounts that can be applied to individual subscriptions.
 
@@ -63,6 +62,7 @@ The plan name appears on the pricing table that you can generate to share with c
 Plan settings control additional subscription behavior beyond pricing.
 
 - **Ask for credit card**: Determines whether users must provide payment details when subscribing. This can be disabled for free plans with no charges, allowing frictionless signups. For plans with any charges (fixed or metered), credit card collection is always required.
+- **Trial period**: When enabled, lets customers try the plan for a set number of days before being charged. You can configure the trial length and how many days before the trial ends to prompt for payment details. Plans with a trial enabled show a "Free trial for N day(s)" badge on the pricing table. See [Create plans — Configure trial period](/billing/manage-plans/create-plans/#configure-trial-period) for configuration details.
 
 ### Plan feature pricing
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -29,25 +29,21 @@ Once you’ve got a plan strategy along with a plan feature list, prices, and de
 
 All plans must belong to a plan group. When you create your first plan, it will be automatically added to the default group. A plan group can only contain either user plans or organization plans. When you create your first plan, we automatically create a group based on the plan type you select. 
 
-<Aside>
+Remember you can create one charge or feature that can be used and redefined across all plans. E.g. You can have one ‘Base price’ charge that is defined as `0.00` in a **free plan**, `10.00` in a **Plus plan**, and `25.00` in a **Pro plan**.
 
-Remember you can create one charge or feature that can be used and redefined across all plans. E.g. You can have one ‘Base price’ charge that is defined as 0.00 in a free plan, 10.00 in a Plus plan, and 25.00 in a Pro plan.
-
-</Aside>
 
 ## Add a plan
 
-1. Go to **Billing > Plans**. 
-2. If this is the first plan, select **Add plan** on the empty page. 
-3. If you already have plans, select **Add plan** in the top right. The **Add plan** window opens.
+1. Go to **Billing > Plans**
+2. Select **Add plan**, a window opens
     
     ![Add plans window](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a8a237d5-c242-45dc-453e-a7ad66e33a00/public)
     
-4. Choose whether the plan is for **Organizations** or **Users**, or select the **Group** the plan belongs to. Only one of these options will appear. You cannot change these selections later.
-5. Give the plan a **Name** (e.g. `Free`), a **Description**. This is the name that will also appear in the pricing table (if you use one).
-6. Give your plan a **Key** for referencing in your code. This cannot be changed after a plan is published.
-7. Select a **Default currency**. This field only appears if one has not been set. You can change this later in **Settings > Billing**, but only before any of your plans are published.
-8. Select **Save**.
+3. Choose whether the plan is for **Organizations** or **Users**, or select the **Group** the plan belongs to. Only one of these options will appear. You cannot change these selections later.
+4. Give the plan a **Name** (e.g., `Free`), a **Description**. This is the name that will also appear in the pricing table (if you use one).
+5. Give your plan a **Key** (e.g., `free_plan`) for referencing in your code. This cannot be changed after a plan is published.
+6. Select a **Default currency**. This field only appears if one has not been set. You can change this later in **Settings > Billing**, but only before any of your plans are published.
+7. Select **Save**
 
 ## Configure plan settings
 
@@ -98,9 +94,10 @@ Enabling a trial period requires the **Ask for credit card** toggle to be on. Yo
 
 In **Trials** section:
 
-- Enable **Trial period**.
-- Set the **Trial length (days)** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
-- Set **Ask for credit card before trial ends (days)** (default: 3, minimum: 0). This must be less than the trial length. This controls when the customer is asked to provide payment details before the trial expires.
+1. Enable **Trial period**.
+2. Set the **Trial length (days)** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
+3. Set **Ask for credit card before trial ends (days)** (default: 3, minimum: 0). This must be less than the trial length. This controls when the customer is asked to provide payment details before the trial expires.
+4. Select **Save draft** or **Publish** to apply your changes.
 
     ![Trial period settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eb377c66-a42f-4759-a7ef-a3eea3dce800/socialsharingimage)
 
@@ -119,22 +116,10 @@ In **Trials** section:
 | Trial length in days | Number of days the customer can use the plan for free | 30 | Must be ≥ 1 |
 | Days before trial end to prompt for credit card | How many days before trial expiry the customer is prompted for payment details | 3 | Must be ≥ 0 and less than the trial length |
 
-4. Select **Save draft** or **Publish** to apply your changes.
 
 ## Add a subscription fee or fixed charge to a plan
 
 A fixed charge is a recurring charge such as base price or subscription fee. You can set **billing intervals** (daily, weekly, monthly, or yearly) and optionally **offer the charge as annual** with a custom yearly price when customers choose yearly billing.
-
-<Aside title="Billing intervals and Offer as annual">
-
-When adding a charge, choose **Day**, **Week**, **Month**, or **Year** as the billing interval. To give customers a yearly option at a fixed annual price, turn on **Offer as annual** and set the **Annual price**—only one fixed charge per plan can be offered as annual.
-</Aside>
-
-<Aside type="warning">
-
-You need to create a $0.00 charge for Free plans. This ensures the plan is added to Stripe, and is included on the pricing table.
-
-</Aside>
 
 1. In **Fixed charges**, select **Add charge**.
     1. If the charge exists, select **Use existing feature** then select it from the list. 
@@ -147,18 +132,24 @@ You need to create a $0.00 charge for Free plans. This ensures the plan is added
         
     2. If this is a new charge, give it a name (e.g., `Base subscription fee`). If you’ll reuse this charge across plans, choose a generic name. This cannot be changed later.
 2. Add a **Line item description**. This appears on the customer invoice, so might be more specific than the name, e.g. `Base subscription - Pro plan`.
-
 3. Set the **Price** and choose the **Billing interval**: **Day**, **Week**, **Month**, or **Year**. (You may be asked to set a default currency if you haven’t already).
-4. **(Optional) Offer as annual** – Turn on **Offer as annual** to bill this charge once per year at a fixed price when the customer selects yearly billing. Enter the **Annual price** in the field below. Only one fixed charge per plan can be offered as annual.
-5. Select **Save**.
-6. Select **Save draft**.
-7. Repeat from step 1 for each fixed charge you want to add, or start adding features.
+4. **(Optional) Offer as annual** with a yearly price for this plan.
+5. Select **Save** or **Save draft** to commit your changes.
+6. Repeat for each fixed charge you want to add, or start adding features.
 
-<Aside title="Feature price sync">
+### Offer annual pricing
 
-If you are successfully connected to Stripe and the charge is part of a published plan, it will show as `price synced`. Otherwise the charge will show as `price not synced`.
+To give customers a yearly option at a fixed annual price, turn on **Offer as annual** and set the **Annual price**. 
 
-</Aside>
+    <Aside>
+    Only one fixed charge per plan can be offered as annual.
+    </Aside>
+
+    ![Offer as annual pricing](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/6e5a440f-88f8-4af7-5ab2-a28dd0f58900/socialsharingimage)
+
+### Free plans
+
+To create a free plan, set the **Price** to `0.00`. This ensures the plan is added to Stripe, and is included on the pricing table as free plan.
 
 ## Add features (entitlements) to a plan
 
@@ -194,18 +185,14 @@ You cannot change the Name, the Key or the Type of feature once you have created
 13. For tiered pricing, select **Tiered - Graduated** and define each tier with unit numbers and add the price per unit. 
 14. Select **Add tier** to add a different price for higher unit tiers. For example, a unit might be $10 each if you use 1-10, but is $9 per unit if you use 11 or more.
     
-    <Aside type="warning">
-    
     Ensure the tiered units amounts don’t overlap. E.g. make sure they follow a pattern like 1-10, 11-20, 21-30, etc. If you want to make it so an upper limit is limitless, E.g. 1-10, 11-(blank/limitless); use 1-10, 11-1,000,000 (or a very high number). Graduated unit fields can’t be left blank.
-    
-    </Aside>
     
 15. Select **Save.**
 16. In the **Plan** window, select **Save** to commit your changes.
 17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan. 
 
-<Aside title="Feature price sync">
+## Price sync status
 
-If you are successfully connected to Stripe and the feature is part of a published plan, it will show as `price synced`. Otherwise the feature will show as `price not synced`.
+If you are successfully connected to Stripe and the plan/feature is part of a published plan, it will show as `price synced`. Otherwise the feature will show as `price not synced`.
 
-</Aside>
+    ![Price sync status](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/bc88b122-c6d6-4352-1a54-2fe844f23c00/socialsharingimage)

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -3,6 +3,8 @@ page_id: fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
 title: Create plans
 sidebar:
   order: 2
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
@@ -17,13 +19,13 @@ metadata:
   languages: []
   audience: [developer, product-manager, business-owner]
   complexity: intermediate
-  keywords: [create plans, plan groups, fixed charges, billing interval, offer as annual, metered features, tiered pricing, plan features, subscription fees]
-  updated: 2025-11-27
+  keywords: [create plans, plan groups, fixed charges, billing interval, offer as annual, metered features, tiered pricing, plan features, subscription fees, trial, free trial, trial period]
+  updated: 2026-04-07
 featured: false
 deprecated: false
 ---
 
-Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans them in Kinde.
+Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.
 
 All plans must belong to a plan group. When you create your first plan, it will be automatically added to the default group. A plan group can only contain either user plans or organization plans. When you create your first plan, we automatically create a group based on the plan type you select. 
 
@@ -74,6 +76,44 @@ This option can only be disabled for plans that have no charges. If your plan in
 |-----------|---------------------|
 | Reduce signup friction for a free tier | Disable—let users try your product without entering payment details |
 | Capture payment info for easier upgrades | Enable—collect card details upfront for seamless plan transitions |
+| Offer a free trial that converts to paid | Enable—required when trial period is enabled; payment details are collected before the trial ends |
+
+### Configure trial period
+
+<Aside type="info">
+
+Trial periods require the **billing trials** feature to be enabled for your business. Contact Kinde support or check your feature settings if you don't see the trial options.
+
+</Aside>
+
+Trial periods let customers try a paid plan before being charged. When a trial is active, the customer's Stripe subscription is created with a trial window — no charges are made until the trial expires.
+
+<Aside type="warning">
+
+Enabling a trial period requires the **Ask for credit card** toggle to be on. You cannot enable trials on a plan where credit card collection is disabled.
+
+</Aside>
+
+Still in **Plan settings**, configure the trial:
+
+- Enable **Trial period**.
+- Set the **Trial length in days** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
+- Set **Days before trial end to prompt for credit card** (default: 3, minimum: 0). This must be less than the trial length. This controls when the customer is asked to provide payment details before the trial expires.
+
+#### How trials work at runtime
+
+- When a customer subscribes to a trial plan, they get full access to the plan features immediately — no payment is collected upfront.
+- The pricing table shows a **"Free trial for N day(s)"** badge on plans with a trial enabled.
+- A background process automatically prompts the customer to add payment details the configured number of days before the trial ends.
+- When the trial period ends, Stripe automatically converts the subscription to a paid subscription.
+
+#### Trial period configuration reference
+
+| Setting | Description | Default | Constraints |
+|---------|-------------|---------|-------------|
+| Trial period | Enable or disable the trial for this plan | Off | Requires "Ask for credit card" to be on |
+| Trial length in days | Number of days the customer can use the plan for free | 30 | Must be ≥ 1 |
+| Days before trial end to prompt for credit card | How many days before trial expiry the customer is prompted for payment details | 3 | Must be ≥ 0 and less than the trial length |
 
 4. Select **Save draft** or **Publish** to apply your changes.
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -64,11 +64,13 @@ This toggle controls whether users must enter credit card details when subscribi
 - **Enabled (default)**: Users will be prompted to enter their payment details during signup via a secure Stripe payment form.
 - **Disabled**: Users can subscribe without providing payment information and proceed directly to your application.
 
-<Aside type="warning">
+    ![Ask for credit card toggle](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4c118f78-9f3a-49f4-a681-df79c127b400/socialsharingimage)
 
-This option can only be disabled for plans that have no charges. If your plan includes any pricing (fixed charges or metered/usage-based billing), credit card collection is always required.
+    <Aside type="warning">
 
-</Aside>
+    This option can only be disabled for plans that have no charges. If your plan includes any pricing (fixed charges or metered/usage-based billing), credit card collection is always required.
+
+    </Aside>
 
 ### When to use each setting
 
@@ -94,11 +96,13 @@ Enabling a trial period requires the **Ask for credit card** toggle to be on. Yo
 
 </Aside>
 
-Still in **Plan settings**, configure the trial:
+In **Trials** section:
 
 - Enable **Trial period**.
-- Set the **Trial length in days** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
-- Set **Days before trial end to prompt for credit card** (default: 3, minimum: 0). This must be less than the trial length. This controls when the customer is asked to provide payment details before the trial expires.
+- Set the **Trial length (days)** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
+- Set **Ask for credit card before trial ends (days)** (default: 3, minimum: 0). This must be less than the trial length. This controls when the customer is asked to provide payment details before the trial expires.
+
+    ![Trial period settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eb377c66-a42f-4759-a7ef-a3eea3dce800/socialsharingimage)
 
 #### How trials work at runtime
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -105,8 +105,8 @@ In **Trials** section:
 
 - When a customer subscribes to a trial plan, they get full access to the plan features immediately — no payment is collected upfront.
 - The pricing table shows a **"Free trial for N day(s)"** badge on plans with a trial enabled.
-- A background process automatically prompts the customer to add payment details the configured number of days before the trial ends.
-- When the trial period ends, Stripe automatically converts the subscription to a paid subscription.
+- A background process automatically prompts the customer to verify or update their payment details the configured number of days before the trial ends.
+- When the trial period ends, Stripe attempts to convert the subscription to paid according to your plan pricing, provided valid payment details are in place.
 
 #### Trial period configuration reference
 
@@ -149,7 +149,7 @@ To give customers a yearly option at a fixed annual price, turn on **Offer as an
 
 ### Free plans
 
-To create a free plan, set the **Price** to `0.00`. This ensures the plan is added to Stripe, and is included on the pricing table as free plan.
+To create a free plan, set the **Price** to `0.00`. This ensures the plan is added to Stripe, and is included on the pricing table as a free plan.
 
 ## Add features (entitlements) to a plan
 

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -28,13 +28,14 @@ keywords:
   - feature flags
   - permissions
   - organization claims
-updated: 2026-03-26
+  - billing trial
+updated: 2026-04-07
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to Kinde access tokens including standard JWT claims, Kinde-specific claims like organization codes and feature flags, and token behavior during refresh operations.
 ---
 
-Access tokens are a secure way of authenticating users, and passing information about a user to to a system.
+Access tokens are a secure way of authenticating users and passing information about a user to a system.
 
 ## Access token standard claims
 
@@ -84,6 +85,8 @@ Access tokens are a secure way of authenticating users, and passing information 
   	"view:profile
   ]
   ```
+
+- **Billing trial** - When a user has an active billing trial on their plan, the token may include `has_trial_period` (boolean) and `trial_expires_on` (ISO 8601 datetime string for when the trial ends). `trial_expires_on` is typically present when `has_trial_period` is `true`. For definitions, see [Billing concepts & terms](/billing/about-billing/billing-concepts-terms/).
 
 - **External provider ID** - The ID you use to identify the organization the user is authorized against
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Offer a free trial" guide and updated billing docs: how to enable/configure trial periods, credit‑card prompt timing, and automatic conversion to paid subscriptions; pricing tables and plan cards show a “Free trial for N day(s)” badge.
  * Clarified tax/VAT handling: tax calculation/invoice behavior follows the connected Stripe account/settings.
  * Documented trial-related access-token claims and removed the prior limitation against trial-enabled plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->