### PR TITLE
chore: flatten metadata wrapper and extend frontmatter schema

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -17,7 +17,9 @@ export const collections = {
         sdk: z.union([z.string(), z.array(z.string())]).optional().nullable(),
         languages: z.union([z.string(), z.array(z.string())]).optional().nullable(),
         audience: z.union([z.string(), z.array(z.string())]).optional(),
-        complexity: z.string().optional()
+        complexity: z.string().optional(),
+        topics: z.array(z.string()).optional().nullable(),
+        updated: z.coerce.date().optional().nullable()
       })
     })
   }),

--- a/src/content/docs/authenticate/about-auth/about-authentication.mdx
+++ b/src/content/docs/authenticate/about-auth/about-authentication.mdx
@@ -12,18 +12,33 @@ relatedArticles:
 app_context:
   - m: settings
     s: authentication
-description: Learn about Kinde's authentication methods including password, passwordless, social sign-in, and enterprise connections.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [authentication, sign up, sign in, password, passwordless, social login, enterprise, SSO]
-  updated: 2025-01-16
+description: >-
+  Learn about Kinde's authentication methods including password, passwordless,
+  social sign-in, and enterprise connections.
 featured: false
 deprecated: false
-ai_summary: Comprehensive overview of Kinde's authentication methods including password, passwordless, social sign-in, and enterprise connections with multi-domain support.
+ai_summary: >-
+  Comprehensive overview of Kinde's authentication methods including password,
+  passwordless, social sign-in, and enterprise connections with multi-domain
+  support.
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - authentication
+  - sign up
+  - sign in
+  - password
+  - passwordless
+  - social login
+  - enterprise
+  - SSO
+updated: 2025-01-16
 ---
 
 Kinde makes authentication easy by providing a range of methods to choose from.

--- a/src/content/docs/authenticate/about-auth/authentication-faq.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-faq.mdx
@@ -11,16 +11,24 @@ app_context:
   - m: settings
     s: authentication
 description: Frequently asked questions about Kinde authentication.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, admin]
-  complexity: beginner
-  keywords: [authentication, FAQ, troubleshooting, setup, configuration]
-  updated: 2025-01-16
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - admin
+complexity: beginner
+keywords:
+  - authentication
+  - FAQ
+  - troubleshooting
+  - setup
+  - configuration
+updated: 2025-01-16
 ---
 
 Find answers to common questions about Kinde authentication. Click to expand a topic.

--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -10,18 +10,33 @@ relatedArticles:
   - 0145d1ce-564e-4c28-820f-2f126abbfe3a
   - a5225946-27ad-41c0-a3c1-9a6d735e3efb
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
-description: Detailed guide to all authentication methods supported by Kinde including email, phone, social, and enterprise authentication.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [email authentication, password, passwordless, phone auth, SMS, social login, enterprise SSO, OTP]
-  updated: 2026-03-26
+description: >-
+  Detailed guide to all authentication methods supported by Kinde including
+  email, phone, social, and enterprise authentication.
 featured: false
 deprecated: false
-ai_summary: Complete guide to Kinde's authentication methods including email/password, passwordless OTP, phone SMS authentication, social providers, and enterprise SSO connections.
+ai_summary: >-
+  Complete guide to Kinde's authentication methods including email/password,
+  passwordless OTP, phone SMS authentication, social providers, and enterprise
+  SSO connections.
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - email authentication
+  - password
+  - passwordless
+  - phone auth
+  - SMS
+  - social login
+  - enterprise SSO
+  - OTP
+updated: 2026-03-26
 ---
 
 Kinde supports the following authentication methods.

--- a/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
+++ b/src/content/docs/authenticate/about-auth/identity-and-verification.mdx
@@ -8,18 +8,31 @@ relatedArticles:
   - d5ab49ac-bf16-487a-b1a1-e07f68e42be7
   - 776166a5-eebd-42be-a695-36eaafba0823
   - 8b9376c4-308c-4eaa-a990-606fb8bbf770
-description: Understanding how user identity and verification works in Kinde, including identity types, trusted providers, and verification processes.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, security-engineer]
-  complexity: intermediate
-  keywords: [user identity, verification, trusted providers, email verification, social identity, enterprise identity, profile sync]
-  updated: 2025-01-16
+description: >-
+  Understanding how user identity and verification works in Kinde, including
+  identity types, trusted providers, and verification processes.
 featured: false
 deprecated: false
-ai_summary: Comprehensive guide to user identity management in Kinde covering identity types, verification processes, trusted providers, and profile synchronization.
+ai_summary: >-
+  Comprehensive guide to user identity management in Kinde covering identity
+  types, verification processes, trusted providers, and profile synchronization.
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - security-engineer
+complexity: intermediate
+keywords:
+  - user identity
+  - verification
+  - trusted providers
+  - email verification
+  - social identity
+  - enterprise identity
+  - profile sync
+updated: 2025-01-16
 ---
 
 A key part of making authentication secure, is through verification of user identities. Verification usually happens at sign up, to ensure the person signing up exists and is the intended person gaining access to your app or project.

--- a/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
+++ b/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
@@ -1,23 +1,43 @@
 ---
 page_id: c93d0dc2-adad-4bb3-9618-6dc2109d5aa8
 title: Top questions about Kinde authentication
-description: A collection of the top questions and answers about how to set up and configure Kinde authentication for your user's needs.
+description: >-
+  A collection of the top questions and answers about how to set up and
+  configure Kinde authentication for your user's needs.
 sidebar:
   order: 4
-relatedArticles: 
-   - cc242fb3-4b06-4842-97c8-dd58e87308df
-   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
-   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
-metadata:
-  topics: [authentication, enterprise auth, SSO, social sign-in, authentication issues, user access control, user access, user authentication]
-  audience: [frontend-developer]
-  complexity: beginner
-  keywords: [login, sign in, popup, error, sessions, tokens, auth, forgot password, password reset]
-  updated: 2026-03-26
+relatedArticles:
+  - cc242fb3-4b06-4842-97c8-dd58e87308df
+  - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
+  - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
 featured: false
 deprecated: false
 ai-summary: >
-  A collection of the top questions and answers about how to set up and configure Kinde authentication for your user's needs.
+  A collection of the top questions and answers about how to set up and
+  configure Kinde authentication for your user's needs.
+topics:
+  - authentication
+  - enterprise auth
+  - SSO
+  - social sign-in
+  - authentication issues
+  - user access control
+  - user access
+  - user authentication
+audience:
+  - frontend-developer
+complexity: beginner
+keywords:
+  - login
+  - sign in
+  - popup
+  - error
+  - sessions
+  - tokens
+  - auth
+  - forgot password
+  - password reset
+updated: 2026-03-26
 ---
 
 Here are concise answers to common authentication questions. Select a question to expand the answer.

--- a/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
+++ b/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
@@ -12,7 +12,7 @@ relatedArticles:
   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
 featured: false
 deprecated: false
-ai-summary: >
+ai_summary: >
   A collection of the top questions and answers about how to set up and
   configure Kinde authentication for your user's needs.
 topics:

--- a/src/content/docs/authenticate/about-auth/user-communication.mdx
+++ b/src/content/docs/authenticate/about-auth/user-communication.mdx
@@ -7,17 +7,29 @@ relatedArticles:
   - 0222489b-3478-48a7-a5c9-c99c6044f0e9
   - c4182a6d-64ca-4c82-ba33-e5fc5d8b8cad
   - e519f56a-603a-44dd-a946-3aaf6fb256ce
-description: Learn about how Kinde communicates with users through emails, SMS, and WhatsApp for authentication purposes.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [user communication, email, SMS, WhatsApp, OTP, verification, Twilio, webhooks]
-  updated: 2026-03-03
+description: >-
+  Learn about how Kinde communicates with users through emails, SMS, and
+  WhatsApp for authentication purposes.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - user communication
+  - email
+  - SMS
+  - WhatsApp
+  - OTP
+  - verification
+  - Twilio
+  - webhooks
+updated: 2026-03-03
 ---
 
 Kinde only sends emails or texts to users as part of the authentication experience, for example to send one-time passwords or to verify user identity for self-sign-up.

--- a/src/content/docs/authenticate/auth-guides/enterprise-connections-identity.mdx
+++ b/src/content/docs/authenticate/auth-guides/enterprise-connections-identity.mdx
@@ -6,17 +6,29 @@ sidebar:
 relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - e519f56a-603a-44dd-a946-3aaf6fb256ce
-description: Understanding why Kinde enforces one enterprise identity per user for security, account integrity, and simplified tenant management.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, security-engineer, enterprise-admin]
-  complexity: intermediate
-  keywords: [enterprise identity, SSO, identity provider, IdP, security, account integrity, tenant management]
-  updated: 2025-01-16
+description: >-
+  Understanding why Kinde enforces one enterprise identity per user for
+  security, account integrity, and simplified tenant management.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - security-engineer
+  - enterprise-admin
+complexity: intermediate
+keywords:
+  - enterprise identity
+  - SSO
+  - identity provider
+  - IdP
+  - security
+  - account integrity
+  - tenant management
+updated: 2025-01-16
 ---
 
 At Kinde, each user can only have one enterprise identity provider (IdP) connection as part of their user profile. This is because we want to keep things simple, secure, and reliable.

--- a/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
+++ b/src/content/docs/authenticate/auth-guides/mixed-b2b-b2c.mdx
@@ -9,17 +9,29 @@ relatedArticles:
   - 0145d1ce-564e-4c28-820f-2f126abbfe3a
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
-description: Complete guide to setting up unified authentication for mixed B2B and B2C businesses using Kinde Scale plan features.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, enterprise-admin]
-  complexity: advanced
-  keywords: [B2B, B2C, mixed authentication, enterprise connections, SAML, organizations, home realm discovery]
-  updated: 2025-01-16
+description: >-
+  Complete guide to setting up unified authentication for mixed B2B and B2C
+  businesses using Kinde Scale plan features.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - enterprise-admin
+complexity: advanced
+keywords:
+  - B2B
+  - B2C
+  - mixed authentication
+  - enterprise connections
+  - SAML
+  - organizations
+  - home realm discovery
+updated: 2025-01-16
 ---
 
 If you have an app or site that supports a mix of business customers and direct customers, this guide shows you how to set up authentication in Kinde to meet both these needs.

--- a/src/content/docs/authenticate/auth-guides/pass-params-idp.mdx
+++ b/src/content/docs/authenticate/auth-guides/pass-params-idp.mdx
@@ -7,17 +7,29 @@ relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - b663dbde-2045-4f51-bab4-84d0c9fbe15b
   - 50284476-2442-414c-af20-01ed3ef4ca4e
-description: Learn how to pass static and dynamic parameters to identity providers during authentication for improved user experience.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: [json]
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [upstream params, identity provider, OAuth 2.0, SAML, login_hint, prompt, account switcher]
-  updated: 2025-01-16
+description: >-
+  Learn how to pass static and dynamic parameters to identity providers during
+  authentication for improved user experience.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages:
+  - json
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - upstream params
+  - identity provider
+  - OAuth 2.0
+  - SAML
+  - login_hint
+  - prompt
+  - account switcher
+updated: 2025-01-16
 ---
 
 You can pass provider-specific parameters to an Identity Provider (IdP) during authentication. These are also known as 'upstream params'. The values your pass can either be static per connection or dynamic per user.

--- a/src/content/docs/authenticate/authentication-methods/email-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/email-authentication.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - c4bc277a-5ec7-418c-ba1c-4d58c9ddfd7d
   - 2aa551b8-06c0-4947-bd4b-d643c77ed224
-description: Comprehensive overview of email authentication methods including verification, account linking, and customization options.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [email authentication, email verification, account linking, Gravatar, login_hint, profile pictures]
-  updated: 2025-01-16
+description: >-
+  Comprehensive overview of email authentication methods including verification,
+  account linking, and customization options.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - email authentication
+  - email verification
+  - account linking
+  - Gravatar
+  - login_hint
+  - profile pictures
+updated: 2025-01-16
 ---
 
 The most common application signup and sign in method for users is email. Kinde supports a number of approaches to email authentication.

--- a/src/content/docs/authenticate/authentication-methods/email-deliverability.mdx
+++ b/src/content/docs/authenticate/authentication-methods/email-deliverability.mdx
@@ -8,17 +8,29 @@ relatedArticles:
   - 90134c89-16e4-4981-b988-b0cb4f1722c5
 tableOfContents:
   maxHeadingLevel: 3
-description: Guide to email deliverability best practices including custom email senders, authentication records, and troubleshooting delivery issues.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, devops]
-  complexity: intermediate
-  keywords: [email deliverability, SMTP, SPF, DMARC, DKIM, email authentication, spam prevention]
-  updated: 2026-03-03
+description: >-
+  Guide to email deliverability best practices including custom email senders,
+  authentication records, and troubleshooting delivery issues.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - devops
+complexity: intermediate
+keywords:
+  - email deliverability
+  - SMTP
+  - SPF
+  - DMARC
+  - DKIM
+  - email authentication
+  - spam prevention
+updated: 2026-03-03
 ---
 
 Kinde encourages users to configure their own email sender, so that verification and other emails are sent from your own business, and not Kinde.

