### PR TITLE
feat: move action buttons above TOC with sticky positioning

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -48,7 +48,8 @@ customHeaders:
           'sha256-zB5rUhTjHzt+r/RjhhI8CyMb5Y63k+J7ICVfQ7iHJqA='
           'sha256-fFmtUWM/kGeUru+1rcCArLmnXKoEjis5I/dYQkZA+HM='
           'sha256-13ENHEoc4foVPMgYwApSstLrIGX/6Y5xvroD2DkDFcE='
-          'sha256-yFuBDNMj2fpiA5dUkQrfMrCWmvLpElEv1n2dFVmg3Dg=' 'self'
+          'sha256-yFuBDNMj2fpiA5dUkQrfMrCWmvLpElEv1n2dFVmg3Dg='
+          'sha256-VHT08NPRGGUrrSetqHAQHYFOVOYq2FUOSHNd3IQRfYU=' 'self'
           widgets.kinde.com kinde.com https://www.kinde.com
           https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.23.5/dist/browser/standalone.min.js
       - key: Strict-Transport-Security
@@ -76,9 +77,10 @@ customHeaders:
           default-src 'self' *.kinde.com;  style-src 'self' 'unsafe-inline'
           https://fonts.googleapis.com;  frame-ancestors 'none';  script-src
           https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.23.5/dist/browser/standalone.min.js
-          'unsafe-inline' 'self' widgets.kinde.com kinde.com https://www.kinde.com;  font-src
-          https://fonts.scalar.com 'self' https://fonts.gstatic.com; connect-src
-          'self' wss: https://api.management.inkeep.com https://api.inkeep.com
+          'unsafe-inline' 'self' widgets.kinde.com kinde.com
+          https://www.kinde.com;  font-src https://fonts.scalar.com 'self'
+          https://fonts.gstatic.com; connect-src 'self' wss:
+          https://api.management.inkeep.com https://api.inkeep.com
           wss://api.inkeep.com https://api.hsforms.com https://app.kinde.com
           https://kinde.com https://widgets.kinde.com https://api-spec.kinde.com
           https://kinde-api-docs-proxy.pages.dev https://analytics.usehall.com;
@@ -90,9 +92,10 @@ customHeaders:
           default-src 'self' *.kinde.com;  style-src 'self' 'unsafe-inline'
           https://fonts.googleapis.com;  frame-ancestors 'none';  script-src
           https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.23.5/dist/browser/standalone.min.js
-          'unsafe-inline' 'self' widgets.kinde.com kinde.com https://www.kinde.com;  font-src
-          https://fonts.scalar.com 'self' https://fonts.gstatic.com; connect-src
-          'self' wss: https://api.management.inkeep.com https://api.inkeep.com
+          'unsafe-inline' 'self' widgets.kinde.com kinde.com
+          https://www.kinde.com;  font-src https://fonts.scalar.com 'self'
+          https://fonts.gstatic.com; connect-src 'self' wss:
+          https://api.management.inkeep.com https://api.inkeep.com
           wss://api.inkeep.com https://api.hsforms.com https://app.kinde.com
           https://kinde.com https://widgets.kinde.com https://api-spec.kinde.com
           https://kinde-api-docs-proxy.pages.dev https://analytics.usehall.com;

--- a/src/components/ContributionGuides.astro
+++ b/src/components/ContributionGuides.astro
@@ -22,36 +22,71 @@ try {
 }
 ---
 
-<aside
-  class="not-content mt-6 border-t-[1px] border-kinde-grey-100 py-6 dark:border-kinde-grey-900"
->
+<aside class="contribution-guides not-content">
   <a
     href="/contribute/"
-    class="flex items-center justify-start gap-1 text-kinde-grey-900 hover:opacity-90 dark:text-white"
+    class="contribution-guides__item"
   >
     <Icon name="book" size={16} />
-    <h3 class="text-sm font-medium dark:!font-normal">Contribute</h3>
+    <span>Contribute</span>
   </a>
-  
+
   <a
     href={chatGptUrl}
     target="_blank"
     rel="noopener noreferrer"
-    class={`flex items-center justify-start gap-1 mt-4 text-kinde-grey-900 hover:opacity-90 dark:text-white plausible-event-name=Open+with+ChatGPT plausible-event-url=${currentPath}`}
+    class={`contribution-guides__item plausible-event-name=Open+with+ChatGPT plausible-event-url=${currentPath}`}
   >
     <Icon name="talk-1" size={16} />
