### PR TITLE
fix: update enterprise connection setup to use booking link

### DIFF
--- a/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
+++ b/src/content/docs/get-started/team-and-account/enterprise-access-to-kinde.mdx
@@ -25,16 +25,17 @@ keywords:
   - entity id
   - metadata url
   - acs url
-updated: 2024-01-15
+updated: 2026-04-14
 featured: false
 deprecated: false
 ai_summary: Guide to setting up enterprise access to Kinde using SAML connections for team member authentication via Identity Provider.
 ---
 
-
 If you want your team members to sign in to the Kinde dashboard using an enterprise connection (such as SAML) instead of via our default sign up flow, you can contact us to request it. You must be on a Kinde Scale or Enterprise plan to request this.
 
-Email your business name and email ID to support@kinde.com and provide the following from your Identity Provider (IdP). 
+To get started, please [book a time with our team](https://meetings-ap1.hubspot.com/kinde/speak-with-the-team). We recommend completing this setup on a live call with our team to make sure everything moves smoothly.
+
+During the call, please have the following details from your Identity Provider (IdP) ready.
 
 For SAML connections:
 - Entity ID
@@ -47,11 +48,11 @@ For SAML connections:
 
 For Entra ID connections:
 - Client ID
-- Client Secret^
+- Client Secret
 - Microsoft Entra domain
 - Home realm domains (if applicable)
 - Upstream params (if applicable)
 
-^Contact us to discuss the most secure way to provide this information
+For security reasons, our team will guide you on how to share this information safely during setup.
 
-Once we have these, we can set up the connection and send you an ACS url (also known as a **reply url**), for example: `https://app.kinde.com/login/saml/callback`, to complete the setup with your IdP. 
+Once we have these, we can set up the connection and send you an ACS URL (also known as a reply URL), for example: `https://app.kinde.com/login/saml/callback`, to complete the setup with your IdP.


### PR DESCRIPTION
**Description** 

This change updates the enterprise connection setup documentation to reflect a recent process update.
Instead of asking users to email support, we now require customers to book a call with our team to complete the setup. This allows us to guide them through the configuration live and ensure everything is set up correctly.
The wording around sharing sensitive information has also been updated to clarify that secure handling will be guided during the call.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated enterprise access onboarding process to streamline setup by replacing email-based requests with direct live call booking.
  * Enhanced guidance to help users prepare identity provider details before their setup call.
  * Improved clarity on how information will be securely shared during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->