--- a/src/content/docs/authenticate/authentication-methods/password-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/password-authentication.mdx
@@ -7,17 +7,29 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - d5ab49ac-bf16-487a-b1a1-e07f68e42be7
   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
-description: Complete guide to password authentication in Kinde including security features, password strength requirements, forgot password flow, and password reset options.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [password authentication, password strength, password reset, security, hash encryption, MFA, forgot password]
-  updated: 2026-03-26
+description: >-
+  Complete guide to password authentication in Kinde including security
+  features, password strength requirements, forgot password flow, and password
+  reset options.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - password authentication
+  - password strength
+  - password reset
+  - security
+  - hash encryption
+  - MFA
+  - forgot password
+updated: 2026-03-26
 ---
 
 Password authentication is where an end user supplies and maintains their own password to access your app or project.

--- a/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
   - 0145d1ce-564e-4c28-820f-2f126abbfe3a
   - 8a385f58-5e01-437c-8128-6b86ee8ff382
-description: Guide to passwordless authentication using one-time passcodes (OTP) via email or phone, including setup and security considerations.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [passwordless authentication, OTP, one-time passcode, email code, phone code, security]
-  updated: 2025-01-16
+description: >-
+  Guide to passwordless authentication using one-time passcodes (OTP) via email
+  or phone, including setup and security considerations.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - passwordless authentication
+  - OTP
+  - one-time passcode
+  - email code
+  - phone code
+  - security
+updated: 2025-01-16
 ---
 
 Passwordless authentication is a type of authentication that does not require end-users to set or maintain passwords for access to an application. Instead, they authenticate using a one-time passcode (OTP).

--- a/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
@@ -7,17 +7,28 @@ relatedArticles:
   - f18a5a74-23b3-43d8-8db9-440ee485e4d4
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
-description: Complete setup guide for phone/SMS authentication using Twilio, including configuration, MFA integration, and message formatting.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: intermediate
-  keywords: [phone authentication, SMS, Twilio, MFA, A2P messaging, 10DLC, verification code]
-  updated: 2026-03-03
+description: >-
+  Complete setup guide for phone/SMS authentication using Twilio, including
+  configuration, MFA integration, and message formatting.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: intermediate
+keywords:
+  - phone authentication
+  - SMS
+  - Twilio
+  - MFA
+  - A2P messaging
+  - 10DLC
+  - verification code
+updated: 2026-03-03
 ---
 
 You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up. 

--- a/src/content/docs/authenticate/authentication-methods/set-up-user-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/set-up-user-authentication.mdx
@@ -18,17 +18,29 @@ app_context:
     s: mfa
   - m: settings
     s: mfa
-description: Comprehensive guide to configuring all authentication methods in Kinde including email, phone, username, social, and enterprise connections.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [authentication setup, email auth, phone auth, username auth, social auth, enterprise auth, SAML, OAuth]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to configuring all authentication methods in Kinde
+  including email, phone, username, social, and enterprise connections.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - authentication setup
+  - email auth
+  - phone auth
+  - username auth
+  - social auth
+  - enterprise auth
+  - SAML
+  - OAuth
+updated: 2025-01-16
 ---
 
 Kinde supports many authentication options that let you control how users access your applications.

--- a/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
+++ b/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - 8b9376c4-308c-4eaa-a990-606fb8bbf770
   - c2a21e18-b542-4c07-a3b3-206ed4ce9508
-description: Guide to SMS deliverability including regional considerations, sender ID configuration, and country-specific delivery rates.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, devops]
-  complexity: intermediate
-  keywords: [SMS deliverability, Twilio, sender ID, regional delivery, 10DLC, A2P messaging]
-  updated: 2026-03-03
+description: >-
+  Guide to SMS deliverability including regional considerations, sender ID
+  configuration, and country-specific delivery rates.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - devops
+complexity: intermediate
+keywords:
+  - SMS deliverability
+  - Twilio
+  - sender ID
+  - regional delivery
+  - 10DLC
+  - A2P messaging
+updated: 2026-03-03
 ---
 
 Kinde encourages customers to configure their own SMS sender, so that verification, country registrations, sender IDs, and deliverability metrics are controlled and managed by you.

--- a/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/username-authentication.mdx
@@ -6,17 +6,26 @@ sidebar:
 relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
-description: Guide to username-based authentication including unique constraints, sign-up flow, and integration with password/passwordless methods.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [username authentication, unique usernames, case insensitive, sign-up flow, identity verification]
-  updated: 2025-01-16
+description: >-
+  Guide to username-based authentication including unique constraints, sign-up
+  flow, and integration with password/passwordless methods.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - username authentication
+  - unique usernames
+  - case insensitive
+  - sign-up flow
+  - identity verification
+updated: 2025-01-16
 ---
 
 Along with email and phone number, Kinde supports authentication where a username is the user’s sign-in identity.

--- a/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
@@ -8,17 +8,27 @@ relatedArticles:
   - 90134c89-16e4-4981-b988-b0cb4f1722c5
 tableOfContents:
   maxHeadingLevel: 3
-description: Configure WhatsApp in Kinde to send OTP and MFA codes via WhatsApp, with fallback to SMS. Uses your Meta/WhatsApp Business account.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: intermediate
-  keywords: [WhatsApp, OTP, MFA, Meta, WhatsApp Business, messaging]
-  updated: 2026-03-03
+description: >-
+  Configure WhatsApp in Kinde to send OTP and MFA codes via WhatsApp, with
+  fallback to SMS. Uses your Meta/WhatsApp Business account.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: intermediate
+keywords:
+  - WhatsApp
+  - OTP
+  - MFA
+  - Meta
+  - WhatsApp Business
+  - messaging
+updated: 2026-03-03
 ---
 
 You can send one-time passcodes (OTP) and multi-factor authentication (MFA) codes via **WhatsApp** in addition to SMS. When WhatsApp is set up and enabled, Kinde prefers WhatsApp for delivering codes and falls back to SMS if WhatsApp delivery fails and SMS is configured.

--- a/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
+++ b/src/content/docs/authenticate/custom-configurations/advanced-organization.mdx
@@ -9,17 +9,28 @@ relatedArticles:
   - 38e9186d-cca5-44a6-86ab-dde9f21167ff
   - 692187c5-1b82-467a-b86f-85b9098ecaab
   - 309186eb-1d2a-45d0-9089-b516e65927f9
-description: Guide to advanced organization features including custom policies, default roles, email senders, custom domains, and organization-level MFA.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, product-manager]
-  complexity: advanced
-  keywords: [advanced organizations, organization policies, default roles, custom email sender, custom domains, organization MFA]
-  updated: 2025-01-16
+description: >-
+  Guide to advanced organization features including custom policies, default
+  roles, email senders, custom domains, and organization-level MFA.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - product-manager
+complexity: advanced
+keywords:
+  - advanced organizations
+  - organization policies
+  - default roles
+  - custom email sender
+  - custom domains
+  - organization MFA
+updated: 2025-01-16
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
+++ b/src/content/docs/authenticate/custom-configurations/authentication-experience.mdx
@@ -9,17 +9,29 @@ relatedArticles:
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
   - 1c180220-a98c-42b7-8707-3b95a1ecb4e5
   - 3821e088-e51c-4a10-a4e1-b471a525d75b
-description: Comprehensive guide to customizing the authentication experience including unified sign-up, name requirements, marketing consent, and profile picture settings.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, ux-designer]
-  complexity: intermediate
-  keywords: [authentication experience, unified sign-up, seamless registration, marketing consent, Gravatar, login_hint]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to customizing the authentication experience including
+  unified sign-up, name requirements, marketing consent, and profile picture
+  settings.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - ux-designer
+complexity: intermediate
+keywords:
+  - authentication experience
+  - unified sign-up
+  - seamless registration
+  - marketing consent
+  - Gravatar
+  - login_hint
+updated: 2025-01-16
 ---
 
 Kinde aims to give you as much control of your user’s sign up and sign in experience as possible, without compromising security. Here are some options for customizing the authentication experience in your applications.

--- a/src/content/docs/authenticate/custom-configurations/custom-authentication-pages.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-authentication-pages.mdx
@@ -8,17 +8,32 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 776166a5-eebd-42be-a695-36eaafba0823
   - 8b9376c4-308c-4eaa-a990-606fb8bbf770
-description: Step-by-step guide to creating custom authentication pages while maintaining Kinde's security for verification and MFA processes.
-metadata:
-  topics: [authenticate]
-  sdk: [react, nextjs]
-  languages: [javascript, jsx]
-  audience: [developer, frontend-developer]
-  complexity: advanced
-  keywords: [custom authentication pages, connection ID, login_hint, social auth, email auth, phone auth, enterprise auth]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to creating custom authentication pages while maintaining
+  Kinde's security for verification and MFA processes.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk:
+  - react
+  - nextjs
+languages:
+  - javascript
+  - jsx
+audience:
+  - developer
+  - frontend-developer
+complexity: advanced
+keywords:
+  - custom authentication pages
+  - connection ID
+  - login_hint
+  - social auth
+  - email auth
+  - phone auth
+  - enterprise auth
+updated: 2025-01-16
 ---
 
 You can host your own custom sign up and sign in pages to use with Kinde. Integrate your own designs for the initial sign up and sign in page, and still get the security of Kinde’s auth (and verification) process.

--- a/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
+++ b/src/content/docs/authenticate/custom-configurations/custom-oauth2-connection.mdx
@@ -7,17 +7,29 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 64079be6-be72-4b63-a9d1-4466af4d49be
   - a5225946-27ad-41c0-a3c1-9a6d735e3efb
-description: Step-by-step guide to setting up custom OAuth2 and OIDC connections including OAuth provider setup, credentials configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: advanced
-  keywords: [custom OAuth2, OIDC, OAuth provider, client ID, client secret, callback URL, custom connection, identity provider]
-  updated: 2026-03-03
+description: >-
+  Step-by-step guide to setting up custom OAuth2 and OIDC connections including
+  OAuth provider setup, credentials configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: advanced
+keywords:
+  - custom OAuth2
+  - OIDC
+  - OAuth provider
+  - client ID
+  - client secret
+  - callback URL
+  - custom connection
+  - identity provider
+updated: 2026-03-03
 ---
 
 You can enable users to sign up and sign in using their credentials from any OAuth2- and Open ID connection- compatible identity provider. To set this up, you need access to your provider's developer console and a little technical know-how. We recommend setting this up in a non-production environment first, to test the connection thoroughly.

--- a/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
+++ b/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
@@ -12,17 +12,27 @@ app_context:
     s: authentication
   - m: settings
     s: environment_details
-description: Guide to disabling self sign-up for your business or specific organizations, allowing only selective user addition via import, manual addition, or API.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, enterprise-admin]
-  complexity: beginner
-  keywords: [disable sign-up, self sign-up, invitation only, user management, organization policies]
-  updated: 2025-01-16
+description: >-
+  Guide to disabling self sign-up for your business or specific organizations,
+  allowing only selective user addition via import, manual addition, or API.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - enterprise-admin
+complexity: beginner
+keywords:
+  - disable sign-up
+  - self sign-up
+  - invitation only
+  - user management
+  - organization policies
+updated: 2025-01-16
 ---
 
 You can prevent users from signing up to your business, and only add users selectively.

--- a/src/content/docs/authenticate/custom-configurations/prepopulate-identity-sign-in.mdx
+++ b/src/content/docs/authenticate/custom-configurations/prepopulate-identity-sign-in.mdx
@@ -6,17 +6,33 @@ sidebar:
 relatedArticles:
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
   - cc242fb3-4b06-4842-97c8-dd58e87308df
-description: Guide to pre-populating user identity fields using login_hint parameter for email, phone, and username authentication to improve user experience.
-metadata:
-  topics: [authenticate]
-  sdk: [react, nextjs]
-  languages: [javascript, jsx]
-  audience: [developer, frontend-developer, ux-designer]
-  complexity: intermediate
-  keywords: [login_hint, pre-populate, user identity, email, phone, username, authentication UX]
-  updated: 2025-01-16
+description: >-
+  Guide to pre-populating user identity fields using login_hint parameter for
+  email, phone, and username authentication to improve user experience.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk:
+  - react
+  - nextjs
+languages:
+  - javascript
+  - jsx
+audience:
+  - developer
+  - frontend-developer
+  - ux-designer
+complexity: intermediate
+keywords:
+  - login_hint
+  - pre-populate
+  - user identity
+  - email
+  - phone
+  - username
+  - authentication UX
+updated: 2025-01-16
 ---
 
 You can create a smoother sign-up and sign-in experience by passing a login_hint when users authenticate. When the user arrives at the sign-in page, their credentials are pre-filled, saving them time. This works for emails, phone numbers, and usernames.

