### PR TITLE
doc feature: add bun as default tab in PackageManagers component

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -340,9 +340,7 @@ export default defineConfig({
         "./src/components/Aside.astro",
         "./src/components/FileTree.astro",
         "./src/components/Divider.astro",
-        {
-          "starlight-package-managers": ["PackageManagers"]
-        },
+        "./src/components/PackageManagers.astro",
         {
           "@astrojs/starlight/components": ["Tabs", "TabItem"]
         }

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -1,0 +1,9 @@
+---
+import { PackageManagers as SPM, type PackageManagersProps } from 'starlight-package-managers'
+
+type Props = PackageManagersProps
+
+const { pkgManagers = ['npm', 'pnpm', 'yarn', 'bun'], ...rest } = Astro.props
+---
+
+<SPM pkgManagers={pkgManagers} {...rest} />


### PR DESCRIPTION
Adds bun as a default tab alongside npm, pnpm, and yarn in all `<PackageManagers>` blocks across the docs.

Done via a thin wrapper component (src/components/PackageManagers.astro) that sets bun in the default pkgManagers array and forwards all other props to the underlying starlight-package-managers component. The auto-import in astro.config.mjs is updated to use the local wrapper instead of the direct package import. No MDX files needed to change.

<img width="423" height="148" alt="image" src="https://github.com/user-attachments/assets/e414bcce-c5f2-4c0c-94be-d035f0e36d29" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * PackageManagers component now includes default options for npm, pnpm, yarn, and bun when no managers are specified.
  * Component configuration has been restructured for improved integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->