### PR TITLE
update: document SvelteKit redirect URL and password reset email customization limit (gap report)

### DIFF
--- a/src/content/docs/design/content-customization/email-content.mdx
+++ b/src/content/docs/design/content-customization/email-content.mdx
@@ -29,7 +29,7 @@ keywords:
   - passwordless auth
   - SMTP
   - business name
-updated: 2026-03-03
+updated: 2026-04-07
 featured: false
 deprecated: false
 ai_summary: Guide for customizing email content including sender details, logo configuration, OTP email customization, and multi-language support for authentication emails.
@@ -37,7 +37,7 @@ ai_summary: Guide for customizing email content including sender details, logo c
 
 If emails are part of your authentication processes for users - for example, users receive sign-in codes via email in a passwordless process - you can customize email details, with some limitations. Core auth emails (verification, OTP, password reset) cannot be fully disabled; you can only customize who they are sent from and their content.
 
-## **Change the email sender** **name**
+## Change the email sender name
 
 You can add your business or brand name so it appears as the sender of emails.
 
@@ -49,13 +49,15 @@ You can add your business or brand name so it appears as the sender of emails.
 
 If you want to change the email sender address, you add your own email provider’s SMTP details. See [Customize email sender](/get-started/connect/customize-email-sender/).
 
-## **Change email logo**
+## Change email logo
 
 Emails inherit the logo you set as part of your [global brand](/design/brand/global-brand-defaults/). But you can also set a unique logo [for each organization](/design/brand/apply-branding-for-an-organization/) in your business.
 
 ## Change who verification emails are sent from
 
-_Only applies if you choose not to send emails from your own provider_
+<Aside>
+Only applies if you choose not to send emails from your own provider.
+</Aside>
 
 When Kinde sends an email on your behalf, it is sent from the ‘Business name’ listed in your Kinde business by default.
 
@@ -90,3 +92,7 @@ You can include the sign-in code in the subject line of OTP emails to make it vi
 2. Select the language you want to edit. Only [languages you have selected](/design/content-customization/set-language-for-pages/) in your business are available.
 3. In the subject line field, include the `${code}` placeholder. This is where the code will appear. E.g. Enter `${code}` for access.
 4. Select **Save**.
+
+## Can password reset emails use fully custom HTML?
+
+No. Password reset is a core authentication email. You can customize subject, body text, disclaimers, and placeholders where the template editor exposes them—the same pattern as other auth emails—but you cannot supply a **fully custom HTML** email as a free-form document.

--- a/src/content/docs/design/content-customization/email-content.mdx
+++ b/src/content/docs/design/content-customization/email-content.mdx
@@ -96,3 +96,7 @@ You can include the sign-in code in the subject line of OTP emails to make it vi
 ## Can password reset emails use fully custom HTML?
 
 No. Password reset is a core authentication email. You can customize subject, body text, disclaimers, and placeholders where the template editor exposes them—the same pattern as other auth emails—but you cannot supply a **fully custom HTML** email as a free-form document.
+
+<Aside>
+This limit applies to core auth email templates only. It is separate from [customizing hosted pages with code](/design/customize-with-code/customize-with-css-html/), where you can bring your own HTML, CSS, and JavaScript for Kinde-hosted UI (such as sign-in and password entry screens).
+</Aside>

--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -4,6 +4,8 @@ title: SvelteKit SDK
 description: "Complete guide for SvelteKit SDK including OAuth 2.0 flows, session management, authentication integration, and user profile access for SvelteKit applications."
 sidebar:
   order: 12
+tableOfContents:
+  maxHeadingLevel: 3
 head:
   - tag: meta
     attrs:
@@ -31,7 +33,7 @@ keywords:
   - Client Credentials
   - session hooks
   - authentication
-updated: 2024-01-15
+updated: 2026-04-07
 featured: false
 deprecated: false
 ai_summary: Complete guide for SvelteKit SDK including OAuth 2.0 flows, session management, authentication integration, and user profile access for SvelteKit applications.