--- a/src/content/docs/authenticate/custom-configurations/proxy-your-kinde-auth-pages-through-cloudflare.mdx
+++ b/src/content/docs/authenticate/custom-configurations/proxy-your-kinde-auth-pages-through-cloudflare.mdx
@@ -5,17 +5,29 @@ sidebar:
   order: 9
 relatedArticles:
   - f0bc688b-a817-42ab-9a20-8e09cec06f37
-description: Guide to proxying Kinde authentication pages through Cloudflare to leverage advanced security features like WAF and bot mitigation.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, devops, security-engineer]
-  complexity: advanced
-  keywords: [Cloudflare proxy, WAF, bot mitigation, custom domain, DNS, SSL, security]
-  updated: 2025-01-16
+description: >-
+  Guide to proxying Kinde authentication pages through Cloudflare to leverage
+  advanced security features like WAF and bot mitigation.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - devops
+  - security-engineer
+complexity: advanced
+keywords:
+  - Cloudflare proxy
+  - WAF
+  - bot mitigation
+  - custom domain
+  - DNS
+  - SSL
+  - security
+updated: 2025-01-16
 ---
 
 You can take advantage of Cloudflare’s advanced security features such as their WAF and bot mitigation tools by proxying your Kinde hosted auth pages through Cloudflare.

--- a/src/content/docs/authenticate/custom-configurations/redirect-users.mdx
+++ b/src/content/docs/authenticate/custom-configurations/redirect-users.mdx
@@ -6,17 +6,29 @@ sidebar:
 relatedArticles:
   - 02d02820-92da-4721-9a91-222c9b095869
   - 684fc526-a338-4a67-9af6-742a39b66aff
-description: Guide to redirecting users after authentication using cookies, local storage, or the state parameter for secure post-auth navigation.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: [javascript, jsx]
-  audience: [developer, frontend-developer]
-  complexity: intermediate
-  keywords: [user redirect, callback URL, state parameter, CSRF protection, local storage, cookies]
-  updated: 2025-01-16
+description: >-
+  Guide to redirecting users after authentication using cookies, local storage,
+  or the state parameter for secure post-auth navigation.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages:
+  - javascript
+  - jsx
+audience:
+  - developer
+  - frontend-developer
+complexity: intermediate
+keywords:
+  - user redirect
+  - callback URL
+  - state parameter
+  - CSRF protection
+  - local storage
+  - cookies
+updated: 2025-01-16
 ---
 
 After authenticating a user in Kinde, you can return them to a specific page within your application.

--- a/src/content/docs/authenticate/custom-configurations/static-ip.mdx
+++ b/src/content/docs/authenticate/custom-configurations/static-ip.mdx
@@ -6,16 +6,21 @@ sidebar:
 relatedArticles:
   - c53c9254-7bbb-4d58-b949-3ccdc3cd3dee
 description: Guide to using a static IP address for your Kinde business.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin]
-  complexity: advanced
-  keywords: [static-ip, infrastructure, whitelist]
-  updated: 2025-08-06
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+complexity: advanced
+keywords:
+  - static-ip
+  - infrastructure
+  - whitelist
+updated: 2025-08-06
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -11,17 +11,31 @@ relatedArticles:
 app_context:
   - m: settings
     s: authentication
-description: Comprehensive overview of enterprise authentication connections including SAML, Microsoft Entra ID, Google Workspace, Okta, and Cloudflare with provisioning options.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: intermediate
-  keywords: [enterprise connections, SAML, Microsoft Entra ID, Google Workspace, Okta, Cloudflare, SSO, JIT provisioning]
-  updated: 2026-03-26
+description: >-
+  Comprehensive overview of enterprise authentication connections including
+  SAML, Microsoft Entra ID, Google Workspace, Okta, and Cloudflare with
+  provisioning options.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: intermediate
+keywords:
+  - enterprise connections
+  - SAML
+  - Microsoft Entra ID
+  - Google Workspace
+  - Okta
+  - Cloudflare
+  - SSO
+  - JIT provisioning
+updated: 2026-03-26
 ---
 
 Enterprise authentication is a common method for managing user access to systems in large organizations.

--- a/src/content/docs/authenticate/enterprise-connections/advanced-saml-configurations.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/advanced-saml-configurations.mdx
@@ -4,21 +4,34 @@ title: Advanced SAML configurations
 sidebar:
   order: 13
 relatedArticles:
-  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
-description: Advanced SAML configuration options including Name ID formats, signing algorithms, protocol bindings, and upstream parameters for enterprise authentication.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [SAML, Name ID, signing algorithm, protocol binding, upstream parameters, RSA-SHA256, HTTP POST binding]
-  updated: 2025-09-19
+description: >-
+  Advanced SAML configuration options including Name ID formats, signing
+  algorithms, protocol bindings, and upstream parameters for enterprise
+  authentication.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - SAML
+  - Name ID
+  - signing algorithm
+  - protocol binding
+  - upstream parameters
+  - RSA-SHA256
+  - HTTP POST binding
+updated: 2025-09-19
 ---
 
 When you set up a SAML connection, you might need to include advanced configurations to meet identity provider requirements, and to get the connection running properly and securely.

--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -1,6 +1,6 @@
 ---
 page_id: 98f6868a-7871-4ece-ba9c-2a7b21d1b322
-title: Microsoft Entra ID enterprise connection (OAuth 2.0, WS-Fed)
+title: 'Microsoft Entra ID enterprise connection (OAuth 2.0, WS-Fed)'
 sidebar:
   order: 6
 relatedArticles:
@@ -11,18 +11,32 @@ relatedArticles:
 app_context:
   - m: settings
   - s: authentication
-description: Step-by-step guide to setting up Microsoft Entra ID (formerly Azure AD) enterprise authentication with WS Federated and OAuth 2.0 protocols.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [Microsoft Entra ID, Azure AD, WS Federated, OAuth 2.0, enterprise auth, group sync, upstream params]
-  updated: 2026-01-12
-ai_summary: Step-by-step guide to setting up Microsoft Entra ID (formerly Azure AD) enterprise authentication with WS Federated and OAuth 2.0 protocols.
+description: >-
+  Step-by-step guide to setting up Microsoft Entra ID (formerly Azure AD)
+  enterprise authentication with WS Federated and OAuth 2.0 protocols.
+ai_summary: >-
+  Step-by-step guide to setting up Microsoft Entra ID (formerly Azure AD)
+  enterprise authentication with WS Federated and OAuth 2.0 protocols.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - Microsoft Entra ID
+  - Azure AD
+  - WS Federated
+  - OAuth 2.0
+  - enterprise auth
+  - group sync
+  - upstream params
+updated: 2026-01-12
 ---
 
 Kinde supports the use of Microsoft Entra ID as an authentication method. We support WS Federated and OAuth2.0 (follow the topic below), and [Microsoft Entra ID SAML](/authenticate/enterprise-connections/entra-id-saml/) which is covered in a separate topic.

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -6,19 +6,32 @@ sidebar:
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
-  - e100d77b-530b-4327-8216-93c955657e0c	
+  - e100d77b-530b-4327-8216-93c955657e0c
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
-description: Step-by-step guide to integrating Cloudflare as a SAML identity provider with Kinde for enterprise authentication and access control.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [Cloudflare, SAML, identity provider, IdP, Zero Trust, enterprise auth, SSO, access policies]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to integrating Cloudflare as a SAML identity provider with
+  Kinde for enterprise authentication and access control.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - Cloudflare
+  - SAML
+  - identity provider
+  - IdP
+  - Zero Trust
+  - enterprise auth
+  - SSO
+  - access policies
+updated: 2025-01-16
 ---
 
 If you use Cloudflare to centralize authentication and authorization in your business, you can integrate Kinde as a service provider for these processes. This gives you the benefits of Kinde’s robust auth capabilities, while keeping the familiar Cloudflare structure.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -5,20 +5,31 @@ sidebar:
   order: 9
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
-  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - e100d77b-530b-4327-8216-93c955657e0c
-description: Step-by-step guide to setting up Google Workspace SAML authentication including metadata file hosting and Admin Console configuration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [Google Workspace, SAML, enterprise auth, metadata hosting, Admin Console, SSO]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Google Workspace SAML authentication
+  including metadata file hosting and Admin Console configuration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - Google Workspace
+  - SAML
+  - enterprise auth
+  - metadata hosting
+  - Admin Console
+  - SSO
+updated: 2025-01-16
 ---
 
 You can set up SAML to work with your Google Workspace.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -5,24 +5,39 @@ sidebar:
   order: 12
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
-  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
 app_context:
   - m: settings
     s: authentication
-description: Complete guide to setting up custom SAML authentication with any identity provider including certificate generation, advanced configurations, and testing.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [SAML, custom SAML, identity provider, IdP, service provider, SP, certificate, private key, JIT provisioning]
-  updated: 2025-01-16
+description: >-
+  Complete guide to setting up custom SAML authentication with any identity
+  provider including certificate generation, advanced configurations, and
+  testing.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - SAML
+  - custom SAML
+  - identity provider
+  - IdP
+  - service provider
+  - SP
+  - certificate
+  - private key
+  - JIT provisioning
+updated: 2025-01-16
 ---
 
 In Kinde, you can use SAML as your authentication protocol. Kinde acts as a service provider (SP), so you still need to bring your own identity provider (IdP) to set it up. Identity providers can include Google, Microsoft, Cloudflare, and others.

--- a/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
@@ -8,17 +8,28 @@ relatedArticles:
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
-description: Guide to setting up enterprise connections for B2B businesses including organization-level connections and domain-based access control.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, product-manager]
-  complexity: advanced
-  keywords: [B2B, enterprise connections, organization-level, domain restrictions, JIT provisioning, allowed domains]
-  updated: 2025-12-19
+description: >-
+  Guide to setting up enterprise connections for B2B businesses including
+  organization-level connections and domain-based access control.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - product-manager
+complexity: advanced
+keywords:
+  - B2B
+  - enterprise connections
+  - organization-level
+  - domain restrictions
+  - JIT provisioning
+  - allowed domains
+updated: 2025-12-19
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -1,24 +1,35 @@
 ---
 page_id: ed2f7810-6f8c-4dec-bcf1-f49922174daa
 title: Microsoft Entra ID enterprise connection (SAML)
-sidebar: 
+sidebar:
   order: 7
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
   - e100d77b-530b-4327-8216-93c955657e0c
-description: Step-by-step guide to setting up Microsoft Entra ID SAML enterprise authentication including application configuration and group synchronization.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [Microsoft Entra ID, SAML, Azure AD, enterprise application, group claims, federation metadata]
-  updated: 2026-03-26
+description: >-
+  Step-by-step guide to setting up Microsoft Entra ID SAML enterprise
+  authentication including application configuration and group synchronization.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - Microsoft Entra ID
+  - SAML
+  - Azure AD
+  - enterprise application
+  - group claims
+  - federation metadata
+updated: 2026-03-26
 ---
 
 Kinde supports the use of Microsoft Entra ID (SAML) as an enterprise-level authentication method. This service used to be Azure AD.

--- a/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
@@ -4,20 +4,31 @@ title: Home realm or IdP discovery
 sidebar:
   order: 4
 relatedArticles:
-  - fcf28a71-c3a8-4474-9564-ad089d3f2105  
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - cc242fb3-4b06-4842-97c8-dd58e87308df
-description: Guide to home realm discovery (HRD) for seamless enterprise authentication routing based on email domains and identity provider selection.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: intermediate
-  keywords: [home realm discovery, HRD, IdP discovery, email domain routing, enterprise auth, SSO button]
-  updated: 2026-03-26
+description: >-
+  Guide to home realm discovery (HRD) for seamless enterprise authentication
+  routing based on email domains and identity provider selection.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: intermediate
+keywords:
+  - home realm discovery
+  - HRD
+  - IdP discovery
+  - email domain routing
+  - enterprise auth
+  - SSO button
+updated: 2026-03-26
 ---
 
 Home realm discovery (HRD) provides a seamless sign-in experience for your enterprise auth users. When HRD is configured and a user sign in, Kinde checks which IdP or connection group a user belongs to, before authenticating them. It is also known as Identity Provider or IdP discovery.

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -10,18 +10,33 @@ relatedArticles:
 app_context:
   - m: settings
     s: authentication
-description: Guide to configuring IdP-initiated SAML single sign-on flows where authentication starts at the Identity Provider rather than your application.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [IdP-initiated, SAML, SSO, identity provider, service provider, SP-initiated, enterprise authentication]
-  updated: 2025-12-19
+description: >-
+  Guide to configuring IdP-initiated SAML single sign-on flows where
+  authentication starts at the Identity Provider rather than your application.
 featured: false
 deprecated: false
