### PR TITLE
fix: add refresh token cookie mismatch + _kbrte cookie note (gap report) 

### DIFF
--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -15,7 +15,7 @@ metadata:
   audience: [developer, product-manager]
   complexity: intermediate
   keywords: [session management, SSO session, session cookies, inactivity timeout, browser session]
-  updated: 2026-04-03
+  updated: 2026-04-13
 featured: false
 deprecated: false
 ---
@@ -46,3 +46,9 @@ Kinde measures inactivity **on the server**. Browsing your own app—switching p
 There is **no public list of every action** that resets inactivity. In practice, treat **authenticated, end-user-facing traffic to Kinde** as the model, rather than assuming every client-side event is visible to Kinde.
 
 **Machine-to-machine (M2M)** integrations and the **Management API** use separate credentials and contexts. They are **not** equivalent to activity on a specific person’s browser SSO session when you interpret this setting.
+
+## What is the `_kbrte` cookie?
+
+`_kbrte` is a Kinde browser session cookie. It is set by Kinde’s authentication service and is used to track the authenticated session state for the current browser. It plays a role in how Kinde measures SSO session inactivity — when this cookie is present and valid, Kinde can identify the user’s session and count authenticated interactions against the inactivity timer.
+
+You do not need to interact with this cookie directly. It is managed by Kinde and will be cleared when the user signs out or when the session expires.

--- a/src/content/docs/build/tokens/refresh-tokens.mdx
+++ b/src/content/docs/build/tokens/refresh-tokens.mdx
@@ -31,7 +31,7 @@ keywords:
   - session management
   - token security
   - auto-update
-updated: 2026-04-03
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to refresh tokens including how they work, implementation with offline scope, token rotation, security best practices, and SDK integration.
@@ -115,6 +115,12 @@ To avoid this, Kinde supports **client-specific refresh token cookies**. When en
 - **Default**: The feature is disabled by default.
 - **Cookie naming**: Kinde uses the first 6 characters of the application's client ID to build the cookie name (e.g. `refresh_token_abc123`).
 - **Fallback**: If a client-specific cookie is not found, Kinde falls back to the standard `refresh_token` cookie.
+
+<Aside title="Cookie path scope">
+
+The `refresh_token` cookie uses `Path=/oauth2/token` by default. This path scope means the cookie is only sent by the browser on requests to that specific path — not to your application routes. If you are debugging cookie behavior, look for the cookie under the `/oauth2/token` path in your browser's DevTools (**Application > Cookies**), not at the root path.
+
+</Aside>
 
 ## Refresh tokens when you are not using an SDK
 

--- a/src/content/docs/build/tokens/token-validation-errors.mdx
+++ b/src/content/docs/build/tokens/token-validation-errors.mdx
@@ -27,7 +27,7 @@ keywords:
   - invalid_client
   - invalid_grant
   - unauthorized_client
-updated: 2024-01-15
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Reference guide for OAuth 2.0 access token validation including successful response formats and common error codes with troubleshooting information.
@@ -49,7 +49,7 @@ Here’s some typical successful and unsuccessful (error) responses.
 
 - `invalid_request` – The request is missing a parameter so the server can’t proceed with the request. This may also be returned if the request includes an unsupported parameter or repeats a parameter.
 - `invalid_client` – Client authentication failed, such as if the request contains an invalid client ID or secret. Send an HTTP 401 response in this case.
-- `invalid_grant` – The authorization code (or user’s password for the password grant type) is invalid or expired. This is also the error you would return if the redirect URL given in the authorization grant does not match the URL provided in this access token request.
+- `invalid_grant` – The authorization code (or user’s password for the password grant type) is invalid or expired. This is also the error you would return if the redirect URL given in the authorization grant does not match the URL provided in this access token request. Also returned when a rotated refresh token stored in memory no longer matches the `refresh_token` cookie — for example, after a silent refresh that did not update the `httpOnly` cookie. See [React SDK refresh token troubleshooting](/developer-tools/sdks/frontend/react-sdk/#why-am-i-getting-invalid_grant-errors-after-the-sdk-silently-refreshes-my-token).
 - `invalid_scope` – For access token requests that include a scope (password or client_credentials grants), this error indicates an invalid scope value in the request.
 - `unauthorized_client` – The client is not authorized to use the requested grant type. For example, if you restrict which applications can use the Implicit grant, you would return this error for the other apps.
 - `unsupported_grant_type` – If a grant type is requested that the authorization server doesn’t recognize, use this code. Note that unknown grant types also use this specific error code rather than using the `invalid_request` above.

--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -32,7 +32,7 @@ keywords:
   - register
   - logout
   - access tokens
-updated: 2026-04-03
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Complete guide for React SDK including installation, provider setup, authentication hooks, callback handling, and API integration for React 18+ applications.
@@ -970,6 +970,14 @@ The cache that **`getAccessToken()`** reads is updated when those flows succeed.
 ### Does `getAccessToken` throw or return an error object when something goes wrong?
 
 No. **`getAccessToken()`** resolves to **`Promise<string | undefined>`**. You get the JWT when a value exists in storage and **`undefined`** when there is nothing to read (for example, the user is signed out). It **does not throw** and **does not** return an error object for refresh failures, because it **does not perform refresh**. Use **`refreshToken()`** when you need an explicit refresh and handle its outcome separately.
+
+### Why am I getting `invalid_grant` errors after the SDK silently refreshes my token?
+
+This typically happens when using a custom domain with `httpOnly` cookies. When the SDK refreshes the access token in memory (about 10 seconds before expiry), the rotated `refresh_token` must be written back to the `httpOnly` cookie via a `Set-Cookie` response header. If the SDK's refresh request does not include `credentials: "include"`, the browser will not process that header and the cookie retains the old (now invalidated) refresh token. On the next page load, the cookie is read first and the mismatch causes `invalid_grant`.
+
+To confirm, check your network tab for the token refresh request — it should be a `POST` to `/oauth2/token` and the response should include `Set-Cookie`. If `credentials` is missing from the request, this is a known SDK issue. As a workaround, ensure your app uses `refreshToken()` explicitly and that your server-side configuration sends the correct `SameSite` and `Path` attributes.
+
+See [Refresh token cookie path scope](/build/tokens/refresh-tokens/#client-specific-refresh-token-cookies) and [token validation errors](/build/tokens/token-validation-errors/) for related context.
 
 ## API References - KindeProvider
 


### PR DESCRIPTION
Adds missing troubleshooting context for the React SDK refresh token / httpOnly cookie mismatch pattern, documents the _kbrte session cookie, and extends the invalid_grant error reference.

Gap report March 2026 — Gap 1 + Gap 13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `_kbrte` browser session cookie's role in authentication and SSO inactivity tracking
  * Added guidance on refresh token cookie path scope defaults and debugging
  * Expanded `invalid_grant` error documentation with additional scenarios
  * New FAQ addressing token refresh issues with custom domains and httpOnly cookies, including verification steps and workarounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->