### PR TITLE
fix: document JSON flag API gap and logo 120px size limit (gap report)

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
@@ -15,7 +15,7 @@ metadata:
   audience: [developer, enterprise-admin, security-engineer]
   complexity: intermediate
   keywords: [user provisioning, JIT provisioning, enterprise connections, SSO, identity management, troubleshooting]
-  updated: 2025-01-16
+  updated: 2026-04-13
 featured: false
 deprecated: false
 ---
@@ -99,3 +99,9 @@ If duplicate identities are created for users in Kinde, it may because the **Tru
 **Customer's SSO auth not working**
 
 Some B2B businesses allow their customers to sign in using their own enterprise SSO. When setting this up, a common mistake is that they supply incorrect values for the Client ID and Client Secret, based on the identity provider information. Double check these if you come across connection issues.  
+
+## Automated provisioning with SCIM (coming soon)
+
+SCIM (System for Cross-domain Identity Management) support is currently in development. When available, SCIM will allow you to automatically provision and de-provision users in Kinde from your identity provider, and map IdP user groups to roles and permissions in Kinde — keeping user access in sync without manual steps.
+
+Follow progress and signal interest on the [Kinde roadmap](https://updates.kinde.com/board/integrate-scim-identity-management).

--- a/src/content/docs/design/brand/global-brand-defaults.mdx
+++ b/src/content/docs/design/brand/global-brand-defaults.mdx
@@ -30,7 +30,7 @@ keywords:
   - light theme
   - dark theme
   - user preference
-updated: 2024-01-15
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Guide for setting global brand defaults including logo upload, favicon configuration, theme selection, and brand color customization for authentication pages.
@@ -53,12 +53,19 @@ Use the following procedures to make design changes to suit your brand.
 
 Logos must be under 1MB, and they are resized to have a maximum width or height of 120 pixels based on the aspect ratio. SVG works best as it displays well on any screen, but PNG and other formats are accepted.
 
+    <Aside type="warning">
+
+    The 120 px maximum width is a fixed constraint and cannot be changed through standard brand settings. If you need a larger logo, use [custom authentication pages](/authenticate/custom-configurations/custom-authentication-pages/) to control the layout and sizing directly.
+
+    </Aside>
+
 1. In Kinde, go to **Design > Global > Brand**.
 2. In the **Logo** section, upload your company logo. Make sure images are less than 1MB, are PNG, JPEG, or GIF.
 3. Scroll down to the bottom of the page and select the global logo fallback behavior.
    - Enable to use the global logo as a fallback default for organizations where the logo is not available. This means the end customer will see the organization logo, if not the global level logo, and failing that, the name of the organization.
    - Disable if you want the default behavior to be show the organization logo, then the organization name, and as a last option show the global logo.
 4. Select **Save**.
+
 
 <Aside>
 

--- a/src/content/docs/design/brand/global-brand-defaults.mdx
+++ b/src/content/docs/design/brand/global-brand-defaults.mdx
@@ -53,11 +53,11 @@ Use the following procedures to make design changes to suit your brand.
 
 Logos must be under 1MB, and they are resized to have a maximum width or height of 120 pixels based on the aspect ratio. SVG works best as it displays well on any screen, but PNG and other formats are accepted.
 
-    <Aside type="warning">
+<Aside type="warning">
 
-    The 120 px maximum width is a fixed constraint and cannot be changed through standard brand settings. If you need a larger logo, use [custom authentication pages](/authenticate/custom-configurations/custom-authentication-pages/) to control the layout and sizing directly.
+The 120 px maximum height or width is a fixed constraint and cannot be changed through standard brand settings. If you need a larger logo, use [custom authentication pages](/authenticate/custom-configurations/custom-authentication-pages/) to control the layout and sizing directly.
 
-    </Aside>
+</Aside>
 
 1. In Kinde, go to **Design > Global > Brand**.
 2. In the **Logo** section, upload your company logo. Make sure images are less than 1MB, are PNG, JPEG, or GIF.
@@ -71,7 +71,7 @@ Logos must be under 1MB, and they are resized to have a maximum width or height 
 
 The logo will be automatically linked to the [Redirect URL](/get-started/connect/callback-urls/) set for your business, or the [application homepage URL](/design/brand/link-to-homepage/) set up for each application. If you are using tracking, the URL will also reflect that the user clicked out of the sign up/sign in screen, so you can distinguish this action from successful sign ins.
 
-   </Aside>
+</Aside>
 
 ## Add favicons for web browsers
 

--- a/src/content/docs/releases/feature-flags/manage-feature-flags-api.mdx
+++ b/src/content/docs/releases/feature-flags/manage-feature-flags-api.mdx
@@ -30,7 +30,7 @@ keywords:
   - delete flag
   - api management
   - management api
-updated: 2024-01-15
+updated: 2026-04-13
 featured: false
 deprecated: false
 ai_summary: Guide to managing feature flags through the Kinde API including setup requirements and available flag management functions.
@@ -53,3 +53,13 @@ If you plan to use feature flags through the Kinde API, you will be able to do t
 - Delete a flag
 
 [See relevant posts and responses in the API documentation.](/kinde-apis/management#tag/feature-flags)
+
+## Which flag types can I use in the API?
+
+When creating a feature flag via the Management API, the `type` field accepts the following values:
+
+- `str` — string
+- `int` — integer
+- `bool` — boolean
+
+The **JSON** flag type is available in the Kinde dashboard but is not currently supported via the Management API. JSON flags must be created in the dashboard. Once created, they can be managed (overridden, deleted) via the API, but the `type` cannot be set to `json` through an API call.


### PR DESCRIPTION
Documents two quick-win gaps from the March 2026 gap report:

**Feature flag JSON type (API gap)**: Adds a new **"Which flag types can I use in the API?"** section to the manage-feature-flags-api page. Clarifies that str, int, and bool are the only types supported via the Management API — the JSON type must be created in the dashboard.

**Logo sizing limit**: Adds a note inside the logo upload section of global-brand-defaults clarifying that 120 px is a fixed maximum width that cannot be overridden through brand settings, with a pointer to custom auth pages for users who need a larger logo.

**Add SCIM coming soon note**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated brand guidelines with clarification on logo sizing constraints and guidance for custom authentication pages.
  * Added API documentation clarifying supported flag types (`str`, `int`, `bool`) and noting that the `json` flag type cannot be created directly through the API.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->