-ai_summary: Guide to configuring IdP-initiated SAML single sign-on flows where authentication starts at the Identity Provider rather than your application, including setup steps, IdP configuration, and security best practices.
+ai_summary: >-
+  Guide to configuring IdP-initiated SAML single sign-on flows where
+  authentication starts at the Identity Provider rather than your application,
+  including setup steps, IdP configuration, and security best practices.
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - IdP-initiated
+  - SAML
+  - SSO
+  - identity provider
+  - service provider
+  - SP-initiated
+  - enterprise authentication
+updated: 2025-12-19
 ---
 
 In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.

--- a/src/content/docs/authenticate/enterprise-connections/lastpass-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/lastpass-sso.mdx
@@ -6,19 +6,31 @@ sidebar:
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
-  - e100d77b-530b-4327-8216-93c955657e0c	
+  - e100d77b-530b-4327-8216-93c955657e0c
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
-description: Step-by-step guide to integrating LastPass as a SAML identity provider with Kinde for enterprise authentication and access control.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [LastPass, SAML, identity provider, IdP, enterprise auth, SSO, access policies]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to integrating LastPass as a SAML identity provider with
+  Kinde for enterprise authentication and access control.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - LastPass
+  - SAML
+  - identity provider
+  - IdP
+  - enterprise auth
+  - SSO
+  - access policies
+updated: 2025-01-16
 ---
 
 If you use LastPass to centralize authentication and authorization in your business, you can integrate Kinde as a service provider for these processes. This gives you the benefits of Kinde’s robust auth capabilities, while keeping the familiar LastPass structure.

--- a/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
@@ -8,17 +8,30 @@ relatedArticles:
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
-description: Guide to mapping and syncing users for enterprise authentication including user ID mapping, profile sync, and webhook integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: [json]
-  audience: [developer, enterprise-admin, integration-engineer]
-  complexity: advanced
-  keywords: [user mapping, user syncing, enterprise auth, webhooks, profile sync, user ID, API integration]
-  updated: 2025-01-16
+description: >-
+  Guide to mapping and syncing users for enterprise authentication including
+  user ID mapping, profile sync, and webhook integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages:
+  - json
+audience:
+  - developer
+  - enterprise-admin
+  - integration-engineer
+complexity: advanced
+keywords:
+  - user mapping
+  - user syncing
+  - enterprise auth
+  - webhooks
+  - profile sync
+  - user ID
+  - API integration
+updated: 2025-01-16
 ---
 
 When you use Kinde to authenticate users via an enterprise connection such as SAML, you also need a way for users to be identified in Kinde so they match the identities stored in your Identity Provider (IdP).

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -6,19 +6,31 @@ sidebar:
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
-  - e100d77b-530b-4327-8216-93c955657e0c	
+  - e100d77b-530b-4327-8216-93c955657e0c
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
-description: Step-by-step guide to integrating Okta as a SAML identity provider with Kinde, including application setup and troubleshooting.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [Okta, SAML, identity provider, IdP, enterprise auth, SSO, application assignment]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to integrating Okta as a SAML identity provider with Kinde,
+  including application setup and troubleshooting.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - Okta
+  - SAML
+  - identity provider
+  - IdP
+  - enterprise auth
+  - SSO
+  - application assignment
+updated: 2025-01-16
 ---
 
 If you use Okta to centralize authentication and authorization in your business, you can integrate Kinde as a service provider for these processes. This gives you the benefits of Kinde’s robust auth capabilities, while keeping the familiar Okta structure.

--- a/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
@@ -7,17 +7,28 @@ relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
-description: Comprehensive guide to user provisioning for enterprise connections including JIT provisioning, pre-provisioning, and troubleshooting SSO issues.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: intermediate
-  keywords: [user provisioning, JIT provisioning, enterprise connections, SSO, identity management, troubleshooting]
-  updated: 2026-04-13
+description: >-
+  Comprehensive guide to user provisioning for enterprise connections including
+  JIT provisioning, pre-provisioning, and troubleshooting SSO issues.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: intermediate
+keywords:
+  - user provisioning
+  - JIT provisioning
+  - enterprise connections
+  - SSO
+  - identity management
+  - troubleshooting
+updated: 2026-04-13
 ---
 
 When you set up Kinde with enterprise authentication like SAML or Cloudflare, you’ll want to make sure that users are set up with the correct access and identity from day one. How you do this depends on how you ‘provision’ their enterprise user identity.

--- a/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
@@ -6,17 +6,27 @@ sidebar:
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041
-description: Quick guide to refreshing SAML certificates and private keys for enterprise authentication security maintenance.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: intermediate
-  keywords: [SAML certificate, private key, certificate refresh, enterprise auth, security maintenance]
-  updated: 2025-01-16
+description: >-
+  Quick guide to refreshing SAML certificates and private keys for enterprise
+  authentication security maintenance.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: intermediate
+keywords:
+  - SAML certificate
+  - private key
+  - certificate refresh
+  - enterprise auth
+  - security maintenance
+updated: 2025-01-16
 ---
 
 If you secure your authentication setup with SAML certificate and private key, you’ll need to update or refresh these periodically.

--- a/src/content/docs/authenticate/manage-authentication/manage-authentication-applications.mdx
+++ b/src/content/docs/authenticate/manage-authentication/manage-authentication-applications.mdx
@@ -6,17 +6,26 @@ sidebar:
 relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
-description: Guide to configuring different authentication methods for different applications including mobile apps and platform-specific auth.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: beginner
-  keywords: [application authentication, mobile auth, platform-specific auth, Google auth, Apple auth]
-  updated: 2025-01-16
+description: >-
+  Guide to configuring different authentication methods for different
+  applications including mobile apps and platform-specific auth.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - application authentication
+  - mobile auth
+  - platform-specific auth
+  - Google auth
+  - Apple auth
+updated: 2025-01-16
 ---
 
 If you want, you can select different authentication methods for different applications. You might want to do this, for example, so users sign in with Google for your Android app and Apple for your iOS app.

--- a/src/content/docs/authenticate/manage-authentication/navigate-between-organizations.mdx
+++ b/src/content/docs/authenticate/manage-authentication/navigate-between-organizations.mdx
@@ -8,17 +8,30 @@ relatedArticles:
   - 26f54959-70f4-4634-a7de-35df80f8cfbb
   - 692187c5-1b82-467a-b86f-85b9098ecaab
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
-description: Step-by-step guide to building an organization switcher for B2B applications using ID tokens and React components.
-metadata:
-  topics: [authenticate]
-  sdk: [react]
-  languages: [javascript, jsx]
-  audience: [developer, frontend-developer]
-  complexity: intermediate
-  keywords: [organization switcher, B2B, ID tokens, React, multi-organization, org navigation]
-  updated: 2026-04-13
+description: >-
+  Step-by-step guide to building an organization switcher for B2B applications
+  using ID tokens and React components.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk:
+  - react
+languages:
+  - javascript
+  - jsx
+audience:
+  - developer
+  - frontend-developer
+complexity: intermediate
+keywords:
+  - organization switcher
+  - B2B
+  - ID tokens
+  - React
+  - multi-organization
+  - org navigation
+updated: 2026-04-13
 ---
 
 A common pattern in B2B products is for users who belong to multiple organizations to be able to switch between them. This topic demonstrates how to achieve this.

--- a/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
+++ b/src/content/docs/authenticate/manage-authentication/organization-auth-experience.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - ef1d8444-4e31-45b0-bd46-fc00111d7aa8
   - 79ea5a51-4036-414e-93f4-21dde0f98d9c
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
-description: Guide to setting custom authentication methods per organization including shared connections and enterprise connections for B2B customers.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, product-manager]
-  complexity: intermediate
-  keywords: [organization authentication, custom auth, shared connections, enterprise connections, B2B auth]
-  updated: 2025-01-16
+description: >-
+  Guide to setting custom authentication methods per organization including
+  shared connections and enterprise connections for B2B customers.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - product-manager
+complexity: intermediate
+keywords:
+  - organization authentication
+  - custom auth
+  - shared connections
+  - enterprise connections
+  - B2B auth
+updated: 2025-01-16
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/authenticate/manage-authentication/session-management-per-organization.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management-per-organization.mdx
@@ -10,17 +10,28 @@ relatedArticles:
 app_context:
   - m: organization_details
   - s: sessions
-description: Guide to managing Kinde authenticated sessions at the organization level including session persistence and inactivity timeouts for enterprise customers.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, product-manager]
-  complexity: intermediate
-  keywords: [organization session management, SSO session, session cookies, inactivity timeout, enterprise auth]
-  updated: 2026-04-03
+description: >-
+  Guide to managing Kinde authenticated sessions at the organization level
+  including session persistence and inactivity timeouts for enterprise
+  customers.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - product-manager
+complexity: intermediate
+keywords:
+  - organization session management
+  - SSO session
+  - session cookies
+  - inactivity timeout
+  - enterprise auth
+updated: 2026-04-03
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -4,20 +4,29 @@ title: Session management
 sidebar:
   order: 7
 relatedArticles:
-  - 6f5b7b0d-3818-4654-a1a1-3247a5e4d52a 
+  - 6f5b7b0d-3818-4654-a1a1-3247a5e4d52a
   - 5a248c6f-c1ae-480a-95c3-d3c69c81598d
   - 4ed081b0-7853-49be-b5fd-22a84a86bdad
-description: Guide to managing Kinde authenticated sessions including session persistence, inactivity timeouts, and browser session behavior.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: intermediate
-  keywords: [session management, SSO session, session cookies, inactivity timeout, browser session]
-  updated: 2026-04-13
+description: >-
+  Guide to managing Kinde authenticated sessions including session persistence,
+  inactivity timeouts, and browser session behavior.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: intermediate
+keywords:
+  - session management
+  - SSO session
+  - session cookies
+  - inactivity timeout
+  - browser session
+updated: 2026-04-13
 ---
 
 You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.

--- a/src/content/docs/authenticate/manage-authentication/sign-in-to-last-org.mdx
+++ b/src/content/docs/authenticate/manage-authentication/sign-in-to-last-org.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - f3e20936-d4da-4abc-8430-7620cae7fa6b
   - 692187c5-1b82-467a-b86f-85b9098ecaab
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
-description: Guide to automatically signing users into their most recent organization instead of showing an organization switcher for improved UX.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, ux-designer]
-  complexity: beginner
-  keywords: [last organization, organization switcher, B2B, user experience, automatic sign-in]
-  updated: 2025-01-16
+description: >-
+  Guide to automatically signing users into their most recent organization
+  instead of showing an organization switcher for improved UX.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - ux-designer
+complexity: beginner
+keywords:
+  - last organization
+  - organization switcher
+  - B2B
+  - user experience
+  - automatic sign-in
+updated: 2025-01-16
 ---
 
 A common pattern in B2B products is for users who belong to multiple organizations, to be able to [switch between them](/authenticate/manage-authentication/navigate-between-organizations/). However, if you have a switcher in your application, you may want users to be signed in to the most recent organization instead.

--- a/src/content/docs/authenticate/manage-authentication/sync-with-kinde.mdx
+++ b/src/content/docs/authenticate/manage-authentication/sync-with-kinde.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - 5a248c6f-c1ae-480a-95c3-d3c69c81598d
   - 51899f7f-3436-46e0-9a1b-6ecc3603a0df
-description: Comprehensive guide to keeping your application in sync with Kinde using refresh tokens, API calls, and webhooks for real-time data consistency.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, backend-developer, integration-engineer]
-  complexity: advanced
-  keywords: [sync with Kinde, refresh tokens, API integration, webhooks, token claims, real-time sync]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to keeping your application in sync with Kinde using
+  refresh tokens, API calls, and webhooks for real-time data consistency.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - backend-developer
+  - integration-engineer
+complexity: advanced
+keywords:
+  - sync with Kinde
+  - refresh tokens
+  - API integration
+  - webhooks
+  - token claims
+  - real-time sync
+updated: 2025-01-16
 ---
 
 Kinde’s main object delivery method is to include claims in ID and access tokens when a user authenticates. This is a very efficient delivery method because as soon as a user signs in, you have everything you need to give them access, including their permissions.

--- a/src/content/docs/authenticate/manage-authentication/user-auth-applications.mdx
+++ b/src/content/docs/authenticate/manage-authentication/user-auth-applications.mdx
@@ -11,17 +11,26 @@ relatedArticles:
 app_context:
   - m: settings
     s: authentication
-description: Guide to sharing authenticated sessions across multiple applications using SSO cookies, refresh tokens, and multi-domain authentication.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager]
-  complexity: intermediate
-  keywords: [multi-application sessions, SSO cookies, refresh tokens, offline scopes, multi-domain auth]
-  updated: 2026-03-03
+description: >-
+  Guide to sharing authenticated sessions across multiple applications using SSO
+  cookies, refresh tokens, and multi-domain authentication.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: intermediate
+keywords:
+  - multi-application sessions
+  - SSO cookies
+  - refresh tokens
+  - offline scopes
+  - multi-domain auth
+updated: 2026-03-03
 ---
 
 Kinde supports shared authenticated sessions across applications. For example, in a scenario where you have multiple apps running on separate subdomains, and you want to share a session between apps without prompting the user to sign in again.

