### PR TITLE
fix: add multi-org session cookie behavior and permissions token (gap report)

### DIFF
--- a/src/content/docs/authenticate/manage-authentication/navigate-between-organizations.mdx
+++ b/src/content/docs/authenticate/manage-authentication/navigate-between-organizations.mdx
@@ -16,7 +16,7 @@ metadata:
   audience: [developer, frontend-developer]
   complexity: intermediate
   keywords: [organization switcher, B2B, ID tokens, React, multi-organization, org navigation]
-  updated: 2025-01-16
+  updated: 2026-04-13
 featured: false
 deprecated: false
 ---
@@ -116,3 +116,9 @@ With some extra styling, a switcher might look something like this:
   loading="lazy"
   decoding="async"
 />
+
+## Does the refresh token cookie affect other browser tabs when switching orgs?
+
+Yes. The refresh token cookie is shared across all browser tabs on the same domain. When a user switches to a different organization, the shared cookie is updated with the new org's refresh token. Other open tabs will pick up the new organization context on their next token refresh.
+
+For more on how this works and available workarounds, see [Session management](/authenticate/manage-authentication/session-management/#does-switching-organizations-affect-other-browser-tabs).

--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -15,7 +15,7 @@ metadata:
   audience: [developer, product-manager]
   complexity: intermediate
   keywords: [session management, SSO session, session cookies, inactivity timeout, browser session]
-  updated: 2026-04-03
+  updated: 2026-04-13
 featured: false
 deprecated: false
 ---
@@ -46,3 +46,9 @@ Kinde measures inactivity **on the server**. Browsing your own app—switching p
 There is **no public list of every action** that resets inactivity. In practice, treat **authenticated, end-user-facing traffic to Kinde** as the model, rather than assuming every client-side event is visible to Kinde.
 
 **Machine-to-machine (M2M)** integrations and the **Management API** use separate credentials and contexts. They are **not** equivalent to activity on a specific person’s browser SSO session when you interpret this setting.
+
+## Does switching organizations affect other browser tabs?
+
+Yes. When a user switches to a different organization (by calling `login({ orgCode })` from your app), a new refresh token for that organization is issued and stored in the `refresh_token` cookie. Because this cookie is shared across all tabs on the same domain, other tabs that were authenticated to a different organization will use the new cookie on their next token refresh — and will then be operating in the context of the most recently signed-in organization.
+
+If your application needs each browser tab to maintain an independent org context, you will need to manage org tokens at the application layer (for example, storing org-specific tokens in tab-local state rather than relying on the shared cookie).

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -42,7 +42,7 @@ Access tokens are a secure way of authenticating users and passing information a
 ```jsonc
 {
   "aud": [
-    "myapp:prod-api
+    "myapp:prod-api"
   ],
   "azp": "dee7f3c57b3c47e8b96edde2c7ecab7d",
   "exp": 1693371599,
@@ -65,13 +65,13 @@ Access tokens are a secure way of authenticating users and passing information a
     "delete:competitions",
     "view:stats",
     "invite:users",
-    "view:profile
+    "view:profile"
   ],
   "scp": [
     "openid",
     "profile",
     "email",
-    "offline
+    "offline"
   ],
   "sub": "kp:_xxxxxxxxx" // your user id
 }

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -39,7 +39,7 @@ Access tokens are a secure way of authenticating users and passing information a
 
 ## Example access token
 
-```json
+```jsonc
 {
   "aud": [
     "myapp:prod-api

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -29,13 +29,53 @@ keywords:
   - permissions
   - organization claims
   - billing trial
-updated: 2026-04-07
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to Kinde access tokens including standard JWT claims, Kinde-specific claims like organization codes and feature flags, and token behavior during refresh operations.
 ---
 
 Access tokens are a secure way of authenticating users and passing information about a user to a system.
+
+## Example access token
+
+```json
+{
+  "aud": [
+    "myapp:prod-api
+  ],
+  "azp": "dee7f3c57b3c47e8b96edde2c7ecab7d",
+  "exp": 1693371599,
+  "feature_flags": {
+    "analytics": {
+      "t": "b",
+      "v": true
+    },
+    "theme": {
+      "t": "s",
+      "v": "pink"
+    }
+  },
+  "iat": 1693285199,
+  "iss": "https://<your_subdomain>.kinde.com",
+  "jti": "fbb6bc62-x64e-4256-8ea4-8fb9a645b123",
+  "org_code": "org_xxxxxxxxx",
+  "permissions": [
+    "create:competitions",
+    "delete:competitions",
+    "view:stats",
+    "invite:users",
+    "view:profile
+  ],
+  "scp": [
+    "openid",
+    "profile",
+    "email",
+    "offline
+  ],
+  "sub": "kp:_xxxxxxxxx" // your user id
+}
+```
 
 ## Access token standard claims
 
@@ -105,45 +145,11 @@ Access tokens are a secure way of authenticating users and passing information a
 
   ```
 
-## Example access token
+## Can I remove claims to reduce token size?
 
-```json
-{
-  "aud": [
-    "myapp:prod-api
-  ],
-  "azp": "dee7f3c57b3c47e8b96edde2c7ecab7d",
-  "exp": 1693371599,
-  "feature_flags": {
-    "analytics": {
-      "t": "b",
-      "v": true
-    },
-    "theme": {
-      "t": "s",
-      "v": "pink"
-    }
-  },
-  "iat": 1693285199,
-  "iss": "https://<your_subdomain>.kinde.com",
-  "jti": "fbb6bc62-x64e-4256-8ea4-8fb9a645b123",
-  "org_code": "org_xxxxxxxxx",
-  "permissions": [
-    "create:competitions",
-    "delete:competitions",
-    "view:stats",
-    "invite:users",
-    "view:profile
-  ],
-  "scp": [
-    "openid",
-    "profile",
-    "email",
-    "offline
-  ],
-  "sub": "kp:_xxxxxxxxx" // your user id
-}
-```
+Yes. Kinde automatically populates the access token with claims like `permissions`, `feature_flags`, and `org_code`. If your app handles this data another way — or you want to keep JWTs small and free of client-readable claims — you can strip any of these from the token at generation time using the [user token generation workflow](/workflows/example-workflows/user-token-generation/#reduce-token-size).
+
+The workflow fires whenever a token is issued and gives you full control over what goes into the final token. You can also use it to retrieve data from the [Kinde Management API](/kinde-apis/management/) server-side instead of embedding it in the JWT.
 
 ## How long does an access token last?
 

--- a/src/content/docs/manage-users/roles-and-permissions/user-permissions.mdx
+++ b/src/content/docs/manage-users/roles-and-permissions/user-permissions.mdx
@@ -31,7 +31,7 @@ keywords:
   - dynamic permissions
   - token refresh
   - permission deletion
-updated: 2026-03-26
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Guide to managing user permissions in Kinde including permission creation, editing, deletion, key naming conventions, and integration with roles for access control.
@@ -77,3 +77,7 @@ When you delete a permission, you remove the permission access from all users wh
 ## Are Kinde permissions shared across environments?
 
 Yes. Permissions are defined at the **business level**, not per environment. A permission created in your development environment is the same permission in staging and production — there is no per-environment isolation. If your team needs to test permission changes without affecting production, manage each environment in a separate Kinde business. Permissions can also be grouped into [roles](/manage-users/roles-and-permissions/user-roles/) to make assigning access easier.
+
+## Are permissions included in access tokens?
+
+Yes. Permissions assigned to a user are automatically included in their access token as the `permissions` claim. If you want to keep them out of the token, you can use the [user token generation workflow](/workflows/example-workflows/user-token-generation/#reduce-token-size) to strip the claim before the token is issued. For details on the token structure and retrieval options, see [Access tokens](/build/tokens/about-access-tokens/).


### PR DESCRIPTION
Explains two areas of existing Kinde behavior that users are hitting unexpectedly, surfaced in the March 2026 gap report.

session-management.mdx — new section explaining that the refresh_token cookie is shared across all tabs; switching orgs in one tab affects others on their next refresh, with a workaround for app-layer isolation
navigate-between-organizations.mdx — short callout + cross-link to session management
Permissions in access tokens (Gap 8)

about-access-tokens.mdx — new **## Can I remove claims to reduce token size?** section covering how to strip permissions, feature_flags, and other claims via the user token generation workflow
user-permissions.mdx — cross-link to access tokens and the workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified organization-switching behavior: refresh token cookies are shared across tabs and can change other tabs’ org context on next token refresh.
  * Expanded access token guidance: reorganized examples and added guidance on which claims are auto-populated and how to reduce token size.
  * Added FAQs on permissions in access tokens and cross-tab org switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->