### PR TITLE
chore: add per-doc last updated and ai_summary to llms txt

### DIFF
--- a/scripts/generate-llms-txt-abridged.js
+++ b/scripts/generate-llms-txt-abridged.js
@@ -63,6 +63,10 @@ export function extractFrontmatter() {
         fileName: fileName,
         title: frontmatter.title || '',
         description: frontmatter.description || '',
+        ai_summary: frontmatter.ai_summary || '',
+        updated: frontmatter.updated instanceof Date
+          ? frontmatter.updated.toISOString().split('T')[0]
+          : frontmatter.updated || '',
         keywords: keywords,
         topics: topics
       });
@@ -136,9 +140,15 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     
     // Build content without extra labels and with minimal line breaks
     let content = '';
-    
-    if (result.description) {
-      content += result.description;
+
+    if (result.updated) {
+      content += `Last updated: ${result.updated}\n`;
+    }
+
+    const summary = result.ai_summary || result.description;
+    if (summary) {
+      if (content) content += '\n';
+      content += summary;
     }
     
     if (result.keywords) {

--- a/scripts/generate-llms-txt-full.js
+++ b/scripts/generate-llms-txt-full.js
@@ -89,6 +89,9 @@ export function extractCompleteDocs() {
         fileName: fileName,
         title: frontmatter.title || '',
         description: frontmatter.description || '',
+        updated: frontmatter.updated instanceof Date
+          ? frontmatter.updated.toISOString().split('T')[0]
+          : frontmatter.updated || '',
         keywords: keywords,
         topics: topics,
         content: cleanContent(content)
@@ -157,7 +160,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     if (result.description) {
       completeContent += `> ${result.description}\n\n`;
     }
-    
+
+    if (result.updated) {
+      completeContent += `Last updated: ${result.updated}\n\n`;
+    }
+
     // Add keywords and topics if available
     if (result.keywords || result.topics) {
       let metadata = '';


### PR DESCRIPTION
- Adds per-doc Last updated date to llms-full/llms-abridged file.
- Adds ai_summary to llm-abridged file.

**Abridged (llms-abridged.txt)**: Each doc section now shows the last updated date (when present) and uses ai_summary as the summary text, with a fallback to description for docs that don't have one yet

**Full (llms-full.txt)**: Each doc section now shows the last updated date after the description blockquote

Dates are normalised to YYYY-MM-DD format (gray-matter auto-parses YAML dates into JS Date objects, so an explicit conversion was added)
Coverage: 440/443 docs have updated, 338/443 have ai_summary — missing fields are gracefully omitted