--- a/src/content/docs/authenticate/multi-factor-auth/about-multi-factor-authentication.mdx
+++ b/src/content/docs/authenticate/multi-factor-auth/about-multi-factor-authentication.mdx
@@ -14,17 +14,30 @@ app_context:
     s: authentication
   - m: settings
     s: mfa
-description: Comprehensive overview of multi-factor authentication (MFA) including available factors, user experience, recovery codes, and organization-level enforcement.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, security-engineer]
-  complexity: intermediate
-  keywords: [multi-factor authentication, MFA, authenticator app, SMS, email, recovery codes, security]
-  updated: 2025-01-16
+description: >-
+  Comprehensive overview of multi-factor authentication (MFA) including
+  available factors, user experience, recovery codes, and organization-level
+  enforcement.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - security-engineer
+complexity: intermediate
+keywords:
+  - multi-factor authentication
+  - MFA
+  - authenticator app
+  - SMS
+  - email
+  - recovery codes
+  - security
+updated: 2025-01-16
 ---
 
 To increase security for your product, you can enable multi-factor authentication (MFA). This means that your users sign in using at least two authentication methods, for example, password _plus_ verification code.

--- a/src/content/docs/authenticate/multi-factor-auth/enable-multi-factor-authentication.mdx
+++ b/src/content/docs/authenticate/multi-factor-auth/enable-multi-factor-authentication.mdx
@@ -14,17 +14,27 @@ app_context:
     s: authentication
   - m: settings
     s: mfa
-description: Step-by-step guide to enabling multi-factor authentication including mandatory and optional settings for enhanced security.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, security-engineer]
-  complexity: beginner
-  keywords: [enable MFA, multi-factor authentication, mandatory MFA, optional MFA, security setup]
-  updated: 2026-03-03
+description: >-
+  Step-by-step guide to enabling multi-factor authentication including mandatory
+  and optional settings for enhanced security.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - security-engineer
+complexity: beginner
+keywords:
+  - enable MFA
+  - multi-factor authentication
+  - mandatory MFA
+  - optional MFA
+  - security setup
+updated: 2026-03-03
 ---
 
 Add security to the authentication process by enabling multi-factor authentication (MFA). MFA means users sign in using at least two authentication factors, for example, password _plus_ SMS code.

--- a/src/content/docs/authenticate/multi-factor-auth/mfa-per-org.mdx
+++ b/src/content/docs/authenticate/multi-factor-auth/mfa-per-org.mdx
@@ -13,17 +13,28 @@ app_context:
     s: authentication
   - m: settings
     s: mfa
-description: Advanced guide to setting multi-factor authentication per organization including role exemptions and enterprise connection exemptions for B2B customers.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, enterprise-admin, security-engineer]
-  complexity: advanced
-  keywords: [organization MFA, role exemptions, enterprise connections, B2B MFA, advanced org features]
-  updated: 2026-02-23
+description: >-
+  Advanced guide to setting multi-factor authentication per organization
+  including role exemptions and enterprise connection exemptions for B2B
+  customers.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - enterprise-admin
+  - security-engineer
+complexity: advanced
+keywords:
+  - organization MFA
+  - role exemptions
+  - enterprise connections
+  - B2B MFA
+  - advanced org features
+updated: 2026-02-23
 ---
 <Aside type="upgrade">
 

--- a/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
+++ b/src/content/docs/authenticate/social-sign-in/add-social-sign-in.mdx
@@ -6,17 +6,29 @@ sidebar:
 app_context:
   - m: settings
     s: authentication
-description: Comprehensive guide to adding and managing social sign-in connections including setup, security considerations, and provider-specific configurations.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, security-engineer]
-  complexity: intermediate
-  keywords: [social sign-in, social connections, OAuth, client ID, client secret, trusted providers]
-  updated: 2026-03-26
+description: >-
+  Comprehensive guide to adding and managing social sign-in connections
+  including setup, security considerations, and provider-specific
+  configurations.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - security-engineer
+complexity: intermediate
+keywords:
+  - social sign-in
+  - social connections
+  - OAuth
+  - client ID
+  - client secret
+  - trusted providers
+updated: 2026-03-26
 ---
 
 Social connections enable you to sign up and sign in users with credentials from their existing social accounts, such as Google or GitHub.

--- a/src/content/docs/authenticate/social-sign-in/apple.mdx
+++ b/src/content/docs/authenticate/social-sign-in/apple.mdx
@@ -3,17 +3,30 @@ page_id: b17ef65e-5153-4764-b699-0e618337d697
 title: Apple social sign in
 sidebar:
   order: 3
-description: Complete guide to setting up Apple social sign-in including Apple Developer account setup, Services ID configuration, and JWT client secret generation.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: [ruby, jwt]
-  audience: [developer, integration-engineer]
-  complexity: advanced
-  keywords: [Apple sign-in, Apple Developer, Services ID, JWT, client secret, private key, token renewal]
-  updated: 2025-01-16
+description: >-
+  Complete guide to setting up Apple social sign-in including Apple Developer
+  account setup, Services ID configuration, and JWT client secret generation.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages:
+  - ruby
+  - jwt
+audience:
+  - developer
+  - integration-engineer
+complexity: advanced
+keywords:
+  - Apple sign-in
+  - Apple Developer
+  - Services ID
+  - JWT
+  - client secret
+  - private key
+  - token renewal
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Apple credentials. 

--- a/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/bitbucket-sso.mdx
@@ -7,17 +7,28 @@ relatedArticles:
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
   - 66e7bda8-bc17-463b-8b63-980bccf57e86
-description: Step-by-step guide to setting up Bitbucket social sign-in including Bitbucket app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Bitbucket sign-in, Bitbucket app, OAuth, client ID, client secret, callback URL, permissions]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Bitbucket social sign-in including Bitbucket
+  app creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Bitbucket sign-in
+  - Bitbucket app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - permissions
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Bitbucket credentials. To enable this, follow all the steps below to create a Bitbucket app and configure credentials in Kinde.

--- a/src/content/docs/authenticate/social-sign-in/clever.mdx
+++ b/src/content/docs/authenticate/social-sign-in/clever.mdx
@@ -3,18 +3,30 @@ page_id: c4449422-d296-447e-8595-6485d3d963e4
 title: Clever social sign in
 sidebar:
   order: 5
-description: Step-by-step guide to setting up Clever social sign-in including Clever app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Clever sign-in, Clever app, OAuth, client ID, client secret, callback URL]
-  updated: 2026-01-08
-ai_summary: Step-by-step guide to setting up Clever social sign-in including Clever app creation, OAuth configuration, callback URL setup, and Kinde integration.
+description: >-
+  Step-by-step guide to setting up Clever social sign-in including Clever app
+  creation, OAuth configuration, and Kinde integration.
+ai_summary: >-
+  Step-by-step guide to setting up Clever social sign-in including Clever app
+  creation, OAuth configuration, callback URL setup, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Clever sign-in
+  - Clever app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+updated: 2026-01-08
 ---
 
 You can enable users to sign up and sign in using their Clever credentials. To enable this, follow all the steps below to create a Clever app and configure credentials in Kinde.

--- a/src/content/docs/authenticate/social-sign-in/discord.mdx
+++ b/src/content/docs/authenticate/social-sign-in/discord.mdx
@@ -3,17 +3,27 @@ page_id: 055d2828-1ca0-4d26-887f-99d7cc9bf5db
 title: Discord social sign in
 sidebar:
   order: 6
-description: Step-by-step guide to setting up Discord social sign-in including Discord app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Discord sign-in, Discord app, OAuth, client ID, client secret, callback URL]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Discord social sign-in including Discord app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Discord sign-in
+  - Discord app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Discord credentials. To enable this, you’ll need a Discord app and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/facebook.mdx
+++ b/src/content/docs/authenticate/social-sign-in/facebook.mdx
@@ -3,17 +3,28 @@ page_id: a6b7de94-fad8-44f1-ab3d-646271b5ab91
 title: Facebook social sign in
 sidebar:
   order: 7
-description: Comprehensive guide to setting up Facebook social sign-in including Meta app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Facebook sign-in, Meta app, OAuth, client ID, client secret, callback URL, Facebook Login for Business]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to setting up Facebook social sign-in including Meta app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Facebook sign-in
+  - Meta app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - Facebook Login for Business
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Facebook credentials. To enable this, you’ll need a Facebook app and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/github.mdx
+++ b/src/content/docs/authenticate/social-sign-in/github.mdx
@@ -3,17 +3,28 @@ page_id: c5c36c7e-0f28-4c9d-a39d-223cb00503a1
 title: GitHub social sign in
 sidebar:
   order: 8
-description: Step-by-step guide to setting up GitHub social sign-in including GitHub app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [GitHub sign-in, GitHub app, OAuth, client ID, client secret, callback URL, webhooks]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up GitHub social sign-in including GitHub app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - GitHub sign-in
+  - GitHub app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - webhooks
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their GitHub credentials. To enable this, you’ll need some technical know-how and a [GitHub app](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) and credentials.

--- a/src/content/docs/authenticate/social-sign-in/gitlab.mdx
+++ b/src/content/docs/authenticate/social-sign-in/gitlab.mdx
@@ -3,17 +3,28 @@ page_id: dba4d800-efd5-49b3-8ed8-b963c95cece2
 title: GitLab social sign in
 sidebar:
   order: 9
-description: Step-by-step guide to setting up GitLab social sign-in including GitLab app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [GitLab sign-in, GitLab app, OAuth, client ID, client secret, callback URL, scopes]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up GitLab social sign-in including GitLab app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - GitLab sign-in
+  - GitLab app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - scopes
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their GitLab credentials. To enable this, you’ll need some technical know-how and a GitLab app and credentials. Here’s some [GitLab docs](https://docs.gitlab.com/ee/integration/oauth_provider.html) that might help.

--- a/src/content/docs/authenticate/social-sign-in/google.mdx
+++ b/src/content/docs/authenticate/social-sign-in/google.mdx
@@ -3,17 +3,28 @@ page_id: b663dbde-2045-4f51-bab4-84d0c9fbe15b
 title: Google social sign in
 sidebar:
   order: 10
-description: Step-by-step guide to setting up Google social sign-in including Google Cloud project setup, OAuth credentials, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Google sign-in, OAuth, Google Cloud, client ID, client secret, callback URL, webview limitations]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Google social sign-in including Google Cloud
+  project setup, OAuth credentials, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Google sign-in
+  - OAuth
+  - Google Cloud
+  - client ID
+  - client secret
+  - callback URL
+  - webview limitations
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Google credentials. To set this up, you need a Google cloud account and project, and a little technical know-how.

--- a/src/content/docs/authenticate/social-sign-in/linkedin.mdx
+++ b/src/content/docs/authenticate/social-sign-in/linkedin.mdx
@@ -3,17 +3,28 @@ page_id: 54e47257-6156-4bec-a29a-f274387e7831
 title: LinkedIn social sign in
 sidebar:
   order: 11
-description: Step-by-step guide to setting up LinkedIn social sign-in including LinkedIn app creation, OpenID Connect configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [LinkedIn sign-in, OpenID Connect, OAuth, client ID, client secret, callback URL, LinkedIn developer]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up LinkedIn social sign-in including LinkedIn
+  app creation, OpenID Connect configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - LinkedIn sign-in
+  - OpenID Connect
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - LinkedIn developer
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their LinkedIn credentials. To enable this, you’ll need a LinkedIn app and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/microsoft-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/microsoft-sso.mdx
@@ -3,17 +3,29 @@ page_id: 635088d8-2db1-4dd0-825a-bb72dee41b20
 title: Microsoft social sign in
 sidebar:
   order: 12
-description: Step-by-step guide to setting up Microsoft social sign-in including Azure app registration, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Microsoft sign-in, Azure, Entra ID, app registration, OAuth, client ID, client secret, home realm]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Microsoft social sign-in including Azure app
+  registration, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Microsoft sign-in
+  - Azure
+  - Entra ID
+  - app registration
+  - OAuth
+  - client ID
+  - client secret
+  - home realm
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Microsoft credentials. To enable this, you’ll need a Microsoft Azure account and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/roblox-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/roblox-sso.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - a5225946-27ad-41c0-a3c1-9a6d735e3efb
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
-description: Step-by-step guide to setting up Roblox social sign-in including Roblox app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Roblox sign-in, Roblox app, OAuth, client ID, client secret, callback URL]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Roblox social sign-in including Roblox app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Roblox sign-in
+  - Roblox app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Roblox credentials. To enable this, you’ll need some technical know-how and a Roblox app.