-    <h3 class="text-sm font-medium dark:!font-normal">Open with ChatGPT</h3>
+    <span>Open with ChatGPT</span>
   </a>
-  
+
   <button
     id="copy-markdown-button"
-    class={`flex items-center justify-start gap-1 mt-4 text-kinde-grey-900 hover:opacity-90 dark:text-white bg-transparent border-none cursor-pointer w-full text-left p-0 plausible-event-name=Copy+for+AI plausible-event-url=${currentPath}`}
+    class={`contribution-guides__item plausible-event-name=Copy+for+AI plausible-event-url=${currentPath}`}
     data-markdown={rawMarkdown}
   >
     <Icon name="sparkle" size={16} />
-    <h3 class="text-sm font-medium dark:!font-normal">Copy for AI</h3>
+    <span>Copy for AI</span>
   </button>
 </aside>
+
+<style>
+  .contribution-guides {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding-top: 3.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid;
+    margin-bottom: 1.5rem;
+    @apply border-kinde-grey-100 bg-white dark:border-kinde-grey-900 dark:bg-black;
+  }
+
+  .contribution-guides__item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.25rem;
+    margin-top: 1rem;
+    font-size: var(--sl-text-sm);
+    font-weight: 500;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+    width: 100%;
+    text-align: left;
+    @apply text-kinde-grey-900 hover:opacity-90 dark:text-white dark:font-normal;
+  }
+
+  .contribution-guides__item:first-child {
+    margin-top: 0;
+  }
+</style>
 
 <script>
   document.getElementById('copy-markdown-button')?.addEventListener('click', async function() {
@@ -82,7 +117,7 @@ ${rawMarkdown}
       
       // Show success notification
       const button = this as HTMLButtonElement;
-      const titleElement2 = button.querySelector('h3');
+      const titleElement2 = button.querySelector('span');
       if (titleElement2) {
         const originalText = titleElement2.textContent;
         titleElement2.textContent = 'Markdown copied!';

--- a/src/starlight-overrides/PageSidebar.astro
+++ b/src/starlight-overrides/PageSidebar.astro
@@ -1,7 +1,6 @@
 ---
 import type {Props} from "@astrojs/starlight/props";
 import ContributionGuides from "@components/ContributionGuides.astro";
-
 import MobileTableOfContents from "virtual:starlight/components/MobileTableOfContents";
 import TableOfContents from "virtual:starlight/components/TableOfContents";
 ---
@@ -14,8 +13,8 @@ import TableOfContents from "virtual:starlight/components/TableOfContents";
       </div>
       <div class="right-sidebar-panel sl-hidden lg:sl-block">
         <div class="sl-container">
-          <TableOfContents {...Astro.props} />
           <ContributionGuides />
+          <TableOfContents {...Astro.props} />
         </div>
       </div>
     </>
@@ -36,14 +35,14 @@ import TableOfContents from "virtual:starlight/components/TableOfContents";
     line-height: var(--sl-line-height-headings);
     margin-bottom: 0.5rem;
   }
-  .right-sidebar-panel :global(:where(a)) {
+  .right-sidebar-panel :global(starlight-toc :where(a)) {
     display: block;
     font-size: var(--sl-text-xs);
     text-decoration: none;
     color: var(--sl-color-gray-3);
     overflow-wrap: anywhere;
   }
-  .right-sidebar-panel :global(:where(a):hover) {
+  .right-sidebar-panel :global(starlight-toc :where(a):hover) {
     color: var(--sl-color-white);
   }
   @media (min-width: 72rem) {


### PR DESCRIPTION
#### Description (required)

Move the Contribute, Open with ChatGPT, and Copy for AI action buttons from the bottom of the right-hand sidebar to the top, above the "On this page" table of contents. The buttons are now sticky so they remain visible as users scroll through long pages.

**Changes:**
- Repositioned `ContributionGuides` above `TableOfContents` in `PageSidebar.astro`
- Added sticky positioning (`position: sticky; top: 0`) and vertical alignment padding so the buttons align with the page H1
- Scoped the sidebar's grey link color styles to `starlight-toc` links only, so the action buttons render in full black
- Updated CSP hashes in `customHttp.yml` for the restyled component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced contribution guides component styling with improved dark and light mode support
  * Reorganized sidebar navigation for better visual hierarchy

* **Chores**
  * Updated security headers to improve content delivery and resource accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->