### PR TITLE
chore: replace npm/npx bash blocks with PackageManagers component

### DIFF
--- a/src/content/docs/build/tokens/decode-jwts.mdx
+++ b/src/content/docs/build/tokens/decode-jwts.mdx
@@ -4,6 +4,8 @@ title: Decoding JSON Web Tokens
 description: Learn how to decode JSON Web Tokens (JWTs) using Kinde's JWT libraries, including validation methods, security considerations, and practical implementation examples.
 sidebar:
   order: 9
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - 4ed081b0-7853-49be-b5fd-22a84a86bdad
   - cf687bce-9732-4b67-9da5-580953c8549f
@@ -27,7 +29,7 @@ keywords:
   - token security
   - JWT libraries
   - token parsing
-updated: 2025-12-15
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to decoding JSON Web Tokens using Kinde's JWT libraries, including validation methods, security considerations, and practical implementation examples.
@@ -49,16 +51,7 @@ The decoder extracts and returns the decoded payload containing the token's clai
 
 ### Installation
 
-```bash
-# npm
-npm install @kinde/jwt-decoder
-
-# yarn
-yarn add @kinde/jwt-decoder
-
-# pnpm
-pnpm install @kinde/jwt-decoder
-```
+<PackageManagers pkg='@kinde/jwt-decoder' />
 
 ### Basic Usage
 