--- a/src/content/docs/authenticate/social-sign-in/slack.mdx
+++ b/src/content/docs/authenticate/social-sign-in/slack.mdx
@@ -3,17 +3,28 @@ page_id: 20278538-eefc-4943-8a12-33b56c478f70
 title: Slack social sign in
 sidebar:
   order: 14
-description: Step-by-step guide to setting up Slack social sign-in including Slack app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Slack sign-in, Slack app, OAuth, client ID, client secret, callback URL, scopes]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Slack social sign-in including Slack app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Slack sign-in
+  - Slack app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - scopes
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Slack credentials. To enable this, you’ll need some technical know-how and a Slack app.

--- a/src/content/docs/authenticate/social-sign-in/twitch.mdx
+++ b/src/content/docs/authenticate/social-sign-in/twitch.mdx
@@ -3,17 +3,28 @@ page_id: ac9d24dc-c82c-4d0b-99c7-35cb841af783
 title: Twitch social sign in
 sidebar:
   order: 15
-description: Step-by-step guide to setting up Twitch social sign-in including Twitch app registration, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Twitch sign-in, Twitch app, OAuth, client ID, client secret, callback URL, 2FA]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Twitch social sign-in including Twitch app
+  registration, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Twitch sign-in
+  - Twitch app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+  - 2FA
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Twitch credentials. To enable this, you’ll need a Twitch account and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/twitter.mdx
+++ b/src/content/docs/authenticate/social-sign-in/twitter.mdx
@@ -3,17 +3,28 @@ page_id: 2d5ddede-b5be-4c05-ae82-300e0c2201e3
 title: X (formerly Twitter) social sign in
 sidebar:
   order: 16
-description: Step-by-step guide to setting up X (formerly Twitter) social sign-in including X developer platform app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [X sign-in, Twitter sign-in, X developer platform, OAuth, client ID, client secret, callback URL]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up X (formerly Twitter) social sign-in including
+  X developer platform app creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - X sign-in
+  - Twitter sign-in
+  - X developer platform
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their X credentials. To enable this, you’ll need an X developer platform account and some developer know-how.

--- a/src/content/docs/authenticate/social-sign-in/xero-sso.mdx
+++ b/src/content/docs/authenticate/social-sign-in/xero-sso.mdx
@@ -7,17 +7,27 @@ relatedArticles:
   - 720fcdda-daa6-4dff-ad2d-177af555e6bb
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
   - 66e7bda8-bc17-463b-8b63-980bccf57e86
-description: Step-by-step guide to setting up Xero social sign-in including Xero app creation, OAuth configuration, and Kinde integration.
-metadata:
-  topics: [authenticate]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [Xero sign-in, Xero app, OAuth, client ID, client secret, callback URL]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to setting up Xero social sign-in including Xero app
+  creation, OAuth configuration, and Kinde integration.
 featured: false
 deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - Xero sign-in
+  - Xero app
+  - OAuth
+  - client ID
+  - client secret
+  - callback URL
+updated: 2025-01-16
 ---
 
 You can enable users to sign up and sign in using their Xero credentials. To enable this, you’ll need a Xero app and some developer know-how.

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -10,17 +10,34 @@ relatedArticles:
 app_context:
   - m: billing
     s: plans
-description: Overview of Kinde billing capabilities including plan management, pricing tables, payment processing, and customer lifecycle management.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords: [billing, plans, pricing, Stripe, customer lifecycle, revenue, subscriptions, trial, tax, VAT, sales tax, invoicing]
-  updated: 2026-04-07
+description: >-
+  Overview of Kinde billing capabilities including plan management, pricing
+  tables, payment processing, and customer lifecycle management.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - billing
+  - plans
+  - pricing
+  - Stripe
+  - customer lifecycle
+  - revenue
+  - subscriptions
+  - trial
+  - tax
+  - VAT
+  - sales tax
+  - invoicing
+updated: 2026-04-07
 ---
 
 Kinde billing gives you the ability to charge customers for your services and collect revenue.

--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -6,17 +6,34 @@ sidebar:
 relatedArticles:
   - 100f75f1-a0a4-459f-874f-da127f2d0615
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
-description: Comprehensive guide to billing concepts and terminology including plan groups, features, pricing models, and common billing terms.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords: [billing concepts, plan groups, features, pricing models, metered usage, fixed charges, billing interval, offer as annual, multi-currency, trial, trial period, free trial]
-  updated: 2026-04-07
+description: >-
+  Comprehensive guide to billing concepts and terminology including plan groups,
+  features, pricing models, and common billing terms.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - billing concepts
+  - plan groups
+  - features
+  - pricing models
+  - metered usage
+  - fixed charges
+  - billing interval
+  - offer as annual
+  - multi-currency
+  - trial
+  - trial period
+  - free trial
+updated: 2026-04-07
 ---
 
 'Billing' refers to the broad function of creating plans, setting pricing, collecting payments, etc. Here are some of the common concepts and terms you will come across.

--- a/src/content/docs/billing/about-billing/billing-faq.mdx
+++ b/src/content/docs/billing/about-billing/billing-faq.mdx
@@ -9,17 +9,37 @@ relatedArticles:
 app_context:
   - m: billing
   - s: faq
-description: Frequently asked questions about Kinde billing including setup, plan management, payment processing, and customer support scenarios.
-metadata:
-  topics: [billing, faq, plans, payments, subscriptions]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner, support]
-  complexity: beginner
-  keywords: [billing faq, billing questions, plan management, payment processing, subscription management, customer support, trial, free trial, tax, VAT]
-  updated: 2026-04-07
+description: >-
+  Frequently asked questions about Kinde billing including setup, plan
+  management, payment processing, and customer support scenarios.
 featured: false
 deprecated: false
+topics:
+  - billing
+  - faq
+  - plans
+  - payments
+  - subscriptions
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+  - support
+complexity: beginner
+keywords:
+  - billing faq
+  - billing questions
+  - plan management
+  - payment processing
+  - subscription management
+  - customer support
+  - trial
+  - free trial
+  - tax
+  - VAT
+updated: 2026-04-07
 ---
 
 Find quick answers to common questions about Kinde billing. Each section covers specific aspects of billing setup, management, and customer support.

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -1,23 +1,44 @@
 ---
 page_id: 3fb38a43-e37f-4e25-a56b-acb3ea4a6d98
 title: Top questions about Kinde billing
-description: A collection of the top questions and answers about how to set up and configure Kinde billing for your Kinde business.
+description: >-
+  A collection of the top questions and answers about how to set up and
+  configure Kinde billing for your Kinde business.
 sidebar:
   order: 4
-relatedArticles: 
-   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
-   - 9d1daf85-1a2c-4cc5-879a-230c950bed12
-   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-metadata:
-  topics: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe]
-  audience: [frontend-developer]
-  complexity: beginner
-  keywords: [billing, plans, plan selector, entitlements, feature charges, pricing models, MAU, Stripe, tax, VAT]
-  updated: 2026-04-07
+relatedArticles:
+  - bd6757e3-81d5-48d6-89c8-dd4c222ac647
+  - 9d1daf85-1a2c-4cc5-879a-230c950bed12
+  - e6dde80d-2977-419f-a05a-62ad0a7ac6de
 featured: false
 deprecated: false
 ai-summary: >
-  A collection of the top questions and answers about how to set up and configure Kinde billing for your Kinde business.
+  A collection of the top questions and answers about how to set up and
+  configure Kinde billing for your Kinde business.
+topics:
+  - billing
+  - plans
+  - plan selector
+  - entitlements
+  - feature charges
+  - pricing models
+  - MAU
+  - Stripe
+audience:
+  - frontend-developer
+complexity: beginner
+keywords:
+  - billing
+  - plans
+  - plan selector
+  - entitlements
+  - feature charges
+  - pricing models
+  - MAU
+  - Stripe
+  - tax
+  - VAT
+updated: 2026-04-07
 ---
 
 Here are short answers to the most common billing questions. Click any question to expand the answer.

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -12,7 +12,7 @@ relatedArticles:
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
 featured: false
 deprecated: false
-ai-summary: >
+ai_summary: >
   A collection of the top questions and answers about how to set up and
   configure Kinde billing for your Kinde business.
 topics:

--- a/src/content/docs/billing/about-billing/kinde-billing-model.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-model.mdx
@@ -6,17 +6,30 @@ sidebar:
 relatedArticles:
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
   - 9d1daf85-1a2c-4cc5-879a-230c950bed12
-description: Detailed explanation of the Kinde billing model including Stripe integration, B2B/B2C support, multi-currency, and billing cycles.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [Kinde billing model, Stripe integration, B2B, B2C, B2B2C, multi-currency, billing cycles, payment processing]
-  updated: 2025-01-16
+description: >-
+  Detailed explanation of the Kinde billing model including Stripe integration,
+  B2B/B2C support, multi-currency, and billing cycles.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - Kinde billing model
+  - Stripe integration
+  - B2B
+  - B2C
+  - B2B2C
+  - multi-currency
+  - billing cycles
+  - payment processing
+updated: 2025-01-16
 ---
 
 In the Kinde model, we handle everything except the payment processing part of billing. Kinde integrates with a third-party payment processor (Stripe) for secure payment processing.

--- a/src/content/docs/billing/billing-user-experience/add-billing-to-url-sdk.mdx
+++ b/src/content/docs/billing/billing-user-experience/add-billing-to-url-sdk.mdx
@@ -7,17 +7,31 @@ relatedArticles:
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
   - 100f75f1-a0a4-459f-874f-da127f2d0615
   - c47fa1fb-15e1-4dcf-93d9-59df6acdf6da
-description: Guide to integrating billing into your application using URL parameters, React SDK components, and authentication flows.
-metadata:
-  topics: [billing]
-  sdk: [react]
-  languages: [javascript, jsx]
-  audience: [developer, frontend-developer]
-  complexity: intermediate
-  keywords: [billing integration, URL parameters, React SDK, plan selection, pricing table, org signup, B2B]
-  updated: 2025-01-16
+description: >-
+  Guide to integrating billing into your application using URL parameters, React
+  SDK components, and authentication flows.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk:
+  - react
+languages:
+  - javascript
+  - jsx
+audience:
+  - developer
+  - frontend-developer
+complexity: intermediate
+keywords:
+  - billing integration
+  - URL parameters
+  - React SDK
+  - plan selection
+  - pricing table
+  - org signup
+  - B2B
+updated: 2025-01-16
 ---
 
 This topic explains how to customize billing flows with Kinde, including URL parameters, direct auth URLs, and SDK usage in React.

--- a/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
+++ b/src/content/docs/billing/billing-user-experience/customize-billing-pages.mdx
@@ -7,17 +7,33 @@ relatedArticles:
   - 37d5ae8e-cfd1-4e5d-8333-387b6967ec23
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Guide to customizing the plan sign-up experience including three different approaches and billing screen customization options.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: [html, css, javascript]
-  audience: [developer, product-manager, ux-designer]
-  complexity: intermediate
-  keywords: [plan sign-up, billing customization, plan selection, payment flow, billing screens, HTML CSS customization, trial, free trial]
-  updated: 2026-04-07
+description: >-
+  Guide to customizing the plan sign-up experience including three different
+  approaches and billing screen customization options.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages:
+  - html
+  - css
+  - javascript
+audience:
+  - developer
+  - product-manager
+  - ux-designer
+complexity: intermediate
+keywords:
+  - plan sign-up
+  - billing customization
+  - plan selection
+  - payment flow
+  - billing screens
+  - HTML CSS customization
+  - trial
+  - free trial
+updated: 2026-04-07
 ---
 
 There are three ways you can allow customers to sign up to a plan.

--- a/src/content/docs/billing/billing-user-experience/free-trials.mdx
+++ b/src/content/docs/billing/billing-user-experience/free-trials.mdx
@@ -8,24 +8,33 @@ relatedArticles:
   - c47fa1fb-15e1-4dcf-93d9-59df6acdf6da
   - 06bb544c-1b84-4660-ac55-ac80b50ae5be
   - 88e1773a-b681-441f-b4c7-d7d339116867
-description: How to offer free trials on paid plans with Kinde Billing, what customers see in the auth and pricing flow, and how trials convert to paid subscriptions via Stripe.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords:
-    - free trial
-    - trial period
-    - SaaS billing
-    - Stripe trial
-    - pricing table
-    - subscription conversion
-  updated: 2026-04-07
+description: >-
+  How to offer free trials on paid plans with Kinde Billing, what customers see
+  in the auth and pricing flow, and how trials convert to paid subscriptions via
+  Stripe.
 featured: false
 deprecated: false
-ai_summary: How to offer free trials on paid plans with Kinde Billing, what customers see in the auth and pricing flow, and how trials convert to paid subscriptions via Stripe.
+ai_summary: >-
+  How to offer free trials on paid plans with Kinde Billing, what customers see
+  in the auth and pricing flow, and how trials convert to paid subscriptions via
+  Stripe.
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - free trial
+  - trial period
+  - SaaS billing
+  - Stripe trial
+  - pricing table
+  - subscription conversion
+updated: 2026-04-07
 ---
 
 <Aside>