@@ -80,6 +82,12 @@ If you haven’t already got a Kinde account, [register for free here](https://
 ### Add environments
 
 Kinde comes with a production environment, but you can set up other environments if you want to. Each environment has a unique subdomain so be sure to use the correct one in the **Configure your app section** which follows.
+
+### Using dynamic callback URLs
+
+If you need dynamic callback URLs, you can register the patterns Kinde supports (for example wildcard or subdomain placeholders) in **Allowed callback URLs**, as described in [Subdomains for callbacks](/build/domains/subdomains-for-callbacks/), and implement the authorization code flow yourself using [Using Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/) so your server chooses the correct `redirect_uri` for each login.
+
+The SDK uses a **single static** value from `KINDE_REDIRECT_URL` in your environment. It does **not** support building a different `redirect_uri` per HTTP request—for example for multi-tenant subdomains, per-organization callback paths, or `{organization.handle}`-style URLs—because the OAuth redirect must match what is registered for the application.
 
 ## Configure your app
 

--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -33,7 +33,7 @@ keywords:
   - Client Credentials
   - session hooks
   - authentication
-updated: 2026-04-07
+updated: 2026-04-08
 featured: false
 deprecated: false
 ai_summary: Complete guide for SvelteKit SDK including OAuth 2.0 flows, session management, authentication integration, and user profile access for SvelteKit applications.
@@ -85,9 +85,12 @@ Kinde comes with a production environment, but you can set up other environments
 
 ### Using dynamic callback URLs
 
-If you need dynamic callback URLs, you can register the patterns Kinde supports (for example wildcard or subdomain placeholders) in **Allowed callback URLs**, as described in [Subdomains for callbacks](/build/domains/subdomains-for-callbacks/), and implement the authorization code flow yourself using [Using Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/) so your server chooses the correct `redirect_uri` for each login.
+The SDK reads a single static `redirect_uri` from `KINDE_REDIRECT_URL`. It does not build different values per request, so multi-tenant subdomains, per-org paths, and `{organization.handle}`-style URLs are not supported out of the box.
 
-The SDK uses a **single static** value from `KINDE_REDIRECT_URL` in your environment. It does **not** support building a different `redirect_uri` per HTTP request—for example for multi-tenant subdomains, per-organization callback paths, or `{organization.handle}`-style URLs—because the OAuth redirect must match what is registered for the application.
+If you need dynamic callbacks:
+
+- Register wildcard or subdomain patterns in **Allowed callback URLs** — see [Wildcards in callback URLs](/get-started/connect/callback-urls/#wildcards-in-callback-urls).
+- Implement the auth code flow yourself using [Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/) so your server selects the correct `redirect_uri` per request.
 
 ## Configure your app
 

--- a/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/sveltekit-sdk.mdx
@@ -89,6 +89,7 @@ The SDK reads a single static `redirect_uri` from `KINDE_REDIRECT_URL`. It does 
 
 If you need dynamic callbacks:
 
+- For multi-tenant subdomain routing with organization handles, see [Org handles and dynamic callbacks for subdomains](/build/domains/subdomains-for-callbacks/).
 - Register wildcard or subdomain patterns in **Allowed callback URLs** — see [Wildcards in callback URLs](/get-started/connect/callback-urls/#wildcards-in-callback-urls).
 - Implement the auth code flow yourself using [Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/) so your server selects the correct `redirect_uri` per request.
 


### PR DESCRIPTION
This PR documents two limitations in Kinde: 

**SvelteKit** uses one static KINDE_REDIRECT_URL (no built-in dynamic/multi-tenant callbacks; links to wildcards and “without an SDK” for alternatives).

**Password reset mail can’t be fully custom HTML** -only what the auth email templates allow. It also tightens email-content headings/asides and bumps frontmatter (TOC depth, dates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified email customization docs by cleaning up headings, updating verification-note formatting, and adding an FAQ about limits for password-reset email custom HTML while confirming subject/body/disclaimers/placeholders stay customizable.
  * Improved SvelteKit SDK docs with added table of contents configuration and new guidance on dynamic callback URLs, including when to use a manual authorization code flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->