@@ -95,16 +88,7 @@ The [@kinde/jwt-validator](https://www.npmjs.com/package/@kinde/jwt-validator) l
 
 ### Installation
 
-```bash
-# npm
-npm install @kinde/jwt-validator
-
-# yarn
-yarn add @kinde/jwt-validator
-
-# pnpm
-pnpm install @kinde/jwt-validator
-```
+<PackageManagers pkg='@kinde/jwt-validator' />
 
 ### Validation and Decoding
 

--- a/src/content/docs/developer-tools/guides/deploy-on-cloudflare-workers.mdx
+++ b/src/content/docs/developer-tools/guides/deploy-on-cloudflare-workers.mdx
@@ -34,7 +34,7 @@ keywords:
   - opennext
   - edge runtime
   - callback URLs
-updated: 2026-02-06
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide to deploying Next.js applications with Kinde authentication on Cloudflare Workers. Covers OpenNext adapter setup, wrangler.toml configuration with nodejs_compat flags, environment variables in [vars] section (not .env.local), Kinde dashboard callback URL configuration, deployment steps, and troubleshooting common issues like blank screens, localhost redirects, state errors, and undefined environment variables.
@@ -69,15 +69,11 @@ Before diving into setup, understand these critical differences when deploying K
 
 1. Open your project in a terminal and install the OpenNext.js adapter for Cloudflare Workers with the following command:
 
-    ```bash
-    npm install @opennextjs/cloudflare@latest
-    ```
+    <PackageManagers pkg='@opennextjs/cloudflare@latest' />
 
 2. Install Wrangler CLI as a dev dependency:
 
-    ```bash
-    npm i -D wrangler@latest
-    ```
+    <PackageManagers pkg='wrangler@latest' dev />
 
 3. Create a new file called `wrangler.toml` in the root of your project and add the following content:
 
@@ -112,9 +108,7 @@ Before diving into setup, understand these critical differences when deploying K
 
 5. Preview your project in the Cloudflare environment using the following command:
 
-    ```bash
-    npm run preview
-    ```
+    <PackageManagers type='run' pkg='preview' />
 
 6. Add the generated `.open-next` directory to your `.gitignore` file.
 
@@ -134,9 +128,7 @@ Before diving into setup, understand these critical differences when deploying K
 
 2. Deploy your project to Cloudflare Workers using the following command:
 
-    ```bash
-    npm run deploy
-    ```
+    <PackageManagers type='run' pkg='deploy' />
 
     This will deploy your project to Cloudflare Workers. You’ll get a link to see the changes.
 
@@ -186,15 +178,11 @@ If you are using a custom domain, configure the domain in Cloudflare first, then
 
 3. Set your client secret to Cloudflare using the following command:
 
-    ```bash
-    npx wrangler secret put KINDE_CLIENT_SECRET
-    ```
+    <PackageManagers type='dlx' pkg='wrangler' args='secret put KINDE_CLIENT_SECRET' />
 
 4. Redeploy your project to Cloudflare Workers using the following command:
 
-    ```bash
-    npm run deploy
-    ```
+    <PackageManagers type='run' pkg='deploy' />
 
 5. Verify your deployment by visiting your app in the browser. Sign in or sign up with Kinde and you should be redirected to the dashboard page.
 

--- a/src/content/docs/developer-tools/guides/kinde-permissions-react-and-backend.mdx
+++ b/src/content/docs/developer-tools/guides/kinde-permissions-react-and-backend.mdx
@@ -36,7 +36,7 @@ keywords:
   - JWT validation
   - role based access control
   - Kinde permissions
-updated: 2026-03-17
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Guide to implementing Kinde permissions in a React frontend and enforcing the same permissions on backend API routes using access tokens, without calling the Management API.
@@ -299,9 +299,7 @@ Retrieve the token with `getAccessToken()` from `useKindeAuth()`, then send it a
 
 Use Kinde's JWT validator and decoder packages to validate the token and read claims on the backend.
 
-```bash
-npm install @kinde/jwt-validator @kinde/jwt-decoder
-```
+<PackageManagers pkg='@kinde/jwt-validator @kinde/jwt-decoder' />
 
 **Next.js example:**
 

--- a/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nextjs-sdk.mdx
@@ -37,7 +37,7 @@ keywords:
   - authentication
   - route protection
   - environment variables
-updated: 2026-03-26
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide for Next.js App Router SDK including installation, configuration, middleware setup, route protection, and authentication integration for Next.js 13+ applications.
@@ -89,9 +89,8 @@ This SDK is for Next.js version 13+ and uses Server Side Components and App Rout
 5. Copy the environment variables from the **Quick start** page to the `.env.local` file and save changes.
 6. Start the development server:
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
+
 7. Open the browser and navigate to http://localhost:3000 to see the application.
 8. Sign-up for a new user.
 
@@ -285,9 +284,8 @@ Wrap your `RootLayout` component with the `AuthProvider`:
 
 4. Start the development server:
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
+
 5. Open the browser and navigate to http://localhost:3000 to see the application.
 
 Watch the video guide:

--- a/src/content/docs/developer-tools/sdks/backend/nuxt-module.mdx
+++ b/src/content/docs/developer-tools/sdks/backend/nuxt-module.mdx
@@ -32,7 +32,7 @@ keywords:
   - permissions
   - feature flags
   - middleware
-updated: 2024-01-15
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide for Nuxt module including authentication setup, route protection, permissions management, and feature flags for Nuxt 3+ applications.
@@ -54,9 +54,7 @@ If you haven’t already got a Kinde account, [register for free here](https://
 
 Install the `@nuxtjs/kinde` dependency using your package manager of choice.
 
-```bash
-npx nuxi@latest module add kinde
-```
+<PackageManagers type='dlx' pkg='nuxi@latest' args='module add kinde' />
 
 ## Integrate with your app
 

--- a/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/javascript-sdk.mdx
@@ -33,7 +33,7 @@ keywords:
   - organizations
   - access tokens
   - JWT
-updated: 2026-04-03
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide for JavaScript SDK including PKCE authentication, login/register flows, organization management, and API integration for single-page applications.
@@ -91,9 +91,7 @@ Kinde allows you to have one production environment and multiple non-production 
 
 6. Start the development server:
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
 
 7. Open the browser and navigate to http://localhost:3000 to see the application.
 

--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -32,7 +32,7 @@ keywords:
   - register
   - logout
   - access tokens
-updated: 2026-04-13
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide for React SDK including installation, provider setup, authentication hooks, callback handling, and API integration for React 18+ applications.
@@ -90,9 +90,7 @@ Kinde allows you to have one production environment and multiple non-production 
 
 6. Start the development server:
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
 
 7. Open the browser and navigate to http://localhost:3000 to see the application.
 

--- a/src/content/docs/developer-tools/sdks/native/expo.mdx
+++ b/src/content/docs/developer-tools/sdks/native/expo.mdx
@@ -35,7 +35,7 @@ keywords:
   - user profile
   - feature flags
   - permissions
-updated: 2026-03-26
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Complete guide for Expo SDK including authentication setup, token utilities, user profile management, and mobile app integration for React Native applications.
@@ -56,14 +56,6 @@ The Kinde React Native SDK allows developers to quickly and securely integrate a
 Follow [the installation instructions for your chosen OS](https://reactnative.dev/docs/environment-setup) to install dependencies.
 
 ### Install dependencies
-
-```bash
-npm install @kinde/expo
-```
-
-## Installation with Expo Managed Workflow
-
-### Install package
 
 <PackageManagers pkg="@kinde/expo" />
 

--- a/src/content/docs/developer-tools/sdks/native/react-native-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/native/react-native-sdk.mdx
@@ -36,7 +36,7 @@ keywords:
   - expo compatibility
   - native linking
   - cocoapods
-updated: 2024-01-15
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide for React Native SDK including Android/iOS setup, native linking, Expo compatibility, and mobile authentication integration.
@@ -778,11 +778,9 @@ The storage handler can be found at: [Storage class](https://github.com/kinde-o
 
 Run the test suite using the following command at the root of your React Native.
 
-```shell
-npm run test
-```
+<PackageManagers type='run' pkg='test' />
 
-Note: Ensure you have already run `npm install`.
+Note: Ensure you have already run `npm install` or equivalent.
 
 ## SDK API Reference
 

--- a/src/content/docs/integrate/third-party-tools/kinde-and-convex.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-and-convex.mdx
@@ -28,7 +28,7 @@ keywords:
   - authentication
   - database
   - webhooks
-updated: 2026-02-25
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Integrate Kinde with Convex to enable real-time user data sync and secure authentication with Kinde access tokens.
@@ -56,15 +56,12 @@ Example repository: [Kinde React + Convex Starter kit](https://github.com/kinde-
 
 1. Install the Convex and Kinde React SDK dependencies:
 
-    ```bash
-    npm install convex @kinde-oss/kinde-auth-react
-    ```
+    <PackageManagers pkg='convex @kinde-oss/kinde-auth-react' />
 
 2. Use the following command to sign-in to Convex and initialize a new project. Keep this terminal running for the development server.
 
-    ```bash
-    npx convex dev
-    ```
+    <PackageManagers type='dlx' pkg='convex' args='dev' />
+
 ### Add Kinde and Convex providers
 
 1. Update your `main.tsx` file to include the Kinde and Convex providers:
@@ -380,9 +377,7 @@ The Kinde free plan includes one webhook, which is enough for this integrationâ€
 
 1. In your Convex project, install the Kinde webhook library to validate the incoming webhook requests:
 
-    ```bash
-    npm install @kinde/webhooks
-    ```
+    <PackageManagers pkg='@kinde/webhooks' />
 
 2. Update the `users.ts` file: ensure `internalMutation` is in your import from the Convex server (it already is from the earlier step), then add the following two functions after your existing `store` mutation:
 

--- a/src/content/docs/integrate/third-party-tools/kinde-convex-app.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-convex-app.mdx
@@ -25,7 +25,7 @@ keywords:
   - message board
   - real-time
   - authentication
-updated: 2026-03-04
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Tutorial to build a real-time message board with Kinde and Convex—messages table, mutations, queries, and React UI with synced user data.
@@ -338,9 +338,7 @@ In this tutorial you’ll build a small message board where only signed-in users
 
 1. Run the application using the following terminal command:
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 2. Go to http://localhost:5173 and sign in or create a new account.
     

--- a/src/content/docs/integrate/third-party-tools/kinde-firebase.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-firebase.mdx
@@ -28,7 +28,7 @@ keywords:
   - authentication
   - database
   - guestbook app
-updated: 2025-11-11
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Set up a real-time guestbook using Firebase Firestore and Kinde Auth to ensure only authenticated users can post and view messages.
@@ -84,9 +84,7 @@ In this article, we’ll walk through building a secure and scalable guestbook a
 
 1. Install the Firebase package in your project by running the following command in your terminal:
     
-    ```bash
-    npm install firebase
-    ```
+    <PackageManagers pkg='firebase' />
     
 2. Create a Firebase configuration file inside the `/src` directory with the following command:
     
@@ -326,9 +324,7 @@ In this article, we’ll walk through building a secure and scalable guestbook a
 
 1. Run the development server by running this command:
     
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 2. Visit [http://localhost:3000/](http://localhost:3000/) and sign up or sign in to your project.
 3. Go to [http://localhost:3000/add](http://localhost:3000/add) to see the guestbook form in action.

--- a/src/content/docs/integrate/third-party-tools/kinde-mailgun-email-delivery.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-mailgun-email-delivery.mdx
@@ -4,6 +4,8 @@ title: Kinde and Mailgun for email delivery
 description: Guide to sending emails using Mailgun with Kinde including SMTP setup, webhook integration, and Mailgun API configuration
 sidebar:
   order: 13
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - 0222489b-3478-48a7-a5c9-c99c6044f0e9
   - 28ed3700-9ee4-4525-9b5d-1fefe4f89dcd
@@ -25,7 +27,7 @@ keywords:
   - webhooks
   - api integration
   - email deliverability
-updated: 2026-03-03
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Guide to sending emails using Mailgun with Kinde including SMTP setup, webhook integration, and Mailgun API configuration.
@@ -142,9 +144,7 @@ When a user is created, Kinde sends a webhook payload (as a JWT token) that cont
 
 Use the `@kinde-oss/webhook` package to verify Kinde webhook tokens.
 
-```bash
-npm install @kinde-oss/webhook
-```
+<PackageManagers pkg='@kinde-oss/webhook' />
 
 **JavaScript backend example:**
 
@@ -176,9 +176,7 @@ try {
 
 Use the `mailgun.js` and `form-data` packages to send the email via Mailgun API from your JavaScript backend.
 
-```bash
-npm install mailgun.js form-data
-```
+<PackageManagers pkg='mailgun.js form-data' />
 
 Here's how to send a custom email from your endpoint:
 

--- a/src/content/docs/integrate/third-party-tools/kinde-nextjs-drizzle.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-nextjs-drizzle.mdx
@@ -27,7 +27,7 @@ keywords:
   - jwt
   - authentication
   - database
-updated: 2025-11-12
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: "Discover how to integrate Kinde authentication seamlessly into a Next.js application while managing user data with a Drizzle-powered SQLite database."
@@ -56,7 +56,7 @@ By the end of this guide, you’ll have a robust authentication flow complete wi
     
     <PackageManagers pkg='drizzle-orm better-sqlite3' />
 
-    <PackageManagers pkg='-D drizzle-kit @types/better-sqlite3' />
+    <PackageManagers pkg='drizzle-kit @types/better-sqlite3' dev />
     
 3. Create a configuration file for Drizzle in the root directory:
     
@@ -134,9 +134,7 @@ By the end of this guide, you’ll have a robust authentication flow complete wi
     
 10. Push the database changes by entering the following in your terminal:
     
-    ```bash
-    npx drizzle-kit push
-    ```
+    <PackageManagers type='dlx' pkg='drizzle-kit' args='push' />
     
 
 ## Step 2: Save user data to the database after authentication
@@ -204,17 +202,13 @@ By the end of this guide, you’ll have a robust authentication flow complete wi
 
 1. Start your development server by running the following command in your terminal:
     
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 2. Open your web browser and navigate to [`http://localhost:3000`](http://localhost:3000/) to view your Kinde application locally. 
 3. Select **Sign Up** to create a new user account. Enter the required details and complete the sign-up process.
 4. Open a new terminal window and start the Drizzle Studio with the following command:
     
-    ```bash
-    npx drizzle-kit studio
-    ```
+    <PackageManagers type='dlx' pkg='drizzle-kit' args='studio' />
     
     <Aside> 
       Drizzle Studio is a visual tool for managing your database. It provides an intuitive interface to view, edit, and manage data in your database, making it easier to inspect records and make updates without writing SQL queries. It integrates directly with your Drizzle schema, streamlining database interactions during development.

--- a/src/content/docs/integrate/third-party-tools/kinde-nextjs-prisma.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-nextjs-prisma.mdx
@@ -28,7 +28,7 @@ keywords:
   - jwt
   - authentication
   - database
-updated: 2026-01-11
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Learn how to integrate Kinde authentication with a Next.js application and store user data in a Prisma-managed SQLite database.
@@ -49,23 +49,19 @@ By the end, you will have a fully functional authentication flow with user manag
 
 1. Install Prisma client and adapter dependencies with the following bash command:
     
-    ```bash
-    npm install @prisma/client @prisma/adapter-better-sqlite3 typescript@5.9.3
-    ```
+    <PackageManagers pkg='@prisma/client @prisma/adapter-better-sqlite3 typescript@5.9.3' />
+
     <Aside>
       Prisma 7 requires TypeScript version 5.4.0 or higher. Make sure your `typescript` version in `package.json` is `^5.4.0` or higher. We are using version 5.9.3 for this guide.
     </Aside>
+
 2. Install Prisma as a dev dependency:
-    
-    ```bash
-    npm install prisma --save-dev
-    ```
-    
+
+    <PackageManagers pkg='prisma' dev />
+
 3. Initialize your Prisma project with SQLite as the database provider:
-    
-    ```bash
-    npx prisma init --datasource-provider sqlite
-    ```
+
+    <PackageManagers type='dlx' pkg='prisma' args='init --datasource-provider sqlite' />
 
     In this project, we use SQLite, a simple file-based database stored on your computer. 
        
@@ -96,15 +92,11 @@ By the end, you will have a fully functional authentication flow with user manag
     
 5. Run migrations with the following command:
         
-    ```bash
-    npx prisma migrate dev --name init
-    ```
+    <PackageManagers type='dlx' pkg='prisma' args='migrate dev --name init' />
   
 6. Generate the Prisma client with the following command:
 
-    ```bash
-    npx prisma generate
-    ```
+    <PackageManagers type='dlx' pkg='prisma' args='generate' />
     
 7. Set up Prisma Client by creating a new `lib` directory at the `src` directory of your project and adding a `prisma.ts` file:
     
@@ -243,18 +235,15 @@ You’re now ready to test your database integration.
 ## Step 3: Test the Prisma integration
 
 1. Start your development server by running the following command in your terminal:
-    
-    ```bash
-    npm run dev
-    ```
-    
+
+    <PackageManagers type='run' pkg='dev' />
+
 2. Open your web browser and navigate to http://localhost:3000/ to view your Kinde application. 
 3. Select **Sign Up** to create a new user account. Enter the required details and complete the sign-up process.
 4. Open your terminal and start the Prisma Studio by typing the following command:
     
-    ```bash
-    npx prisma studio
-    ```
+    <PackageManagers type='dlx' pkg='prisma' args='studio' />
+
     Prisma Studio will open in your default web browser.
 
     <Aside title="About Prisma Studio">

--- a/src/content/docs/integrate/third-party-tools/kinde-supabase-todo-app.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-supabase-todo-app.mdx
@@ -30,7 +30,7 @@ keywords:
   - authentication
   - database
   - todo app
-updated: 2025-09-01
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: A walkthough example on how to create a to-do list app using Kinde and Supabase, as previously set up.
@@ -167,9 +167,7 @@ Your database policy is now set up to ensure that only the authenticated user's 
     
 3. Run the project with the following terminal command:
     
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 4. Go to [http://localhost:3000](http://localhost:3000/), sign in/sign up, and preview the page. You won’t see any to-do items because we haven’t set any user ID yet.
     

--- a/src/content/docs/integrate/third-party-tools/kinde-supabase.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-supabase.mdx
@@ -31,7 +31,7 @@ keywords:
   - authentication
   - database
   - todo app
-updated: 2025-09-01
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to integrating Kinde authentication with Supabase database including PostgreSQL RLS policies, Next.js setup, and secure user-specific data access.
@@ -142,9 +142,7 @@ This will enable you to create a new standby key.
 
 1. Run the following command in your terminal window to start a new project with Next.js and Supabase. Follow the on-screen instructions.
     
-    ```bash
-    npx create-next-app -e with-supabase
-    ```
+    <PackageManagers type='dlx' pkg='create-next-app' args='-e with-supabase' />
     
 2. Set a name for your project (e.g: `kinde-with-supabase`)
 3. Go into the project directory:
@@ -154,12 +152,10 @@ This will enable you to create a new standby key.
     
     ```
     
-4. Install the Kinde dependency with this command:
+4. Install the dependencies:
     
-    ```bash
-    npm install @kinde-oss/kinde-auth-nextjs jsonwebtoken
-    npm install --save-dev @types/jsonwebtoken
-    ```
+    <PackageManagers pkg='@kinde-oss/kinde-auth-nextjs jsonwebtoken' />
+    <PackageManagers pkg='@types/jsonwebtoken' dev />
     
 5. Create the Kinde auth endpoint in this path **app/api/auth/[kindeAuth]**:
     
@@ -329,10 +325,7 @@ This will enable you to create a new standby key.
     
 13. Start the development environment by typing the following in your terminal:
     
-    ```bash
-    npm run dev
-    
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 14. Go to [http://localhost:3000](http://localhost:3000/) and sign up/sign in to your Kinde application to test the integration.
     

--- a/src/content/docs/integrate/webhooks/webhooks-nextjs.mdx
+++ b/src/content/docs/integrate/webhooks/webhooks-nextjs.mdx
@@ -29,7 +29,7 @@ keywords:
   - local development
   - ngrok
   - localtunnel
-updated: 2026-02-03
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Step-by-step guide to implementing Kinde webhooks in Next.js including JWT verification, API route setup, and local development testing.
@@ -46,9 +46,7 @@ In this guide, we will set up a webhook in Kinde and configure it with a Next.js
 ## Step 1: Create the Kinde webhook route
 
 1. Install the Kinde webhook decoder package with the following command in your terminal:
-    ```bash
-    npm install @kinde/webhooks
-    ```
+    <PackageManagers pkg='@kinde/webhooks' />
 
 2. Create the webhook route endpoint `app/api/webhook/route.ts` and add the following code: 
 
@@ -148,9 +146,7 @@ For this example, we will use localtunnel to create a public proxy URL.
 
 1. Start your development server with the following command: 
 
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
 
 2. Open a new terminal window and install the localtunnel package with the following command:
 

--- a/src/content/docs/testing/cypress/index.mdx
+++ b/src/content/docs/testing/cypress/index.mdx
@@ -21,7 +21,7 @@ keywords:
   - cypress
   - testing
   - setup
-updated: 2026-01-20
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -36,14 +36,10 @@ Learn how to set up Cypress for testing applications using Kinde authentication.
 ## Installation for new projects
 
 1. Install Cypress with the following command:
-    ```bash
-    npm install cypress --save-dev
-    ```
+    <PackageManagers pkg='cypress' dev />
 
 2. Run the following command. The Cypress configuration wizard opens:
-    ```bash
-    npx cypress open
-    ```
+    <PackageManagers type='dlx' pkg='cypress' args='open' />
     - Select **E2E Testing** and select **Continue**.
     - Select **Start E2E Testing in Chrome**. This will open the Cypress Test Runner.
     - Select **Create new spec**. In the pop-up that opens, select **Create spec**
@@ -139,9 +135,7 @@ describe('Authentication', () => {
 
 Open Cypress in interactive mode:
 
-```bash
-npx cypress open
-```
+<PackageManagers type='dlx' pkg='cypress' args='open' />
 
 This opens the Cypress Test Runner where you can:
 - Select a browser
@@ -152,9 +146,7 @@ This opens the Cypress Test Runner where you can:
 
 Run tests in headless mode:
 
-```bash
-npx cypress run
-```
+<PackageManagers type='dlx' pkg='cypress' args='run' />
 
 
 
@@ -164,9 +156,7 @@ npx cypress run
 
 If you get a "command not found" error, make sure Cypress is installed locally:
 
-```bash
-npm install cypress --save-dev
-```
+<PackageManagers pkg='cypress' dev />
 
 ### Environment variables not loading
 

--- a/src/content/docs/testing/cypress/test-auth-features.mdx
+++ b/src/content/docs/testing/cypress/test-auth-features.mdx
@@ -23,7 +23,7 @@ keywords:
   - testing
   - authenticated features
   - session state
-updated: 2026-01-22
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -106,9 +106,8 @@ If you are starting from scratch, you can run sample tests using the [Kinde star
 
 3. Use the following command:
 
-    ```bash
-    npx cypress open
-    ```
+    <PackageManagers type='dlx' pkg='cypress' args='open' />
+
 4. Select the test spec to run.
 
     You should now see the Cypress tests passing in the browser.

--- a/src/content/docs/testing/cypress/test-auth-flows.mdx
+++ b/src/content/docs/testing/cypress/test-auth-flows.mdx
@@ -25,7 +25,7 @@ keywords:
   - sign-up
   - sign-in
   - sign-out
-updated: 2026-01-22
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -112,9 +112,8 @@ Learn how to test authentication flows (sign-up, sign-in, sign-out) with Cypress
 
 1. Use the following command:
 
-    ```bash
-    npx cypress open
-    ```
+    <PackageManagers type='dlx' pkg='cypress' args='open' />
+
 2. Select the test spec to run.
 
     You should now see the Cypress tests passing in the browser.

--- a/src/content/docs/testing/cypress/test-backend-apis.mdx
+++ b/src/content/docs/testing/cypress/test-backend-apis.mdx
@@ -24,7 +24,7 @@ keywords:
   - backend APIs
   - API testing
   - refresh tokens
-updated: 2026-01-22
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -238,9 +238,7 @@ If you are starting from scratch, you can run sample tests using the [Kinde star
 
 3. Run the tests using the following command:
 
-    ```bash
-    npx cypress open
-    ```
+    <PackageManagers type='dlx' pkg='cypress' args='open' />
 
     You should see the tests pass.
 

--- a/src/content/docs/testing/cypress/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/cypress/test-passwordless-flows.mdx
@@ -25,7 +25,7 @@ keywords:
   - magic link
   - email OTP
   - Mailosaur
-updated: 2026-01-20
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -45,9 +45,7 @@ This guide shows you how to automate passwordless authentication testing with Cy
 3. Go to **API Keys** > select **Create standard key** and copy the value.
 4. Install the Mailosaur client in your Cypress project:
 
-    ```bash
-    npm install mailosaur --save-dev
-    ```
+    <PackageManagers pkg='mailosaur' dev />
 
 5. Update your `cypress.env.json` file with your Mailosaur API key and Server ID:
 
@@ -317,9 +315,8 @@ This example uses the Kinde **email + password** authentication method to sign u
 
 1. Use the following command:
 
-    ```bash
-    npx cypress open
-    ```
+    <PackageManagers type='dlx' pkg='cypress' args='open' />
+
 2. Select the test spec to run.
 
     You should now see the Cypress tests passing in the browser.

--- a/src/content/docs/testing/playwright/index.mdx
+++ b/src/content/docs/testing/playwright/index.mdx
@@ -21,7 +21,7 @@ keywords:
   - playwright
   - testing
   - setup
-updated: 2026-01-23
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -48,9 +48,7 @@ Learn how to set up Playwright for testing applications using Kinde authenticati
     This will create the basic Playwright folder structure and configuration files.
 
 2. Install dotenv for environment variable management:
-    ```bash
-    npm install dotenv --save-dev
-    ```
+    <PackageManagers pkg='dotenv' dev />
 
 ## Configuration
 
@@ -146,9 +144,7 @@ test('can visit the application', async ({ page }) => {
 
 Open Playwright in interactive mode:
 
-```bash
-npx playwright test --ui
-```
+<PackageManagers type='dlx' pkg='playwright' args='test --ui' />
 
 This opens the Playwright Test UI where you can:
 - Select a browser
@@ -159,9 +155,7 @@ This opens the Playwright Test UI where you can:
 
 Run tests in headless mode:
 
-```bash
-npx playwright test
-```
+<PackageManagers type='dlx' pkg='playwright' args='test' />
 
 ## Troubleshooting
 
@@ -177,9 +171,7 @@ npm init playwright@latest
 
 Install Playwright browsers:
 
-```bash
-npx playwright install
-```
+<PackageManagers type='dlx' pkg='playwright' args='install' />
 
 ### Environment variables not loading
 

--- a/src/content/docs/testing/playwright/test-auth-features.mdx
+++ b/src/content/docs/testing/playwright/test-auth-features.mdx
@@ -25,7 +25,7 @@ keywords:
   - test automation
   - CI/CD
   - authentication state
-updated: 2026-01-22
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -140,9 +140,8 @@ If you are starting from scratch, you can run sample tests using the [Kinde star
 
 3. Use the following command:
 
-    ```bash
-    npx playwright test --ui
-    ```
+    <PackageManagers type='dlx' pkg='playwright' args='test --ui' />
+
 4. Select the test spec to run.
 
     You should now see the Playwright tests passing in the browser.

--- a/src/content/docs/testing/playwright/test-auth-flows.mdx
+++ b/src/content/docs/testing/playwright/test-auth-flows.mdx
@@ -25,7 +25,7 @@ keywords:
   - sign-up
   - sign-in
   - sign-out
-updated: 2026-01-21
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -114,9 +114,8 @@ Learn how to test authentication flows (sign-up, sign-in, sign-out) with Playwri
 
 1. Use the following command:
 
-    ```bash
-    npx playwright test --ui
-    ```
+    <PackageManagers type='dlx' pkg='playwright' args='test --ui' />
+
 2. Select the test spec to run.
 
     You should now see the Playwright tests passing in the browser.

--- a/src/content/docs/testing/playwright/test-backend-apis.mdx
+++ b/src/content/docs/testing/playwright/test-backend-apis.mdx
@@ -25,7 +25,7 @@ keywords:
   - backend APIs
   - API testing
   - refresh tokens
-updated: 2026-01-22
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -196,9 +196,7 @@ If you are starting from scratch, you can run sample tests using the [Kinde star
 
 3. Run the tests using the following command:
 
-    ```bash
-    npx playwright test --ui
-    ```
+    <PackageManagers type='dlx' pkg='playwright' args='test --ui' />
 
     You should see the tests pass.
 

--- a/src/content/docs/testing/playwright/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/playwright/test-passwordless-flows.mdx
@@ -25,7 +25,7 @@ keywords:
   - magic link
   - email OTP
   - Mailosaur
-updated: 2026-01-21
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -45,9 +45,7 @@ This guide shows you how to automate passwordless authentication testing with Pl
 3. Go to **API Keys** > select **Create standard key** and copy the value.
 4. Install the Mailosaur client in your Playwright project:
 
-    ```bash
-    npm install mailosaur --save-dev
-    ```
+    <PackageManagers pkg='mailosaur' dev />
 
 5. Add the following to your `.env` file:
 
@@ -294,9 +292,8 @@ This example uses the Kinde **email + password** authentication method to sign u
 
 1. Use the following command:
 
-    ```bash
-    npx playwright test --ui
-    ```
+    <PackageManagers type='dlx' pkg='playwright' args='test --ui' />
+
 2. Select the test spec to run.
 
     You should now see the Playwright tests passing in the browser.

--- a/src/content/docs/testing/test-backend-apis-jest.mdx
+++ b/src/content/docs/testing/test-backend-apis-jest.mdx
@@ -23,7 +23,7 @@ keywords:
   - refresh tokens
   - token rotation
   - automated testing
-updated: 2026-01-20
+updated: 2026-04-14
 featured: false
 deprecated: false
 ---
@@ -39,9 +39,7 @@ In this guide, we'll show you how to test backend APIs with Jest. We will use Ki
 
 1. Install Jest and dotenv:
 
-    ```bash
-    npm install --save-dev jest dotenv
-    ```
+    <PackageManagers pkg='jest dotenv' dev />
 
 2. Create a new `.env` file in your project root:
 

--- a/src/content/docs/testing/testing-backend-apis.mdx
+++ b/src/content/docs/testing/testing-backend-apis.mdx
@@ -27,7 +27,7 @@ keywords:
   - automated testing
   - test automation
   - jest
-updated: 2026-01-17
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Overview and setup instructions for testing backend APIs with Kinde refresh tokens
@@ -84,9 +84,7 @@ You can validate the test API request with the Kinde JWT validator and JWT decod
 
 1. Install the required dependencies:
 
-    ```bash
-    npm install @kinde/jwt-validator @kinde/jwt-decoder
-    ```
+    <PackageManagers pkg='@kinde/jwt-validator @kinde/jwt-decoder' />
 
 Here is sample code showing how to validate your JWT token:
 

--- a/src/content/docs/workflows/workflow-tutorials/check-plan-change-eligibility.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/check-plan-change-eligibility.mdx
@@ -25,7 +25,7 @@ keywords:
   - "billing workflow"
   - "stripe billing"
   - "pricing table"
-updated: "2025-11-05"
+updated: "2026-04-14"
 featured: false
 deprecated: false
 ai_summary: "Learn how to set up automatic downgrade eligibility checks using Kinde billing and workflows."
@@ -54,12 +54,10 @@ In this tutorial you’ll set up a way to check a customer’s feature usage, in
 2. Install the project dependencies with the following bash commands in your terminal. 
 This will install Prisma ORM, Zod validator utility, and initiate the Prisma database with SQLite database.
 
-    <PackageManagers pkg="-D prisma" />
+    <PackageManagers pkg='prisma' dev />
     <PackageManagers pkg="@prisma/client zod" />
     
-    ```bash
-    npx prisma init --datasource-provider sqlite
-    ```
+    <PackageManagers type='dlx' pkg='prisma' args='init --datasource-provider sqlite' />
     
 3. Open the `/prisma/schema.prisma` file with your favorite code editor and replace the contents with the following code and save changes. This will add a schema for your `Account` model with `id`, `name`, `accountNumber`, `kindeId`, and other helpful fields.
     
@@ -115,9 +113,7 @@ This will install Prisma ORM, Zod validator utility, and initiate the Prisma dat
     
 6. Run the following bash command in your terminal to migrate the Prisma database:
     
-    ```bash
-    npx prisma migrate dev --name init 
-    ```
+    <PackageManagers type='dlx' pkg='prisma' args='migrate dev --name init' />
     
 
 ### Part 2: Set up the user experience

--- a/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
@@ -25,7 +25,7 @@ keywords:
   - "disposable emails"
   - "spam prevention"
   - "authentication triggers"
-updated: "2025-10-06"
+updated: "2026-04-14"
 featured: false
 deprecated: false
 ai_summary: "Learn how to customize tokens using workflows, to help distinguish customer types."
@@ -80,9 +80,7 @@ We'll check whether the user is a `lifetime_subscriber` and pass that data into 
     - **`lifetime_subscriber`**: with a type of **boolean**. We use boolean because the lifetime subscription is either true or false.
 5. Install the Supabase dependency by running the following command in your project terminal.
     
-    ```bash
-    npm install @supabase/ssr
-    ```
+    <PackageManagers pkg='@supabase/ssr' />
     
 6. Create the necessary Supabase files by running.
     
@@ -191,9 +189,7 @@ We'll check whether the user is a `lifetime_subscriber` and pass that data into 
     
 12. Start your development server by running the following:
     
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 13. Open your browser and visit [http://localhost:3000](http://localhost:3000/). 
 14. Sign up or sign in with a new user account.
@@ -208,9 +204,7 @@ You can use any JavaScript or TypeScript project for your workflow code. In this
 
 1. Start by installing the Kinde infrastructure package with this command.
     
-    ```bash
-    npm install @kinde/infrastructure
-    ```
+    <PackageManagers pkg='@kinde/infrastructure' />
     
 2. Create a configuration file for your workflow by running this command.
     
@@ -372,9 +366,7 @@ You’ll now see your workflow listed inside the dashboard.
         
 7. Run your local development server with the following command.
     
-    ```bash
-    npm run dev
-    ```
+    <PackageManagers type='run' pkg='dev' />
     
 8. Visit `http://localhost:3000` in your browser. Log in or sign up to view the access token.
     


### PR DESCRIPTION
Replace all `npm install`, `npm run`, and `npx` bash code blocks across 32 docs pages with the **<PackageManagers>** MDX component. This gives readers a consistent tabbed UI showing equivalent commands for npm, pnpm, and yarn — rather than npm-only bash snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized package manager command display across SDK documentation and integration guides for improved consistency and readability
  * Enhanced formatting of installation and deployment instructions throughout setup guides and tutorials
  * Updated all documentation with latest release information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->