--- a/src/content/docs/billing/billing-user-experience/plan-selection.mdx
+++ b/src/content/docs/billing/billing-user-experience/plan-selection.mdx
@@ -6,17 +6,29 @@ sidebar:
 relatedArticles:
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Comprehensive guide to building pricing tables in Kinde including plan selection, customization, multi-language support, and integration options.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, ux-designer]
-  complexity: intermediate
-  keywords: [pricing table, plan selection, plan groups, multi-language, plan highlighting, plan ordering, live pricing]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to building pricing tables in Kinde including plan
+  selection, customization, multi-language support, and integration options.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - ux-designer
+complexity: intermediate
+keywords:
+  - pricing table
+  - plan selection
+  - plan groups
+  - multi-language
+  - plan highlighting
+  - plan ordering
+  - live pricing
+updated: 2025-01-16
 ---
 
 You can build pricing tables to enable your customers to select plans and go through a payment flow as part of signing up to your app or site.

--- a/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
+++ b/src/content/docs/billing/billing-user-experience/pricing-table-display.mdx
@@ -6,17 +6,31 @@ sidebar:
 relatedArticles:
   - 37d5ae8e-cfd1-4e5d-8333-387b6967ec23
   - db047df7-d6b6-4d02-843f-dce6000bacbd
-description: Guide to understanding pricing table display defaults for B2C, B2B, and B2B2C models including when pricing tables are shown.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords: [pricing table display, B2C, B2B, B2B2C, plan groups, default display, URL parameters, trial, free trial]
-  updated: 2026-04-07
+description: >-
+  Guide to understanding pricing table display defaults for B2C, B2B, and B2B2C
+  models including when pricing tables are shown.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - pricing table display
+  - B2C
+  - B2B
+  - B2B2C
+  - plan groups
+  - default display
+  - URL parameters
+  - trial
+  - free trial
+updated: 2026-04-07
 ---
 
 The pricing table that is displayed in a particular flow depends on the [default plan groups and pricing table order](/billing/manage-plans/add-manage-plan-groups/).

--- a/src/content/docs/billing/get-started/add-billing-role.mdx
+++ b/src/content/docs/billing/get-started/add-billing-role.mdx
@@ -6,17 +6,28 @@ sidebar:
   relatedArticles:
     - d2d64a2b-1fb7-4c18-88bc-2986723724cb
     - 7e1082b4-2b78-4e76-92fd-ee25497a4e2b
-description: Guide to creating a billing role for B2B organizations including permissions setup and role assignment for billing management.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: beginner
-  keywords: [billing role, B2B, organization billing, billing admin, permissions, org:write:billing]
-  updated: 2025-01-16
+description: >-
+  Guide to creating a billing role for B2B organizations including permissions
+  setup and role assignment for billing management.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: beginner
+keywords:
+  - billing role
+  - B2B
+  - organization billing
+  - billing admin
+  - permissions
+  - 'org:write:billing'
+updated: 2025-01-16
 ---
 
 Skip this step if you sell your services to individuals (B2C).

--- a/src/content/docs/billing/get-started/add-pricing-table.mdx
+++ b/src/content/docs/billing/get-started/add-pricing-table.mdx
@@ -8,17 +8,28 @@ relatedArticles:
 app_context:
   - m: billing
   - s: pricing_tables
-description: Guide to creating pricing tables in Kinde for plan selection during registration and self-serve portal plan changes.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, ux-designer]
-  complexity: beginner
-  keywords: [pricing table, plan selection, registration flow, self-serve portal, plan upgrade, plan downgrade]
-  updated: 2025-01-16
+description: >-
+  Guide to creating pricing tables in Kinde for plan selection during
+  registration and self-serve portal plan changes.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - ux-designer
+complexity: beginner
+keywords:
+  - pricing table
+  - plan selection
+  - registration flow
+  - self-serve portal
+  - plan upgrade
+  - plan downgrade
+updated: 2025-01-16
 ---
 
 Kinde lets you create pricing tables based on your plans. The tables can be integrated into the auth flow so that plan selection becomes part of registration. It might look something like this.

--- a/src/content/docs/billing/get-started/build-plans.mdx
+++ b/src/content/docs/billing/get-started/build-plans.mdx
@@ -6,20 +6,35 @@ sidebar:
 relatedArticles:
   - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
   - 88e1773a-b681-441f-b4c7-d7d339116867
-app_context: 
+app_context:
   - m: billing
   - s: plans
-description: Guide to developing a plan strategy and building plans in Kinde including B2B/B2C considerations, feature planning, and pricing models.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [plan strategy, B2B, B2C, B2B2C, plan features, pricing models, plan limits, feature planning, trial, free trial]
-  updated: 2026-04-07
+description: >-
+  Guide to developing a plan strategy and building plans in Kinde including
+  B2B/B2C considerations, feature planning, and pricing models.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - plan strategy
+  - B2B
+  - B2C
+  - B2B2C
+  - plan features
+  - pricing models
+  - plan limits
+  - feature planning
+  - trial
+  - free trial
+updated: 2026-04-07
 ---
 
 Whether you currently charge for services or are just starting out, building plans is the more complex part of the billing setup process. We recommend you define a strategy before adding plans in Kinde.

--- a/src/content/docs/billing/get-started/connect-to-stripe.mdx
+++ b/src/content/docs/billing/get-started/connect-to-stripe.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - 46241baf-30aa-43c0-ac0c-b2b7e99941f1
   - 8770ef89-e805-475f-b4f5-a86c1e1eccc1
-description: Step-by-step guide to connecting Kinde to Stripe for payment processing and setting up billing policies for cancellations and plan changes.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [Stripe connection, payment processing, billing policies, cancellation policies, plan changes, onboarding]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to connecting Kinde to Stripe for payment processing and
+  setting up billing policies for cancellations and plan changes.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - Stripe connection
+  - payment processing
+  - billing policies
+  - cancellation policies
+  - plan changes
+  - onboarding
+updated: 2025-01-16
 ---
 
 Kinde’s billing feature comes with a dependency on [Stripe](https://stripe.com), which is a globally known and reliable payments processing platform. A new Stripe account is automatically created for you when you set up billing in Kinde.

--- a/src/content/docs/billing/get-started/default-billing-currency.mdx
+++ b/src/content/docs/billing/get-started/default-billing-currency.mdx
@@ -6,17 +6,26 @@ sidebar:
 relatedArticles:
   - 2aa551b8-06c0-4947-bd4b-d643c77ed224
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Guide to setting the default billing currency for all Kinde plans including important considerations about currency selection.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner]
-  complexity: beginner
-  keywords: [default currency, billing currency, currency selection, multi-currency, Stripe transactions]
-  updated: 2025-01-16
+description: >-
+  Guide to setting the default billing currency for all Kinde plans including
+  important considerations about currency selection.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+complexity: beginner
+keywords:
+  - default currency
+  - billing currency
+  - currency selection
+  - multi-currency
+  - Stripe transactions
+updated: 2025-01-16
 ---
 
 You need to set a default billing currency for all your Kinde plans, before you create them. This is the currency that purchase transactions will be processed in Stripe.

--- a/src/content/docs/billing/get-started/publish-plans.mdx
+++ b/src/content/docs/billing/get-started/publish-plans.mdx
@@ -9,17 +9,27 @@ relatedArticles:
 app_context:
   - m: plan
   - s: details
-description: Guide to publishing plans in Kinde including Stripe synchronization and best practices for testing before publication.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords: [publish plans, Stripe sync, draft plans, published plans, plan testing]
-  updated: 2025-01-16
+description: >-
+  Guide to publishing plans in Kinde including Stripe synchronization and best
+  practices for testing before publication.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - publish plans
+  - Stripe sync
+  - draft plans
+  - published plans
+  - plan testing
+updated: 2025-01-16
 ---
 
 When you publish a plan, all of the plan features and charges are synced to Stripe where they are transformed into products that users can buy. 

--- a/src/content/docs/billing/get-started/self-serve-portal-setup.mdx
+++ b/src/content/docs/billing/get-started/self-serve-portal-setup.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - a2668524-5842-4c68-ab50-30b7e8c3e842
   - f36bce4a-52bb-4785-865b-6b33356f9838
-description: Guide to setting up the self-serve portal for customers to manage their own plans, payment information, and account details.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [self-serve portal, customer management, plan upgrades, plan downgrades, payment management, account management]
-  updated: 2025-01-16
+description: >-
+  Guide to setting up the self-serve portal for customers to manage their own
+  plans, payment information, and account details.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - self-serve portal
+  - customer management
+  - plan upgrades
+  - plan downgrades
+  - payment management
+  - account management
+updated: 2025-01-16
 ---
 
 If you want your customers (organizations or individual users) to manage their own plans, including upgrades and downgrades, payment information, team members, etc., set up the self-service portal to allow this. 

--- a/src/content/docs/billing/get-started/setup-overview.mdx
+++ b/src/content/docs/billing/get-started/setup-overview.mdx
@@ -9,17 +9,28 @@ relatedArticles:
 app_context:
   - m: billing
   - s: plans
-description: Step-by-step overview of the billing setup process including Stripe connection, plan creation, and self-serve portal configuration.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [billing setup, Stripe connection, plan creation, self-serve portal, billing roles, pricing tables]
-  updated: 2025-01-16
+description: >-
+  Step-by-step overview of the billing setup process including Stripe
+  connection, plan creation, and self-serve portal configuration.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - billing setup
+  - Stripe connection
+  - plan creation
+  - self-serve portal
+  - billing roles
+  - pricing tables
+updated: 2025-01-16
 ---
 
 Billing is big step for a business, so it’s a good idea to review the process before you start.

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -9,17 +9,32 @@ relatedArticles:
 app_context:
   - m: billing
   - s: plans
-description: Comprehensive guide to understanding plans in Kinde including plan groups, features, pricing models, and plan lifecycle management.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [plans, plan groups, features, pricing models, fixed charges, metered features, unmetered features, plan versioning, trial, free trial]
-  updated: 2026-04-07
+description: >-
+  Comprehensive guide to understanding plans in Kinde including plan groups,
+  features, pricing models, and plan lifecycle management.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - plans
+  - plan groups
+  - features
+  - pricing models
+  - fixed charges
+  - metered features
+  - unmetered features
+  - plan versioning
+  - trial
+  - free trial
+updated: 2026-04-07
 ---
 
 Plans enable you to structure your app features and charge your customers for using your services. Kinde supports both basic and more advanced plans for SaaS services. Here’s some examples:

--- a/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
+++ b/src/content/docs/billing/manage-plans/add-manage-plan-groups.mdx
@@ -7,17 +7,29 @@ relatedArticles:
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
   - 37d5ae8e-cfd1-4e5d-8333-387b6967ec23
-description: Guide to creating and managing plan groups in Kinde including B2B/B2C organization, default groups, and plan ordering.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: beginner
-  keywords: [plan groups, B2B, B2C, B2B2C, default groups, plan organization, pricing tables]
-  updated: 2025-01-16
+description: >-
+  Guide to creating and managing plan groups in Kinde including B2B/B2C
+  organization, default groups, and plan ordering.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: beginner
+keywords:
+  - plan groups
+  - B2B
+  - B2C
+  - B2B2C
+  - default groups
+  - plan organization
+  - pricing tables
+updated: 2025-01-16
 ---
 
 Plan groups are a way of organizing sets of related plans together. 

--- a/src/content/docs/billing/manage-plans/cancel-plans.mdx
+++ b/src/content/docs/billing/manage-plans/cancel-plans.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Guide to canceling subscriptions including customer self-service cancellation and API-based cancellation methods.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: intermediate
-  keywords: [cancel subscription, self-serve portal, API cancellation, agreement ID, billing role, cancellation workflow]
-  updated: 2025-01-16
+description: >-
+  Guide to canceling subscriptions including customer self-service cancellation
+  and API-based cancellation methods.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: intermediate
+keywords:
+  - cancel subscription
+  - self-serve portal
+  - API cancellation
+  - agreement ID
+  - billing role
+  - cancellation workflow
+updated: 2025-01-16
 ---
 
 While we would rather customers didn't cancel their subscription to your services, they do need to be able to. There's two ways to do this.

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -9,20 +9,37 @@ relatedArticles:
   - 88e1773a-b681-441f-b4c7-d7d339116867
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
   - 46241baf-30aa-43c0-ac0c-b2b7e99941f1
-app_context: 
+app_context:
   - m: billing
   - s: plans
-description: Step-by-step guide to creating plans in Kinde including plan groups, fixed charges, metered features, and tiered pricing configuration.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [create plans, plan groups, fixed charges, billing interval, offer as annual, metered features, tiered pricing, plan features, subscription fees, trial, free trial, trial period]
-  updated: 2026-04-07
+description: >-
+  Step-by-step guide to creating plans in Kinde including plan groups, fixed
+  charges, metered features, and tiered pricing configuration.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - create plans
+  - plan groups
+  - fixed charges
+  - billing interval
+  - offer as annual
+  - metered features
+  - tiered pricing
+  - plan features
+  - subscription fees
+  - trial
+  - free trial
+  - trial period
+updated: 2026-04-07
 ---
 
 Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.

--- a/src/content/docs/billing/manage-plans/upgrade-downgrade-plans.mdx
+++ b/src/content/docs/billing/manage-plans/upgrade-downgrade-plans.mdx
@@ -6,17 +6,28 @@ sidebar:
   relatedArticles:
     - 88e1773a-b681-441f-b4c7-d7d339116867
     - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Guide to setting billing policies for plan upgrades, downgrades, and cancellations including usage billing and refund policies.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: beginner
-  keywords: [plan upgrade, plan downgrade, billing policies, usage billing, refund policies, cancellation policies]
-  updated: 2025-01-16
+description: >-
+  Guide to setting billing policies for plan upgrades, downgrades, and
+  cancellations including usage billing and refund policies.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: beginner
+keywords:
+  - plan upgrade
+  - plan downgrade
+  - billing policies
+  - usage billing
+  - refund policies
+  - cancellation policies
+updated: 2025-01-16
 ---
 
 If you offer different levels of paid plans, then you will need to facilitate plan upgrade or downgrade. Before you make plan changes, make sure you have set the policies. 

--- a/src/content/docs/billing/manage-subscribers/add-metered-usage.mdx
+++ b/src/content/docs/billing/manage-subscribers/add-metered-usage.mdx
@@ -5,17 +5,27 @@ sidebar:
   order: 3
 relatedArticles:
   - 7f59a705-ac5d-4b07-a44e-1421dcdeffe8
-description: Guide to manually adding metered usage for customers via the Kinde API including agreement ID and feature code requirements.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, integration-engineer]
-  complexity: intermediate
-  keywords: [metered usage, API, agreement ID, feature code, usage data, billing cycle]
-  updated: 2025-01-16
+description: >-
+  Guide to manually adding metered usage for customers via the Kinde API
+  including agreement ID and feature code requirements.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - integration-engineer
+complexity: intermediate
+keywords:
+  - metered usage
+  - API
+  - agreement ID
+  - feature code
+  - usage data
+  - billing cycle
+updated: 2025-01-16
 ---
 
 From time to time, you may need to manually add metered usage for an individual customer. You can do this via the Kinde API.

--- a/src/content/docs/billing/manage-subscribers/manage-customer-activity-webhooks.mdx
+++ b/src/content/docs/billing/manage-subscribers/manage-customer-activity-webhooks.mdx
@@ -1,23 +1,37 @@
 ---
 page_id: 90ca02a9-ae27-41b3-9159-023334de565b
 title: Respond to customer activity using webhooks
-sidebar: 
+sidebar:
   order: 6
 relatedArticles:
   - 84581694-59d6-4a02-ab8b-c7a2889713d5
   - 7fe91aba-930c-4a63-8996-85af6bb605a7
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
-description: Comprehensive guide to using Kinde billing webhooks to respond to customer activity including event triggers and automation examples.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: [json, jwt]
-  audience: [developer, integration-engineer, backend-developer]
-  complexity: advanced
-  keywords: [billing webhooks, customer activity, JWT, event triggers, automation, subscription events, payment events]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to using Kinde billing webhooks to respond to customer
+  activity including event triggers and automation examples.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages:
+  - json
+  - jwt
+audience:
+  - developer
+  - integration-engineer
+  - backend-developer
+complexity: advanced
+keywords:
+  - billing webhooks
+  - customer activity
+  - JWT
+  - event triggers
+  - automation
+  - subscription events
+  - payment events
+updated: 2025-01-16
 ---
 
 Kinde's billing webhooks are outbound calls Kinde makes to your specified endpoint when particular billing events occur. You can use them to keep your application synchronized with Kinde's billing events, trigger automated actions to provide a seamless experience for your customers, and reduce the load on your support team. 

--- a/src/content/docs/billing/manage-subscribers/upgrade-downgrade-methods.mdx
+++ b/src/content/docs/billing/manage-subscribers/upgrade-downgrade-methods.mdx
@@ -5,17 +5,28 @@ sidebar:
   order: 1
 relatedArticles:
   - e73bafc3-0a9c-48de-9b1a-d91897ffc6cb
-description: Guide to upgrading and downgrading customer subscriptions including self-serve portal, manual changes, and API methods.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: intermediate
-  keywords: [subscription upgrade, subscription downgrade, plan changes, self-serve portal, API, billing policies]
-  updated: 2025-01-16
+description: >-
+  Guide to upgrading and downgrading customer subscriptions including self-serve
+  portal, manual changes, and API methods.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: intermediate
+keywords:
+  - subscription upgrade
+  - subscription downgrade
+  - plan changes
+  - self-serve portal
+  - API
+  - billing policies
+updated: 2025-01-16
 ---
 
 Customers will eventually want to change the plan they are on and you need a way to alter their subscription.

--- a/src/content/docs/billing/payment-management/manage-stripe-connection.mdx
+++ b/src/content/docs/billing/payment-management/manage-stripe-connection.mdx
@@ -6,17 +6,28 @@ sidebar:
 relatedArticles:
   - acdd8b64-d5b7-43ab-b47b-6244d8f5b82e
   - d980a089-d9c1-447b-930a-de0f2c00d3bf
-description: Guide to managing the Stripe connection in Kinde including connection status monitoring, troubleshooting, and disconnection procedures.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: intermediate
-  keywords: [Stripe connection, connection status, troubleshooting, business information, identity verification, disconnect]
-  updated: 2025-01-16
+description: >-
+  Guide to managing the Stripe connection in Kinde including connection status
+  monitoring, troubleshooting, and disconnection procedures.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: intermediate
+keywords:
+  - Stripe connection
+  - connection status
+  - troubleshooting
+  - business information
+  - identity verification
+  - disconnect
+updated: 2025-01-16
 ---
 
 When you connect to Stripe as part of Kinde's billing feature, a new Stripe account is created for you. You cannot connect an existing Stripe account.

--- a/src/content/docs/billing/payment-management/payment-processor.mdx
+++ b/src/content/docs/billing/payment-management/payment-processor.mdx
@@ -5,17 +5,28 @@ sidebar:
   order: 1
   relatedArticles:
     - d980a089-d9c1-447b-930a-de0f2c00d3bf
-description: Step-by-step guide to connecting Stripe payment gateway to Kinde including onboarding flow and connection status management.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, business-owner, admin]
-  complexity: intermediate
-  keywords: [payment gateway, Stripe connection, onboarding flow, business information, connection status, test environment]
-  updated: 2025-01-16
+description: >-
+  Step-by-step guide to connecting Stripe payment gateway to Kinde including
+  onboarding flow and connection status management.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - business-owner
+  - admin
+complexity: intermediate
+keywords:
+  - payment gateway
+  - Stripe connection
+  - onboarding flow
+  - business information
+  - connection status
+  - test environment
+updated: 2025-01-16
 ---
 
 Kinde’s billing feature comes with a dependency on third party payment processor, specifically [Stripe Billing](https://stripe.com/au/billing). A payment processor holds credit card details, processes payments, applies tax, and generally handles all the financial side of billing.

--- a/src/content/docs/billing/pricing/pricing-models.mdx
+++ b/src/content/docs/billing/pricing/pricing-models.mdx
@@ -7,17 +7,28 @@ relatedArticles:
   - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
   - d980a089-d9c1-447b-930a-de0f2c00d3bf
   - 7060212e-5e8c-4188-acd3-e055e3474988
-description: Comprehensive guide to pricing models in Kinde including flat rate, usage-based, tiered, and per-feature pricing strategies.
-metadata:
-  topics: [billing]
-  sdk: []
-  languages: []
-  audience: [developer, product-manager, business-owner]
-  complexity: intermediate
-  keywords: [pricing models, flat rate pricing, usage-based pricing, tiered pricing, per-feature pricing, SaaS pricing strategy]
-  updated: 2025-01-16
+description: >-
+  Comprehensive guide to pricing models in Kinde including flat rate,
+  usage-based, tiered, and per-feature pricing strategies.
 featured: false
 deprecated: false
+topics:
+  - billing
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+  - business-owner
+complexity: intermediate
+keywords:
+  - pricing models
+  - flat rate pricing
+  - usage-based pricing
+  - tiered pricing
+  - per-feature pricing
+  - SaaS pricing strategy
+updated: 2025-01-16
 ---
 
 A pricing model refers to the structured approach businesses use to charge customers for products and services, often based on factors like usage, feature access, or licensing. In Kinde, each feature you include in a plan has a pricing model attached. This topic describes some examples of pricing models you can apply in Kinde, when you might want to use them, and how to [set them up in your Kinde plans](/billing/manage-plans/create-plans/).

--- a/src/content/docs/build/organizations/self-serve-portal-per-org.mdx
+++ b/src/content/docs/build/organizations/self-serve-portal-per-org.mdx
@@ -1,22 +1,36 @@
 ---
 page_id: a0d83c06-866b-4e46-ac22-33ee1d3a5b7f
 title: Customize the self-serve portal for an organization
-description: Use advanced organizations to override the self-serve portal setting for individual organizations. For example, make a function available in one organization that is not suitable for another org.
+description: >-
+  Use advanced organizations to override the self-serve portal setting for
+  individual organizations. For example, make a function available in one
+  organization that is not suitable for another org.
 sidebar:
   order: 11
 relatedArticles:
   - a2668524-5842-4c68-ab50-30b7e8c3e842
   - 692187c5-1b82-467a-b86f-85b9098ecaab
-metadata:
-  topics: [self-serve portal, manage organizations, self-manage, SSO, plan management, payment details]
-  sdk: []
-  languages: []
-  audience: [frontend-developer]
-  complexity: beginner
-  keywords: [self-serve, plan, bill, payment method, SSO]
-  updated: 2025-08-11
 featured: false
 deprecated: false
+topics:
+  - self-serve portal
+  - manage organizations
+  - self-manage
+  - SSO
+  - plan management
+  - payment details
+sdk: []
+languages: []
+audience:
+  - frontend-developer
+complexity: beginner
+keywords:
+  - self-serve
+  - plan
+  - bill
+  - payment method
+  - SSO
+updated: 2025-08-11
 ---
 
 <Aside type="upgrade">

--- a/src/content/docs/contribute/index.mdx
+++ b/src/content/docs/contribute/index.mdx
@@ -29,9 +29,7 @@ keywords:
   - MDX syntax
   - code samples
   - components
-updated: 2024-01-15
-featured: false
-deprecated: false
+updated: 2026-04-14
 ai_summary: Comprehensive contribution guide for Kinde documentation including writing guidelines, MDX syntax, component usage, GitHub workflow, and community contribution standards.
 ---
 
@@ -176,35 +174,35 @@ Copy the whole example below into the top of any new topic. And complete the req
 
 ```md title="src/content/docs/developer-tools/about/our-sdks.mdx
 ---
-page_id: 
-title: 
+page_id:
+title:
 description: "description"
 sidebar:
-  order: 
+  order:
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
-  - 
-  - 
+  -
+  -
 app_context:
-  - m: 
-    s: 
+  - m:
+    s:
 topics:
-  - 
-  - 
-  - 
+  -
+  -
+  -
 sdk: []
 languages: []
-audience: 
-complexity: 
+audience:
+complexity:
 keywords:
-  - 
-  - 
-  - 
-  - 
-  - 
+  -
+  -
+  -
+  -
+  -
 updated: yyyy-mm-dd
-featured: 
-deprecated: 
-ai_summary: 
+ai_summary:
 ---
 ```
 


### PR DESCRIPTION
Several frontmatter fields (topics, sdk, languages, audience, complexity, keywords, updated) were incorrectly nested under a metadata: block in 99 pages across authenticate/ and billing/. The content schema has no metadata object, so all nested values were silently ignored by Astro's schema parser and never emitted as meta tags.

This PR flattens all those fields to top-level, adds topics and updated to the Zod schema in content.config.ts, and updates the contribution guide template and cursor rule to reflect the correct frontmatter shape going forward.

- Promote nested metadata fields to top-level in 99 authenticate/billing pages
- Add topics and updated fields to content.config.ts Zod schema
- Update contribute guide frontmatter and template
- Remove featured/deprecated from template and cursor rule

- Closes #685 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended documentation schema with new optional metadata fields for improved content organization.

* **Refactor**
  * Restructured documentation frontmatter across 80+ pages to use a flattened schema with top-level fields.
  * Reformatted descriptive fields for consistent multiline YAML formatting.
  * Normalized array-based metadata into explicit YAML list structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->