### PR TITLE
fix: update workflow docs with clean usage examples

### DIFF
--- a/src/content/docs/workflows/getting-started/quick-start-guide.mdx
+++ b/src/content/docs/workflows/getting-started/quick-start-guide.mdx
@@ -1,13 +1,18 @@
 ---
 page_id: b5a147ac-c189-40b5-8300-b518dd353f92
-title: Quick start guide (workflows)
+title: Workflow quickstart guide
 sidebar:
   order: 1
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - a49abb3b-467f-4b4c-aba2-07ec360b3f19
   - d360c480-49a8-47d3-b178-1abd34ae669f
   - dcd679b7-1a91-4b6b-b16f-dd38000bb8ae
-description: Step-by-step guide to create your first Kinde workflow using the base template, connecting GitHub repository, and testing authentication triggers with runtime logs.
+app_context:
+  - m: ["Workflows", "Git repo"]
+  - s: "Connected branch"
+description: Step-by-step guide to create your first Kinde workflow using the base template, connecting a GitHub repository, and testing authentication triggers with runtime logs.
 topics:
   - "workflows"
   - "getting-started"
@@ -26,46 +31,61 @@ keywords:
   - "template"
   - "first workflow"
   - "authentication triggers"
-updated: "2025-01-27"
+updated: 2026-04-17
 featured: false
 deprecated: false
-ai_summary: "Step-by-step guide to create your first Kinde workflow using the base template, connecting GitHub repository, and testing authentication triggers with runtime logs."
+ai_summary: "Quickstart guide for Kinde workflows: prerequisites are a Kinde account with an application configured and GitHub. From the official Kinde workflow base template on GitHub, select Use this template to create a new repository, then clone it locally—the starter runs on authentication and logs Hello world via the post-authentication trigger. In Kinde, go to Settings > Git repo, connect GitHub, select that repository and branch (for example main), save so code syncs and a workflow is created automatically (for example Workflow 1 under Workflows). Open the workflow for details, deployments, and Runtime logs (empty until a run). Confirm behavior by signing into your app, then inspect Runtime logs for the new entry showing trigger, execution, Hello world, and completion timing. After a successful run you can edit workflow code or add more workflows. Next steps: read the workflows documentation for triggers and advanced patterns, and browse the Kinde workflow-examples repository on GitHub."
 ---
 
 The quickest way to see an end-to-end example is to follow this guide. It will help you set up your project and create your first workflow.
 
-## Prerequisites
+### What you need
 
-- A Kinde account with an application set up
-- A GitHub account to host your code.
+- A [Kinde](https://app.kinde.com/register) account with an application set up (sign up for free)
+- A [GitHub](https://github.com/) account to host your code (sign up for free)
 
-## 1. Clone the base template
+## Step 1: Create and clone the base template
 
-Sign in to your GitHub account and navigate to [Kinde base workflow template](https://github.com/kinde-starter-kits/workflow-base-template). Click the green **Use this template button** and select "Create a new repository".
+1. Sign in to your GitHub account and navigate to the [Kinde base workflow template](https://github.com/kinde-starter-kits/workflow-base-template)
+2. Select the green **Use this template** button, then select **Create a new repository**
+3. Enter an easily identifiable name for your repository (e.g., "kinde-wf-base-template")
+4. Clone the repository to your local machine using your preferred method (e.g. Git CLI, GitHub Desktop, etc.)
 
-This will create a new repository in your GitHub account with the base template code.
+The base template contains a basic workflow that writes `Hello, world!` to runtime logs when a user authenticates.
 
-It contains a basic workflow that logs out "Hello, world!" when a user authenticates.
+## Step 2: Connect your Git repository
 
-## 2. Connect your GitHub repository to Kinde
+1. Sign in to your Kinde account and go to **Settings > Git repo**
+2. Select **Connect GitHub**
+3. Follow the instructions to connect your GitHub account to Kinde
+4. Select the repository you just created, then select **Next**
+5. Select the branch (e.g., "main") and select **Save** 
+    
+    Kinde will automatically sync the code and create a new workflow for you.
+6. Go to **Kinde home > Workflows** to view your new workflow. You should see a new workflow called `Workflow 1`
 
-Sign in to your Kinde account and navigate to **Settings > Git repo**. Select **Connect GitHub** and follow the instructions to connect your GitHub account to Kinde.
+    ![Workflow 1 base template](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/ae778ce4-bd2f-45ba-5de5-3c21d9b51b00/socialsharingimage)
+7. Select the workflow to see the details and deployments
+8. Select **Runtime logs** to view the logs for the workflow. This should currently be empty.
 
-When you select the repository you just created, Kinde will automatically sync the code and create a new workflow for you.
+## Step 3: Test your workflow
 
-## 3. View your first workflow
+Assuming you have a Kinde application set up, you can test your workflow by signing in to your application. This will trigger the workflow and a new runtime log entry will be available to view.
 
-Navigate to Workflows in the Kinde admin area. You should see a new workflow called `Workflow 1`. Select the workflow to see the details and deployments. Select on **Runtime logs** to view the logs for the workflow. This should currently be empty.
+1. Open **Runtime logs** for the workflow again (refresh the page if the list does not update).
+2. Select the new log entry to see **Hello world** in the output (see sample below).
 
-## 4. Test your workflow
-
-Assuming you have a Kinde application set up, you can test your workflow by signing in to your application. This will trigger the workflow and a new runtime log entry will be available to view. Click on the new log entry to see "Hello, world!
-
-## 5. That's it!
+    ```text title="Workflow sample output"
+    Post-authentication trigger fired
+    Workflow found
+    JavaScript execution started…
+    Info Hello world
+    🎉 Workflow completed in 0.7ms
+    ```
 
 You have successfully created your first Kinde workflow! You can now modify the workflow code to do whatever you like or add more workflows.
 
-### Next steps
+## Next steps
 
 - Explore the [Kinde workflows documentation](/workflows/about-workflows/) to learn more about how workflows work, the available triggers, and how to create more complex workflows.
-- Dive into example workflows in the [Kinde workflow examples GitHub repository](https://github.com/kinde-starter-kits/workflow-examples)
+- Dive into example workflows in the [Kinde workflow examples GitHub repository](https://github.com/kinde-starter-kits/workflow-examples).

--- a/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
@@ -3,6 +3,8 @@ page_id: 56db51a5-5542-4631-8bc6-36339a813a85
 title: Tutorial - Customize tokens using workflows
 sidebar:
   order: 1
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - 62fafade-5d33-4f85-9fd2-712c533db3d0
   - f499ebb0-d7f5-4244-bf92-6bf0f6082b62
@@ -31,371 +33,178 @@ deprecated: false
 ai_summary: "Learn how to customize tokens using workflows, to help distinguish customer types."
 ---
 
-The Kinde user token generation workflow lets you customize the access token. In this article, we’ll walk through a scenario where we store a custom user value in the token.
+Use workflows to add or remove claims from Kinde's access or ID tokens.
 
-## Background
+### What you need 
 
-Our fictional SaaS product offers a lifetime membership option. Users who purchase the lifetime membership get full access to our product. In this article, we’ll build a project that stores extra data in a third-party Supabase database. 
+- A [Kinde](https://app.kinde.com/register) account (sign up for free)
+- A workflow git repository connected to your Kinde account (Use the [workflow base template](/workflows/getting-started/quick-start-guide/))
 
-We'll check whether the user is a `lifetime_subscriber` and pass that data into the Kinde access token. This way, the information stays available for the lifetime of the token, and your app won’t need to make an API request every time it’s required.
+## Customize the access token
 
-## What you need?
+### Add a custom claim
 
-- A [Kinde](https://kinde.com/) account (sign up for free)
-- A [Supabase](http://supabase.com/) account (sign up for free)
-- A [GitHub](https://github.com/) account (sign up for free)
-- A running Kinde application or a starter kit such as the [Next.js starter kit](https://github.com/kinde-starter-kits/kinde-nextjs-app-router-starter-kit)
+1. Add the following code to your `Workflow.ts` file:
 
-## Step 1: Set up a Supabase database
-
-1. Sign in to your [Supabase dashboard](https://supabase.com/).
-2. Select **New Project.**
-    1. Enter a project name.
-    2. Set a secure password for your database.
-    3. Select a database region that best suits your application. 
-    4. Select **Create new project**.
-        
-        ![Set up Supabase project](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eaa63e5e-ecc8-41f3-8527-731bcc49db00/public)
-        
-3. In the project **Settings**, go to **Configuration** > **Data API.** Copy the following:
-    1. **Project URL**.
-    2. **Project API Keys** `anon`  `public`.
-    
-    ![API Keys settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/3e2cbc80-47e6-4f07-e541-6df0124a8d00/public)
-    
-4. Navigate to a **SQL Editor** and paste the following SQL code into the command window and select **Run**:
-    
-    ```sql
-    -- Create the table
-    CREATE TABLE profiles (
-    	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    	kinde_id TEXT NOT NULL,
-    	lifetime_subscriber BOOLEAN DEFAULT FALSE
-    );
-    ```
-    
-    This command creates a `profiles` table with the following columns:
-    
-    - **`kinde_id`**: with a type of **text**.
-    - **`lifetime_subscriber`**: with a type of **boolean**. We use boolean because the lifetime subscription is either true or false.
-5. Install the Supabase dependency by running the following command in your project terminal.
-    
-    <PackageManagers pkg='@supabase/ssr' />
-    
-6. Create the necessary Supabase files by running.
-    
-    ```bash
-    mkdir -p src/utils/supabase
-    touch src/utils/supabase/server.ts
-    ```
-    
-7. Open the newly created `server.ts` file and paste the following code. This sets up Supabase integration for your Next.js project.
-    
-    ```tsx
-    import { createServerClient } from "@supabase/ssr";
-    import { cookies } from "next/headers";
-    
-    export async function createClient() {
-      const cookieStore = await cookies();
-    
-      return createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        {
-          cookies: {
-            getAll() {
-              return cookieStore.getAll();
-            },
-            setAll(cookiesToSet) {
-              try {
-                cookiesToSet.forEach(({ name, value, options }) =>
-                  cookieStore.set(name, value, options)
-                );
-              } catch {
-                // The `setAll` method was called from a Server Component.
-                // This can be ignored if you have middleware refreshing
-                // user sessions.
-              }
-            },
-          },
-        }
-      );
-    }
-    
-    ```
-    
-8. Open your `.env.local` file and add the Supabase project URL and public anon key. You can find these in your Supabase dashboard under **Project Settings > Data API**.
-    
-    ```
-    NEXT_PUBLIC_SUPABASE_URL=https://<supabase_project_id>.supabase.co
-    NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase_anon_public_key>
-    ```
-    
-9. Create a new directory called `success` inside `src/app/api/auth/`, and add a `route.ts` file by running the following code.
-    
-    ```bash
-    mkdir src/app/api/auth/success
-    touch src/app/api/auth/success/route.ts
-    ```
-    
-    This file will act as a GET endpoint that handles authenticated user data.
-    
-10. Open the `route.ts` file in your code editor, paste the following code, and save the file.
-    
-    When this code runs, it retrieves the authenticated user, checks if the user already exists in the Supabase database, and inserts a new record if not.
-    
-    ```tsx
-    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
-    import { NextResponse } from "next/server";
-    import { createClient } from "@/utils/supabase/server";
-    
-    export async function GET() {
-      const supabase = await createClient();
-      const { getUser } = getKindeServerSession();
-      const user = await getUser();
-    
-      if (!user || user == null || !user.id)
-        throw new Error("something went wrong with authentication" + user);
-    
-      let { data: dbUser } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("kinde_id", user.id);
-    
-      // write the user to the database if it doesn't exist
-      if (dbUser && dbUser.length > 0) {
-        dbUser = dbUser[0];
-      } else {
-        const { data, error } = await supabase
-          .from("profiles")
-          .insert({
-            kinde_id: user.id,
-          })
-          .select("*");
-        if (error) {
-          console.error("Error inserting user into database:", error);
-        }
-      }
-    
-      return NextResponse.redirect("http://localhost:3000");
-    }
-    ```
-    
-11. Update your `.env.local` file to set the `KINDE_POST_LOGIN_REDIRECT_URL` to point to the new success route:
-    
-    ```
-    KINDE_POST_LOGIN_REDIRECT_URL=http://localhost:3000/api/auth/success
-    ```
-    
-12. Start your development server by running the following:
-    
-    <PackageManagers type='run' pkg='dev' />
-    
-13. Open your browser and visit [http://localhost:3000](http://localhost:3000/). 
-14. Sign up or sign in with a new user account.
-15. Go to your Supabase dashboard, navigate to **Table Editor > profiles**, and confirm that the new user information has been stored.
-    
-    ![Supabase table editor](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f39c0a6f-6750-4849-441c-b426af064600/public)
-    
-
-## Step 2: Configure your Kinde workflow
-
-You can use any JavaScript or TypeScript project for your workflow code. In this guide, we're using the same Next.js project for both the main project and the workflow code.
-
-1. Start by installing the Kinde infrastructure package with this command.
-    
-    <PackageManagers pkg='@kinde/infrastructure' />
-    
-2. Create a configuration file for your workflow by running this command.
-    
-    ```bash
-    touch kinde.json
-    ```
-    
-3. Open the `kinde.json` file and paste the following code. This configuration defines the version of your workflow and the root directory where your custom code will live. 
-    
-    If you haven’t set up a GitHub repository yet, [create one here](https://github.com/new) and follow the instructions GitHub provides to manage local code.
-    
-    ```json
-    {
-      "version": "1.0.0",
-      "rootDir": "kindeSrc"
-    }
-    ```
-    
-4. Create the folder structure Kinde requires for workflows.
-    
-    ```bash
-    mkdir -p kindeSrc/environment/workflows
-    ```
-    
-5. Inside that folder, create a new file for your workflow. Kinde looks for workflow files using the `[name]Workflow.ts` naming pattern, for example:
-    
-    ```json
-    touch kindeSrc/environment/workflows/supabaseWorkflow.ts
-    ```
-    
-6. Open the new file and paste in the following code. 
-    
-    ```tsx
+    ```typescript
+    // Workflow.ts
     import {
       onUserTokenGeneratedEvent,
-      accessTokenCustomClaims,
       WorkflowSettings,
       WorkflowTrigger,
-      fetch,
-      getEnvironmentVariable,
+      accessTokenCustomClaims,
     } from "@kinde/infrastructure";
-    
+
+    // The setting for this workflow
     export const workflowSettings: WorkflowSettings = {
-      id: "addAccessTokenClaim",
-      name: "Add access token claim",
+      id: "addCustomClaimWorkflow",
+      name: "Add Custom Claim Workflow",
       trigger: WorkflowTrigger.UserTokenGeneration,
+      failurePolicy: {
+        action: "stop",
+      },
       bindings: {
-        "kinde.accessToken": {},
-        "kinde.localization": {},
-        "kinde.fetch": {},
-        "kinde.env": {},
-        url: {},
+        "kinde.accessToken": {}, // required to modify access token claims
+        url: {}, // required for url params
       },
     };
-    
-    export default async function SupabaseWorkflow(
-      event: onUserTokenGeneratedEvent
-    ) {
-      const SUPABASE_ANON_KEY = getEnvironmentVariable("SUPABASE_ANON_KEY")?.value;
-      const SUPABASE_URL = getEnvironmentVariable("SUPABASE_URL")?.value;
-    
+
+    // The workflow code to be executed when the event is triggered
+    export default async function Workflow(event: onUserTokenGeneratedEvent) {
       const accessToken = accessTokenCustomClaims<{
-        lifetime_subscriber: boolean;
-      }>();
-    
-      const response = await fetch(
-        `${SUPABASE_URL}/rest/v1/profiles?kinde_id=eq.${event.context.user.id}`,
-        {
-          method: "GET",
-          headers: {
-            apiKey: SUPABASE_ANON_KEY,
-            Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
-            "Content-Type": "application/json",
-          },
-        }
-      );
-    
-      if (response.data.length > 0) {
-        const profile = response.data[0];
-        accessToken.lifetime_subscriber = profile?.lifetime_subscriber;
-      }
-    }
-    
-    ```
-    
-    This workflow runs when a new user token is generated. It fetches profile data from Supabase and attaches a custom property (`lifetime_subscriber`) to the access token if it's available:
-    
-7. To verify the token and view your new custom claim, update your `page.tsx` file inside `src/app/` with the following code.
-    
-    ```tsx
-    import Link from "next/link";
-    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
-    
-    export default async function Home() {
-      const { getAccessToken } = getKindeServerSession();
-      const token = await getAccessToken();
-    
-      return (
-        <div className="container">
-          <pre className="p-4 rounded-lg bg-slate-900 text-lime-200">
-            <code>{JSON.stringify(token, null, 2)}</code>
-          </pre>
-    
-          <div className="card hero">
-            <p className="text-display-1 hero-title">
-              Let’s start authenticating <br /> with KindeAuth
-            </p>
-            <p className="text-body-1 hero-tagline">Configure your app</p>
-    
-            <Link
-              href="https://kinde.com/docs/sdks/nextjs-sdk"
-              target="_blank"
-              rel="noreferrer"
-              className="btn btn-light btn-big"
-            >
-              Go to docs
-            </Link>
-          </div>
-        </div>
-      );
+        companyName: string
+      }>()
+
+      accessToken.companyName = "Acme Inc."
     }
     ```
-    
-8. Once you're happy with the setup, push your changes to GitHub.
-    
-    ```bash
-    git add .
-    git commit -m "Add Kinde workflow code"
-    git push origin main
+
+The above code adds the `companyName` claim to the access token, with the value `Acme Inc.`.
+
+### Remove claims
+
+1. Add the following code to your `Workflow.ts` file:
+
+    ```typescript
+    // Workflow.ts
+    import {
+      onUserTokenGeneratedEvent,
+      WorkflowSettings,
+      WorkflowTrigger,
+      accessTokenCustomClaims,
+    } from "@kinde/infrastructure";
+
+    // The setting for this workflow
+    export const workflowSettings: WorkflowSettings = {
+      id: "removeClaimWorkflow",
+      name: "Remove Claim Workflow",
+      trigger: WorkflowTrigger.UserTokenGeneration,
+      failurePolicy: {
+        action: "stop",
+      },
+      bindings: {
+        "kinde.accessToken": {}, // required to modify access token claims
+        url: {}, // required for url params
+      },
+    };
+
+    // The workflow code to be executed when the event is triggered
+    export default async function Workflow(event: onUserTokenGeneratedEvent) {
+      const accessToken = accessTokenCustomClaims<{
+        permissions: string[]
+        feature_flags: Record<string, unknown>
+      }>()
+
+      accessToken.permissions = []
+      accessToken.feature_flags = {}
+    }
     ```
-    
 
-## Step 3: Deploy and test the workflow
+The above code removes the `permissions` and `feature_flags` claims from the access token, replacing them with an empty array and object respectively. This is useful for reducing the size of access tokens that are used in API calls.
 
-1. Sign into your [Kinde dashboard](https://kinde.com/) and select **Workflows.**
-2. If you already have your workflow repo connected, go straight to step 4.
-3. Select **Connect repo > Connect GitHub** and follow the onboarding flow to authorize Kinde to access your GitHub account.
-    
-    ![Connect repo in Kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a093135d-77c3-42ec-a0d8-1135c5e65f00/public)
-    
-4. From the drop-down, select your GitHub repository that contains the Kinde workflow code, choose the `main` branch, and click **Next**.
-    
-    If you already have a repo connected and want to change it, go to **Settings > Git repo** and select **Change repo.**
-    
-    ![Change repo](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f374d46c-7d73-48fe-28b5-2f323c658500/public)
-    
-5. Select **Sync code** to pull your latest workflow code from GitHub into your Kinde project. 
-You’ll now see your workflow listed inside the dashboard. 
+Take a look at the available access token claims in the [about access tokens](/build/tokens/about-access-tokens/) doc. You may not be able to remove every default claims.
 
-6. Go to **Settings > Env variables** and add the following variables you got from your **Supabase Project > Data API:**
-    - `SUPABASE_ANON_KEY`
-    - `SUPABASE_URL`
-        
-        These environment variables are securely stored in Kinde and used by your workflow code.
-        
-        ![Add Environment variables](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/e6166743-865f-46da-e0c2-30f52268ea00/public)
-        
-        ![Env variables list](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/c1d16847-1ed5-425f-d05d-b7ed27512300/public)
-        
-7. Run your local development server with the following command.
-    
-    <PackageManagers type='run' pkg='dev' />
-    
-8. Visit `http://localhost:3000` in your browser. Log in or sign up to view the access token.
-    
-    ![View token in browser](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/67a8a3c0-0abb-4f63-6300-81c8846ad300/public)
-    
+## Customize the ID token
 
-The access token will now include your custom `lifetime_subscriber` property if the user exists in your Supabase `profiles` table. 
+1. Add the following code to your `Workflow.ts` file:
 
-This token can now be used throughout your application to conditionally show or hide content based on your user's subscription status.
+    ```typescript
+    // Workflow.ts
+    import {
+      onUserTokenGeneratedEvent,
+      WorkflowSettings,
+      WorkflowTrigger,
+      idTokenCustomClaims
+      
+    } from "@kinde/infrastructure";
 
-## Troubleshooting tips and best practices
+    // The setting for this workflow
+    export const workflowSettings: WorkflowSettings = {
+      id: "customIdTokenClaimsWorkflow",
+      name: "Custom ID Token Claims Workflow",
+      trigger: WorkflowTrigger.UserTokenGeneration,
+      failurePolicy: {
+        action: "stop",
+      },
+      bindings: {
+        "kinde.idToken": {}, // required to modify id token claims
+        url: {}, // required for url params
+      },
+    };
 
-- After making changes to your workflow code, push the updates to GitHub by running the following commands in your terminal:
-    
-    ```bash
-    git add .
-    git commit -m "Your commit message"
-    git push origin main
+    // The workflow code to be executed when the event is triggered
+    export default async function Workflow(event: onUserTokenGeneratedEvent) {
+      const idToken = idTokenCustomClaims<{
+        house: string
+        name: string
+      }>()
+
+      idToken.house = "Gryffindor"
+      idToken.name = "Harry Potter"
+    }
     ```
-    
-- Go to **Workflows** and click **Sync code** to pull in the latest changes from your GitHub repo.
-    
-- To view logs or debug your code, click the **three dots** next to your workflow, then select **Manage workflow**, then select **Runtime logs**. Use `console.log()` in your workflow file to output logs. This is helpful for debugging and checking your variables or API responses.
-    
-    ![Manage workflow menu options](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/250a8e6d-c0ad-462e-0fe7-fb36ca07bd00/public)
-    
-    ![Runtime details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/87519ce5-e174-418d-da87-a0f1d84f5b00/public)
-    
+The above code adds a custom `house` and modifies the default `name` claim to the ID token, with custom values.
 
-### You did it!
+## Glossary
 
-You’ve successfully implemented a Kinde user token generation workflow. Now you’ve got superpowers like custom claims, dynamic logic, and all the flexibility to personalize your app experience.
+### Required bindings 
+
+The following bindings are required to modify the tokens:
+
+- `kinde.accessToken`: required to modify access token claims
+- `kinde.idToken`: required to modify ID token claims
+- `kinde.m2mToken`: required to modify M2M token claims
+
+### Prohibited claims
+
+You can't modify the following claims from the tokens:
+
+**Common prohibited claims:**
+
+- `azp`
+- `exp`
+- `iat`
+- `iss`
+- `nbf`
+- `sid`
+- `sub`
+- `act`
+- `aud`
+
+**Access token prohibited claims:**
+
+- `jti`
+- `scp`
+
+**ID token prohibited claims:**
+
+- `auth_time`
+- `jti`
+- `updated_at`
+- `rat`
+
+**M2M token prohibited claims:**
+
+- `gty`
+- `jti`
+- `scp`

--- a/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/customize-token-with-workflow.mdx
@@ -8,12 +8,17 @@ tableOfContents:
 relatedArticles:
   - 62fafade-5d33-4f85-9fd2-712c533db3d0
   - f499ebb0-d7f5-4244-bf92-6bf0f6082b62
-description: Learn how to customize tokens using workflows, to help distinguish customer types.
+description: Customize access and ID tokens in Kinde using workflows
 topics:
   - "workflows"
   - "example-workflows"
   - "authentication"
+  - "tokens"
+  - "bindings"
 sdk: "kinde infrastructure"
+app_context:
+  - m: ["Workflows", "Git repo"]
+  - s: "User token generation"
 languages:
   - "TypeScript"
   - "JavaScript"
@@ -21,24 +26,25 @@ audience:
   - "developers"
 complexity: "intermediate"
 keywords:
-  - "pre-registration"
-  - "user registration"
-  - "IP checks"
-  - "disposable emails"
-  - "spam prevention"
-  - "authentication triggers"
-updated: "2026-04-14"
+  - "custom claims"
+  - "access token"
+  - "ID token"
+  - "user token generation"
+  - "JWT claims"
+  - "token customization"
+  - "workflow bindings"
+updated: "2026-04-17"
 featured: false
 deprecated: false
-ai_summary: "Learn how to customize tokens using workflows, to help distinguish customer types."
+ai_summary: "This tutorial teaches developers how to customize Kinde access and ID tokens using workflows that run when a user token is generated. It walks through TypeScript examples in Workflow.ts using the User token generation trigger, workflowSettings (including failurePolicy behavior), required bindings, and helper APIs from @kinde/infrastructure. For access tokens, you bind kinde.accessToken and url, then use accessTokenCustomClaims with typed shapes to inject custom string claims or replace bulky built-in claims such as permissions and feature_flags with empty values to reduce token size for APIs. For ID tokens, you bind kinde.idToken and url, then use idTokenCustomClaims to add new claims or change existing ones such as name. The doc clarifies you may not be able to remove or modify every default claim. A glossary explains that kinde.m2mToken is needed for M2M token edits and lists prohibited claims workflows cannot touch, split into common, access-only, ID-only, and M2M-only restrictions covering standard JWT metadata fields. Prerequisites are a Kinde account and the connected workflow repo from the quick start. The page points to about-access-tokens and about-id-tokens for complete claim catalogs."
 ---
 
 Use workflows to add or remove claims from Kinde's access or ID tokens.
 
-### What you need 
+### What you need
 
-- A [Kinde](https://app.kinde.com/register) account (sign up for free)
-- A workflow git repository connected to your Kinde account (Use the [workflow base template](/workflows/getting-started/quick-start-guide/))
+- A [Kinde](https://app.kinde.com/register) account (Sign up for free)
+- A workflow Git repository connected to your Kinde account (use the [workflow base template](/workflows/getting-started/quick-start-guide/))
 
 ## Customize the access token
 
@@ -65,14 +71,14 @@ Use workflows to add or remove claims from Kinde's access or ID tokens.
       },
       bindings: {
         "kinde.accessToken": {}, // required to modify access token claims
-        url: {}, // required for url params
+        url: {}, // required for URL parameters
       },
     };
 
     // The workflow code to be executed when the event is triggered
     export default async function Workflow(event: onUserTokenGeneratedEvent) {
       const accessToken = accessTokenCustomClaims<{
-        companyName: string
+        companyName: string,
       }>()
 
       accessToken.companyName = "Acme Inc."
@@ -104,15 +110,15 @@ The above code adds the `companyName` claim to the access token, with the value 
       },
       bindings: {
         "kinde.accessToken": {}, // required to modify access token claims
-        url: {}, // required for url params
+        url: {}, // required for URL parameters
       },
     };
 
     // The workflow code to be executed when the event is triggered
     export default async function Workflow(event: onUserTokenGeneratedEvent) {
       const accessToken = accessTokenCustomClaims<{
-        permissions: string[]
-        feature_flags: Record<string, unknown>
+        permissions: string[],
+        feature_flags: Record<string, unknown>,
       }>()
 
       accessToken.permissions = []
@@ -122,7 +128,7 @@ The above code adds the `companyName` claim to the access token, with the value 
 
 The above code removes the `permissions` and `feature_flags` claims from the access token, replacing them with an empty array and object respectively. This is useful for reducing the size of access tokens that are used in API calls.
 
-Take a look at the available access token claims in the [about access tokens](/build/tokens/about-access-tokens/) doc. You may not be able to remove every default claims.
+Take a look at the available access token claims in the [about access tokens](/build/tokens/about-access-tokens/) doc. You may not be able to remove every default claim. See the [prohibited claims](#prohibited-claims) section for more information.
 
 ## Customize the ID token
 
@@ -134,8 +140,7 @@ Take a look at the available access token claims in the [about access tokens](/b
       onUserTokenGeneratedEvent,
       WorkflowSettings,
       WorkflowTrigger,
-      idTokenCustomClaims
-      
+      idTokenCustomClaims,
     } from "@kinde/infrastructure";
 
     // The setting for this workflow
@@ -147,37 +152,42 @@ Take a look at the available access token claims in the [about access tokens](/b
         action: "stop",
       },
       bindings: {
-        "kinde.idToken": {}, // required to modify id token claims
-        url: {}, // required for url params
+        "kinde.idToken": {}, // required to modify ID token claims
+        url: {}, // required for URL parameters
       },
     };
 
     // The workflow code to be executed when the event is triggered
     export default async function Workflow(event: onUserTokenGeneratedEvent) {
       const idToken = idTokenCustomClaims<{
-        house: string
-        name: string
+        house: string,
+        name: string,
       }>()
 
       idToken.house = "Gryffindor"
       idToken.name = "Harry Potter"
     }
     ```
-The above code adds a custom `house` and modifies the default `name` claim to the ID token, with custom values.
+
+The above code adds a custom `house` claim to the ID token and updates the `name` claim as shown.
+
+Take a look at the available ID token claims in the [about ID tokens](/build/tokens/about-id-tokens/) doc. You may not be able to modify every default claim. See the [prohibited claims](#prohibited-claims) section for more information.
 
 ## Glossary
 
-### Required bindings 
+### Required bindings
 
-The following bindings are required to modify the tokens:
+Declare the token binding that matches the JWT you are modifying:
 
 - `kinde.accessToken`: required to modify access token claims
 - `kinde.idToken`: required to modify ID token claims
 - `kinde.m2mToken`: required to modify M2M token claims
 
+The workflow examples on this page also declare the native `url` binding (for URL parameters).
+
 ### Prohibited claims
 
-You can't modify the following claims from the tokens:
+You can't modify the following token claims:
 
 **Common prohibited claims:**
 

--- a/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
@@ -12,13 +12,16 @@ relatedArticles:
   - b5a147ac-c189-40b5-8300-b518dd353f92
   - a5c850c0-0251-44ea-adef-73606694ace3
 app_context:
-  - m: ["Workflows", "Git repo"]
-  - s: "User token generation"
+  - m: workflows
+  - s: workflows
 topics:
   - "workflows"
-  - "example-workflows"
-  - "authentication"
-  - "tokens"
+  - "workflow-tutorials"
+  - "third-party-integrations"
+  - "fetch-binding"
+  - "environment-variables"
+  - "user-token-generation"
+  - "custom-claims"
 sdk: "kinde infrastructure"
 languages:
   - "TypeScript"
@@ -27,16 +30,21 @@ audience:
   - "developers"
 complexity: "intermediate"
 keywords:
-  - "custom claims"
-  - "access token"
-  - "ID token"
-  - "JWT claims"
-  - "user token generation"
-  - "token customization"
+  - "third party API"
+  - "external API"
+  - "kinde.fetch"
+  - "HTTP GET"
+  - "workflow bindings"
+  - "access token custom claims"
+  - "UserTokenGeneration"
+  - "getEnvironmentVariable"
+  - "kinde.env"
+  - "API key"
+  - "Workflow.ts"
 updated: 2026-04-21
 featured: false
 deprecated: false
-ai_summary: "Use workflows to add or remove custom claims from Kinde access or ID tokens when tokens are created."
+ai_summary: "Learn how to call a third-party HTTP API from a Kinde workflow during user token generation and map the response into access token custom claims. The tutorial uses `@kinde/infrastructure` (`onUserTokenGeneratedEvent`, `accessTokenCustomClaims`, `fetch`) with bindings `kinde.fetch`, `url`, and `kinde.accessToken`, reads the signed-in user from `event.context.user.id`, handles failed responses, and parses JSON into typed claims. It also shows storing secrets in Kinde env vars (**Settings > Data management > Env variables**), adding the `kinde.env` binding, and using `getEnvironmentVariable` (for example `API_KEY`) in headers such as `Authorization: Bearer`. Pointers link to the fetch binding and environment variable docs."
 ---
 
 You can fetch third party data from your workflows and use within them.
@@ -81,24 +89,19 @@ You can fetch third party data from your workflows and use within them.
       }>();
       
       const loggedInUserId = event.context.user.id;
-      const response = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
+      const { data: userData } = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
         method: "GET",
+        responseFormat: "json",
         headers: {
           "Content-Type": "application/json",
         },
       });
       
-      if (!response.ok) {
-        console.error(`Failed to fetch user data: ${response.statusText}`);
-        return;
-      } 
-
-      const data = await response.json();
-      accessToken.lifetime_subscriber = data.lifetime_subscriber || false;
+      accessToken.lifetime_subscriber = userData.lifetime_subscriber || false;
     }
     ```
 
-    The code fetches the user data from the third party data source and stores it in the access token.
+    The code fetches the user data from the third party data source and stores it in the access token. **GET** is appropriate for a read-only lookup by user ID, matching the [kinde.fetch](/workflows/bindings/fetch-binding/) examples. If you need to send sensitive data in the request body, use **POST** and consider [`kinde.secureFetch`](/workflows/bindings/secure-fetch-binding/) instead.
 
 **Required bindings:**
 
@@ -150,21 +153,16 @@ Read more about the [kinde.fetch binding](/workflows/bindings/fetch-binding/).
       }
       
       const loggedInUserId = event.context.user.id;
-      const response = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
+      const { data: userData } = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
         method: "GET",
+        responseFormat: "json",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
       });
       
-      if (!response.ok) {
-        console.error(`Failed to fetch user data: ${response.statusText}`);
-        return;
-      } 
-
-      const data = await response.json();
-      accessToken.lifetime_subscriber = data.lifetime_subscriber || false;
+      accessToken.lifetime_subscriber = userData.lifetime_subscriber || false;
     }
     ```
 

--- a/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
@@ -170,4 +170,4 @@ Read more about the [kinde.fetch binding](/workflows/bindings/fetch-binding/).
 
 - `kinde.env`: to access the environment variables
 
-Read more about the [kinde.env binding](/workflows/configuration/environment-variables-and-secrets/).
+Read more about the [environment variables and secrets](/workflows/configuration/environment-variables-and-secrets/).

--- a/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
@@ -1,9 +1,9 @@
 ---
 page_id: 4cb565d2-5c3b-47a1-8fc0-2f39879bcaf7
 title: Tutorial - Fetch third party data in workflows
-description: Use workflows to fetch third party data and add it to Kinde access or ID tokens during user token generation.
+description: Fetch third party data from your Kinde workflows
 sidebar:
-  order: 7
+  order: 2
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:
@@ -33,219 +33,88 @@ keywords:
   - "JWT claims"
   - "user token generation"
   - "token customization"
-updated: "2026-04-17"
+updated: 2026-04-21
 featured: false
 deprecated: false
 ai_summary: "Use workflows to add or remove custom claims from Kinde access or ID tokens when tokens are created."
 ---
 
-The Kinde user token generation workflow lets you customize the access token. In this article, we’ll walk through a scenario where we store a custom user value in the token.
+You can fetch third party data from your workflows and use within them.
 
-## Background
+### What you need?
 
-Our fictional SaaS product offers a lifetime membership option. Users who purchase the lifetime membership get full access to our product. In this article, we’ll build a project that stores extra data in a third-party Supabase database. 
+- A [Kinde](https://app.kinde.com/register) account (Sign up for free)
+- A workflow Git repository connected to your Kinde account (use the [workflow base template](/workflows/getting-started/quick-start-guide/))
+- A third party data source such as a database or API
 
-We'll check whether the user is a `lifetime_subscriber` and pass that data into the Kinde access token. This way, the information stays available for the lifetime of the token, and your app won’t need to make an API request every time it’s required.
+## Fetch third party data from the workflow
 
-## What you need?
+### Basic example
 
-- A [Kinde](https://kinde.com/) account (sign up for free)
-- A [Supabase](http://supabase.com/) account (sign up for free)
-- A [GitHub](https://github.com/) account (sign up for free)
-- A running Kinde application or a starter kit such as the [Next.js starter kit](https://github.com/kinde-starter-kits/kinde-nextjs-app-router-starter-kit)
+1. Add the following code to your `Workflow.ts` file:
 
-## Step 1: Set up a Supabase database
+    ```typescript
+    import {
+      onUserTokenGeneratedEvent,
+      accessTokenCustomClaims,
+      WorkflowSettings,
+      WorkflowTrigger,
+      fetch,
+    } from "@kinde/infrastructure";
 
-1. Sign in to your [Supabase dashboard](https://supabase.com/).
-2. Select **New Project.**
-    1. Enter a project name.
-    2. Set a secure password for your database.
-    3. Select a database region that best suits your application. 
-    4. Select **Create new project**.
-        
-        ![Set up Supabase project](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eaa63e5e-ecc8-41f3-8527-731bcc49db00/public)
-        
-3. In the project **Settings**, go to **Configuration** > **Data API.** Copy the following:
-    1. **Project URL**.
-    2. **Project API Keys** `anon`  `public`.
-    
-    ![API Keys settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/3e2cbc80-47e6-4f07-e541-6df0124a8d00/public)
-    
-4. Navigate to a **SQL Editor** and paste the following SQL code into the command window and select **Run**:
-    
-    ```sql
-    -- Create the table
-    CREATE TABLE profiles (
-    	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    	kinde_id TEXT NOT NULL,
-    	lifetime_subscriber BOOLEAN DEFAULT FALSE
-    );
-    ```
-    
-    This command creates a `profiles` table with the following columns:
-    
-    - **`kinde_id`**: with a type of **text**.
-    - **`lifetime_subscriber`**: with a type of **boolean**. We use boolean because the lifetime subscription is either true or false.
-5. Install the Supabase dependency by running the following command in your project terminal.
-    
-    <PackageManagers pkg='@supabase/ssr' />
-    
-6. Create the necessary Supabase files by running.
-    
-    ```bash
-    mkdir -p src/utils/supabase
-    touch src/utils/supabase/server.ts
-    ```
-    
-7. Open the newly created `server.ts` file and paste the following code. This sets up Supabase integration for your Next.js project.
-    
-    ```tsx
-    import { createServerClient } from "@supabase/ssr";
-    import { cookies } from "next/headers";
-    
-    export async function createClient() {
-      const cookieStore = await cookies();
-    
-      return createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        {
-          cookies: {
-            getAll() {
-              return cookieStore.getAll();
-            },
-            setAll(cookiesToSet) {
-              try {
-                cookiesToSet.forEach(({ name, value, options }) =>
-                  cookieStore.set(name, value, options)
-                );
-              } catch {
-                // The `setAll` method was called from a Server Component.
-                // This can be ignored if you have middleware refreshing
-                // user sessions.
-              }
-            },
-          },
-        }
-      );
-    }
-    
-    ```
-    
-8. Open your `.env.local` file and add the Supabase project URL and public anon key. You can find these in your Supabase dashboard under **Project Settings > Data API**.
-    
-    ```
-    NEXT_PUBLIC_SUPABASE_URL=https://<supabase_project_id>.supabase.co
-    NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase_anon_public_key>
-    ```
-    
-9. Create a new directory called `success` inside `src/app/api/auth/`, and add a `route.ts` file by running the following code.
-    
-    ```bash
-    mkdir src/app/api/auth/success
-    touch src/app/api/auth/success/route.ts
-    ```
-    
-    This file will act as a GET endpoint that handles authenticated user data.
-    
-10. Open the `route.ts` file in your code editor, paste the following code, and save the file.
-    
-    When this code runs, it retrieves the authenticated user, checks if the user already exists in the Supabase database, and inserts a new record if not.
-    
-    ```tsx
-    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
-    import { NextResponse } from "next/server";
-    import { createClient } from "@/utils/supabase/server";
-    
-    export async function GET() {
-      const supabase = await createClient();
-      const { getUser } = getKindeServerSession();
-      const user = await getUser();
-    
-      if (!user || user == null || !user.id)
-        throw new Error("something went wrong with authentication" + user);
-    
-      let { data: dbUser } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("kinde_id", user.id);
-    
-      // write the user to the database if it doesn't exist
-      if (dbUser && dbUser.length > 0) {
-        dbUser = dbUser[0];
-      } else {
-        const { data, error } = await supabase
-          .from("profiles")
-          .insert({
-            kinde_id: user.id,
-          })
-          .select("*");
-        if (error) {
-          console.error("Error inserting user into database:", error);
-        }
-      }
-    
-      return NextResponse.redirect("http://localhost:3000");
+    export const workflowSettings: WorkflowSettings = {
+      id: "addThirdPartyDataToAccessToken",
+      name: "Add third party data to access token",
+      trigger: WorkflowTrigger.UserTokenGeneration,
+      bindings: {
+        "kinde.accessToken": {},
+        "kinde.fetch": {},
+        url: {},
+      },
+    };
+
+    export default async function FetchThirdPartyDataWorkflow(
+      event: onUserTokenGeneratedEvent
+    ) {
+      const accessToken = accessTokenCustomClaims<{
+        lifetime_subscriber: boolean;
+      }>();
+      
+      const loggedInUserId = event.context.user.id;
+      const response = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      
+      if (!response.ok) {
+        console.error(`Failed to fetch user data: ${response.statusText}`);
+        return;
+      } 
+
+      const data = await response.json();
+      accessToken.lifetime_subscriber = data.lifetime_subscriber || false;
     }
     ```
-    
-11. Update your `.env.local` file to set the `KINDE_POST_LOGIN_REDIRECT_URL` to point to the new success route:
-    
-    ```
-    KINDE_POST_LOGIN_REDIRECT_URL=http://localhost:3000/api/auth/success
-    ```
-    
-12. Start your development server by running the following:
-    
-    <PackageManagers type='run' pkg='dev' />
-    
-13. Open your browser and visit [http://localhost:3000](http://localhost:3000/). 
-14. Sign up or sign in with a new user account.
-15. Go to your Supabase dashboard, navigate to **Table Editor > profiles**, and confirm that the new user information has been stored.
-    
-    ![Supabase table editor](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f39c0a6f-6750-4849-441c-b426af064600/public)
-    
 
-## Step 2: Configure your Kinde workflow
+    The code fetches the user data from the third party data source and stores it in the access token.
 
-You can use any JavaScript or TypeScript project for your workflow code. In this guide, we're using the same Next.js project for both the main project and the workflow code.
+**Required bindings:**
 
-1. Start by installing the Kinde infrastructure package with this command.
-    
-    <PackageManagers pkg='@kinde/infrastructure' />
-    
-2. Create a configuration file for your workflow by running this command.
-    
-    ```bash
-    touch kinde.json
-    ```
-    
-3. Open the `kinde.json` file and paste the following code. This configuration defines the version of your workflow and the root directory where your custom code will live. 
-    
-    If you haven’t set up a GitHub repository yet, [create one here](https://github.com/new) and follow the instructions GitHub provides to manage local code.
-    
-    ```json
-    {
-      "version": "1.0.0",
-      "rootDir": "kindeSrc"
-    }
-    ```
-    
-4. Create the folder structure Kinde requires for workflows.
-    
-    ```bash
-    mkdir -p kindeSrc/environment/workflows
-    ```
-    
-5. Inside that folder, create a new file for your workflow. Kinde looks for workflow files using the `[name]Workflow.ts` naming pattern, for example:
-    
-    ```json
-    touch kindeSrc/environment/workflows/supabaseWorkflow.ts
-    ```
-    
-6. Open the new file and paste in the following code. 
-    
-    ```tsx
+    - `kinde.fetch`: to fetch the third party data
+    - `url`: required for Kinde to use fetch under the hood
+    - `kinde.accessToken`: to update the the access token
+
+Read more about the [kinde.fetch binding](/workflows/bindings/fetch-binding/).
+
+### Add environment variables
+
+1. Go to **Kinde > Settings > Data management > Env variables** and add any environment variables you need to use in your workflow. (e.g., `API_URL`, `API_KEY`, etc.)
+
+2. Add the following sample code to your `Workflow.ts` file:
+
+    ```typescript
     import {
       onUserTokenGeneratedEvent,
       accessTokenCustomClaims,
@@ -254,156 +123,53 @@ You can use any JavaScript or TypeScript project for your workflow code. In this
       fetch,
       getEnvironmentVariable,
     } from "@kinde/infrastructure";
-    
+
     export const workflowSettings: WorkflowSettings = {
-      id: "addAccessTokenClaim",
-      name: "Add access token claim",
+      id: "addThirdPartyDataUsingEnvs",
+      name: "Add third party data to access token using environment variables",
       trigger: WorkflowTrigger.UserTokenGeneration,
       bindings: {
         "kinde.accessToken": {},
-        "kinde.localization": {},
         "kinde.fetch": {},
         "kinde.env": {},
         url: {},
       },
     };
-    
-    export default async function SupabaseWorkflow(
+
+    export default async function FetchThirdPartyDataWorkflow(
       event: onUserTokenGeneratedEvent
     ) {
-      const SUPABASE_ANON_KEY = getEnvironmentVariable("SUPABASE_ANON_KEY")?.value;
-      const SUPABASE_URL = getEnvironmentVariable("SUPABASE_URL")?.value;
-    
       const accessToken = accessTokenCustomClaims<{
         lifetime_subscriber: boolean;
       }>();
-    
-      const response = await fetch(
-        `${SUPABASE_URL}/rest/v1/profiles?kinde_id=eq.${event.context.user.id}`,
-        {
-          method: "GET",
-          headers: {
-            apiKey: SUPABASE_ANON_KEY,
-            Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
-            "Content-Type": "application/json",
-          },
-        }
-      );
-    
-      if (response.data.length > 0) {
-        const profile = response.data[0];
-        accessToken.lifetime_subscriber = profile?.lifetime_subscriber;
+
+      const apiKey = getEnvironmentVariable("API_KEY")?.value;
+      if (!apiKey) {
+        console.error("API_KEY environment variable is not set");
+        return;
       }
-    }
-    
-    ```
-    
-    This workflow runs when a new user token is generated. It fetches profile data from Supabase and attaches a custom property (`lifetime_subscriber`) to the access token if it's available:
-    
-7. To verify the token and view your new custom claim, update your `page.tsx` file inside `src/app/` with the following code.
-    
-    ```tsx
-    import Link from "next/link";
-    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
-    
-    export default async function Home() {
-      const { getAccessToken } = getKindeServerSession();
-      const token = await getAccessToken();
-    
-      return (
-        <div className="container">
-          <pre className="p-4 rounded-lg bg-slate-900 text-lime-200">
-            <code>{JSON.stringify(token, null, 2)}</code>
-          </pre>
-    
-          <div className="card hero">
-            <p className="text-display-1 hero-title">
-              Let’s start authenticating <br /> with KindeAuth
-            </p>
-            <p className="text-body-1 hero-tagline">Configure your app</p>
-    
-            <Link
-              href="https://kinde.com/docs/sdks/nextjs-sdk"
-              target="_blank"
-              rel="noreferrer"
-              className="btn btn-light btn-big"
-            >
-              Go to docs
-            </Link>
-          </div>
-        </div>
-      );
+      
+      const loggedInUserId = event.context.user.id;
+      const response = await fetch(`https://my-website.com/api/user/${loggedInUserId}`, {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+      });
+      
+      if (!response.ok) {
+        console.error(`Failed to fetch user data: ${response.statusText}`);
+        return;
+      } 
+
+      const data = await response.json();
+      accessToken.lifetime_subscriber = data.lifetime_subscriber || false;
     }
     ```
-    
-8. Once you're happy with the setup, push your changes to GitHub.
-    
-    ```bash
-    git add .
-    git commit -m "Add Kinde workflow code"
-    git push origin main
-    ```
-    
 
-## Step 3: Deploy and test the workflow
+**Required additional binding:**
 
-1. Sign into your [Kinde dashboard](https://kinde.com/) and select **Workflows.**
-2. If you already have your workflow repo connected, go straight to step 4.
-3. Select **Connect repo > Connect GitHub** and follow the onboarding flow to authorize Kinde to access your GitHub account.
-    
-    ![Connect repo in Kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a093135d-77c3-42ec-a0d8-1135c5e65f00/public)
-    
-4. From the drop-down, select your GitHub repository that contains the Kinde workflow code, choose the `main` branch, and click **Next**.
-    
-    If you already have a repo connected and want to change it, go to **Settings > Git repo** and select **Change repo.**
-    
-    ![Change repo](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f374d46c-7d73-48fe-28b5-2f323c658500/public)
-    
-5. Select **Sync code** to pull your latest workflow code from GitHub into your Kinde project. 
-You’ll now see your workflow listed inside the dashboard. 
+- `kinde.env`: to access the environment variables
 
-6. Go to **Settings > Env variables** and add the following variables you got from your **Supabase Project > Data API:**
-    - `SUPABASE_ANON_KEY`
-    - `SUPABASE_URL`
-        
-        These environment variables are securely stored in Kinde and used by your workflow code.
-        
-        ![Add Environment variables](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/e6166743-865f-46da-e0c2-30f52268ea00/public)
-        
-        ![Env variables list](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/c1d16847-1ed5-425f-d05d-b7ed27512300/public)
-        
-7. Run your local development server with the following command.
-    
-    <PackageManagers type='run' pkg='dev' />
-    
-8. Visit `http://localhost:3000` in your browser. Log in or sign up to view the access token.
-    
-    ![View token in browser](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/67a8a3c0-0abb-4f63-6300-81c8846ad300/public)
-    
-
-The access token will now include your custom `lifetime_subscriber` property if the user exists in your Supabase `profiles` table. 
-
-This token can now be used throughout your application to conditionally show or hide content based on your user's subscription status.
-
-## Troubleshooting tips and best practices
-
-- After making changes to your workflow code, push the updates to GitHub by running the following commands in your terminal:
-    
-    ```bash
-    git add .
-    git commit -m "Your commit message"
-    git push origin main
-    ```
-    
-- Go to **Workflows** and click **Sync code** to pull in the latest changes from your GitHub repo.
-    
-- To view logs or debug your code, click the **three dots** next to your workflow, then select **Manage workflow**, then select **Runtime logs**. Use `console.log()` in your workflow file to output logs. This is helpful for debugging and checking your variables or API responses.
-    
-    ![Manage workflow menu options](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/250a8e6d-c0ad-462e-0fe7-fb36ca07bd00/public)
-    
-    ![Runtime details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/87519ce5-e174-418d-da87-a0f1d84f5b00/public)
-    
-
-### You did it!
-
-You’ve successfully implemented a Kinde user token generation workflow. Now you’ve got superpowers like custom claims, dynamic logic, and all the flexibility to personalize your app experience.
+Read more about the [kinde.env binding](/workflows/configuration/environment-variables-and-secrets/).

--- a/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
+++ b/src/content/docs/workflows/workflow-tutorials/fetch-third-party-data.mdx
@@ -1,0 +1,409 @@
+---
+page_id: 4cb565d2-5c3b-47a1-8fc0-2f39879bcaf7
+title: Tutorial - Fetch third party data in workflows
+description: Use workflows to fetch third party data and add it to Kinde access or ID tokens during user token generation.
+sidebar:
+  order: 7
+tableOfContents:
+  maxHeadingLevel: 3
+relatedArticles:
+  - f499ebb0-d7f5-4244-bf92-6bf0f6082b62
+  - 56db51a5-5542-4631-8bc6-36339a813a85
+  - b5a147ac-c189-40b5-8300-b518dd353f92
+  - a5c850c0-0251-44ea-adef-73606694ace3
+app_context:
+  - m: ["Workflows", "Git repo"]
+  - s: "User token generation"
+topics:
+  - "workflows"
+  - "example-workflows"
+  - "authentication"
+  - "tokens"
+sdk: "kinde infrastructure"
+languages:
+  - "TypeScript"
+  - "JavaScript"
+audience:
+  - "developers"
+complexity: "intermediate"
+keywords:
+  - "custom claims"
+  - "access token"
+  - "ID token"
+  - "JWT claims"
+  - "user token generation"
+  - "token customization"
+updated: "2026-04-17"
+featured: false
+deprecated: false
+ai_summary: "Use workflows to add or remove custom claims from Kinde access or ID tokens when tokens are created."
+---
+
+The Kinde user token generation workflow lets you customize the access token. In this article, we’ll walk through a scenario where we store a custom user value in the token.
+
+## Background
+
+Our fictional SaaS product offers a lifetime membership option. Users who purchase the lifetime membership get full access to our product. In this article, we’ll build a project that stores extra data in a third-party Supabase database. 
+
+We'll check whether the user is a `lifetime_subscriber` and pass that data into the Kinde access token. This way, the information stays available for the lifetime of the token, and your app won’t need to make an API request every time it’s required.
+
+## What you need?
+
+- A [Kinde](https://kinde.com/) account (sign up for free)
+- A [Supabase](http://supabase.com/) account (sign up for free)
+- A [GitHub](https://github.com/) account (sign up for free)
+- A running Kinde application or a starter kit such as the [Next.js starter kit](https://github.com/kinde-starter-kits/kinde-nextjs-app-router-starter-kit)
+
+## Step 1: Set up a Supabase database
+
+1. Sign in to your [Supabase dashboard](https://supabase.com/).
+2. Select **New Project.**
+    1. Enter a project name.
+    2. Set a secure password for your database.
+    3. Select a database region that best suits your application. 
+    4. Select **Create new project**.
+        
+        ![Set up Supabase project](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eaa63e5e-ecc8-41f3-8527-731bcc49db00/public)
+        
+3. In the project **Settings**, go to **Configuration** > **Data API.** Copy the following:
+    1. **Project URL**.
+    2. **Project API Keys** `anon`  `public`.
+    
+    ![API Keys settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/3e2cbc80-47e6-4f07-e541-6df0124a8d00/public)
+    
+4. Navigate to a **SQL Editor** and paste the following SQL code into the command window and select **Run**:
+    
+    ```sql
+    -- Create the table
+    CREATE TABLE profiles (
+    	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    	kinde_id TEXT NOT NULL,
+    	lifetime_subscriber BOOLEAN DEFAULT FALSE
+    );
+    ```
+    
+    This command creates a `profiles` table with the following columns:
+    
+    - **`kinde_id`**: with a type of **text**.
+    - **`lifetime_subscriber`**: with a type of **boolean**. We use boolean because the lifetime subscription is either true or false.
+5. Install the Supabase dependency by running the following command in your project terminal.
+    
+    <PackageManagers pkg='@supabase/ssr' />
+    
+6. Create the necessary Supabase files by running.
+    
+    ```bash
+    mkdir -p src/utils/supabase
+    touch src/utils/supabase/server.ts
+    ```
+    
+7. Open the newly created `server.ts` file and paste the following code. This sets up Supabase integration for your Next.js project.
+    
+    ```tsx
+    import { createServerClient } from "@supabase/ssr";
+    import { cookies } from "next/headers";
+    
+    export async function createClient() {
+      const cookieStore = await cookies();
+    
+      return createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+          cookies: {
+            getAll() {
+              return cookieStore.getAll();
+            },
+            setAll(cookiesToSet) {
+              try {
+                cookiesToSet.forEach(({ name, value, options }) =>
+                  cookieStore.set(name, value, options)
+                );
+              } catch {
+                // The `setAll` method was called from a Server Component.
+                // This can be ignored if you have middleware refreshing
+                // user sessions.
+              }
+            },
+          },
+        }
+      );
+    }
+    
+    ```
+    
+8. Open your `.env.local` file and add the Supabase project URL and public anon key. You can find these in your Supabase dashboard under **Project Settings > Data API**.
+    
+    ```
+    NEXT_PUBLIC_SUPABASE_URL=https://<supabase_project_id>.supabase.co
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase_anon_public_key>
+    ```
+    
+9. Create a new directory called `success` inside `src/app/api/auth/`, and add a `route.ts` file by running the following code.
+    
+    ```bash
+    mkdir src/app/api/auth/success
+    touch src/app/api/auth/success/route.ts
+    ```
+    
+    This file will act as a GET endpoint that handles authenticated user data.
+    
+10. Open the `route.ts` file in your code editor, paste the following code, and save the file.
+    
+    When this code runs, it retrieves the authenticated user, checks if the user already exists in the Supabase database, and inserts a new record if not.
+    
+    ```tsx
+    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
+    import { NextResponse } from "next/server";
+    import { createClient } from "@/utils/supabase/server";
+    
+    export async function GET() {
+      const supabase = await createClient();
+      const { getUser } = getKindeServerSession();
+      const user = await getUser();
+    
+      if (!user || user == null || !user.id)
+        throw new Error("something went wrong with authentication" + user);
+    
+      let { data: dbUser } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("kinde_id", user.id);
+    
+      // write the user to the database if it doesn't exist
+      if (dbUser && dbUser.length > 0) {
+        dbUser = dbUser[0];
+      } else {
+        const { data, error } = await supabase
+          .from("profiles")
+          .insert({
+            kinde_id: user.id,
+          })
+          .select("*");
+        if (error) {
+          console.error("Error inserting user into database:", error);
+        }
+      }
+    
+      return NextResponse.redirect("http://localhost:3000");
+    }
+    ```
+    
+11. Update your `.env.local` file to set the `KINDE_POST_LOGIN_REDIRECT_URL` to point to the new success route:
+    
+    ```
+    KINDE_POST_LOGIN_REDIRECT_URL=http://localhost:3000/api/auth/success
+    ```
+    
+12. Start your development server by running the following:
+    
+    <PackageManagers type='run' pkg='dev' />
+    
+13. Open your browser and visit [http://localhost:3000](http://localhost:3000/). 
+14. Sign up or sign in with a new user account.
+15. Go to your Supabase dashboard, navigate to **Table Editor > profiles**, and confirm that the new user information has been stored.
+    
+    ![Supabase table editor](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f39c0a6f-6750-4849-441c-b426af064600/public)
+    
+
+## Step 2: Configure your Kinde workflow
+
+You can use any JavaScript or TypeScript project for your workflow code. In this guide, we're using the same Next.js project for both the main project and the workflow code.
+
+1. Start by installing the Kinde infrastructure package with this command.
+    
+    <PackageManagers pkg='@kinde/infrastructure' />
+    
+2. Create a configuration file for your workflow by running this command.
+    
+    ```bash
+    touch kinde.json
+    ```
+    
+3. Open the `kinde.json` file and paste the following code. This configuration defines the version of your workflow and the root directory where your custom code will live. 
+    
+    If you haven’t set up a GitHub repository yet, [create one here](https://github.com/new) and follow the instructions GitHub provides to manage local code.
+    
+    ```json
+    {
+      "version": "1.0.0",
+      "rootDir": "kindeSrc"
+    }
+    ```
+    
+4. Create the folder structure Kinde requires for workflows.
+    
+    ```bash
+    mkdir -p kindeSrc/environment/workflows
+    ```
+    
+5. Inside that folder, create a new file for your workflow. Kinde looks for workflow files using the `[name]Workflow.ts` naming pattern, for example:
+    
+    ```json
+    touch kindeSrc/environment/workflows/supabaseWorkflow.ts
+    ```
+    
+6. Open the new file and paste in the following code. 
+    
+    ```tsx
+    import {
+      onUserTokenGeneratedEvent,
+      accessTokenCustomClaims,
+      WorkflowSettings,
+      WorkflowTrigger,
+      fetch,
+      getEnvironmentVariable,
+    } from "@kinde/infrastructure";
+    
+    export const workflowSettings: WorkflowSettings = {
+      id: "addAccessTokenClaim",
+      name: "Add access token claim",
+      trigger: WorkflowTrigger.UserTokenGeneration,
+      bindings: {
+        "kinde.accessToken": {},
+        "kinde.localization": {},
+        "kinde.fetch": {},
+        "kinde.env": {},
+        url: {},
+      },
+    };
+    
+    export default async function SupabaseWorkflow(
+      event: onUserTokenGeneratedEvent
+    ) {
+      const SUPABASE_ANON_KEY = getEnvironmentVariable("SUPABASE_ANON_KEY")?.value;
+      const SUPABASE_URL = getEnvironmentVariable("SUPABASE_URL")?.value;
+    
+      const accessToken = accessTokenCustomClaims<{
+        lifetime_subscriber: boolean;
+      }>();
+    
+      const response = await fetch(
+        `${SUPABASE_URL}/rest/v1/profiles?kinde_id=eq.${event.context.user.id}`,
+        {
+          method: "GET",
+          headers: {
+            apiKey: SUPABASE_ANON_KEY,
+            Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    
+      if (response.data.length > 0) {
+        const profile = response.data[0];
+        accessToken.lifetime_subscriber = profile?.lifetime_subscriber;
+      }
+    }
+    
+    ```
+    
+    This workflow runs when a new user token is generated. It fetches profile data from Supabase and attaches a custom property (`lifetime_subscriber`) to the access token if it's available:
+    
+7. To verify the token and view your new custom claim, update your `page.tsx` file inside `src/app/` with the following code.
+    
+    ```tsx
+    import Link from "next/link";
+    import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
+    
+    export default async function Home() {
+      const { getAccessToken } = getKindeServerSession();
+      const token = await getAccessToken();
+    
+      return (
+        <div className="container">
+          <pre className="p-4 rounded-lg bg-slate-900 text-lime-200">
+            <code>{JSON.stringify(token, null, 2)}</code>
+          </pre>
+    
+          <div className="card hero">
+            <p className="text-display-1 hero-title">
+              Let’s start authenticating <br /> with KindeAuth
+            </p>
+            <p className="text-body-1 hero-tagline">Configure your app</p>
+    
+            <Link
+              href="https://kinde.com/docs/sdks/nextjs-sdk"
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-light btn-big"
+            >
+              Go to docs
+            </Link>
+          </div>
+        </div>
+      );
+    }
+    ```
+    
+8. Once you're happy with the setup, push your changes to GitHub.
+    
+    ```bash
+    git add .
+    git commit -m "Add Kinde workflow code"
+    git push origin main
+    ```
+    
+
+## Step 3: Deploy and test the workflow
+
+1. Sign into your [Kinde dashboard](https://kinde.com/) and select **Workflows.**
+2. If you already have your workflow repo connected, go straight to step 4.
+3. Select **Connect repo > Connect GitHub** and follow the onboarding flow to authorize Kinde to access your GitHub account.
+    
+    ![Connect repo in Kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a093135d-77c3-42ec-a0d8-1135c5e65f00/public)
+    
+4. From the drop-down, select your GitHub repository that contains the Kinde workflow code, choose the `main` branch, and click **Next**.
+    
+    If you already have a repo connected and want to change it, go to **Settings > Git repo** and select **Change repo.**
+    
+    ![Change repo](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f374d46c-7d73-48fe-28b5-2f323c658500/public)
+    
+5. Select **Sync code** to pull your latest workflow code from GitHub into your Kinde project. 
+You’ll now see your workflow listed inside the dashboard. 
+
+6. Go to **Settings > Env variables** and add the following variables you got from your **Supabase Project > Data API:**
+    - `SUPABASE_ANON_KEY`
+    - `SUPABASE_URL`
+        
+        These environment variables are securely stored in Kinde and used by your workflow code.
+        
+        ![Add Environment variables](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/e6166743-865f-46da-e0c2-30f52268ea00/public)
+        
+        ![Env variables list](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/c1d16847-1ed5-425f-d05d-b7ed27512300/public)
+        
+7. Run your local development server with the following command.
+    
+    <PackageManagers type='run' pkg='dev' />
+    
+8. Visit `http://localhost:3000` in your browser. Log in or sign up to view the access token.
+    
+    ![View token in browser](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/67a8a3c0-0abb-4f63-6300-81c8846ad300/public)
+    
+
+The access token will now include your custom `lifetime_subscriber` property if the user exists in your Supabase `profiles` table. 
+
+This token can now be used throughout your application to conditionally show or hide content based on your user's subscription status.
+
+## Troubleshooting tips and best practices
+
+- After making changes to your workflow code, push the updates to GitHub by running the following commands in your terminal:
+    
+    ```bash
+    git add .
+    git commit -m "Your commit message"
+    git push origin main
+    ```
+    
+- Go to **Workflows** and click **Sync code** to pull in the latest changes from your GitHub repo.
+    
+- To view logs or debug your code, click the **three dots** next to your workflow, then select **Manage workflow**, then select **Runtime logs**. Use `console.log()` in your workflow file to output logs. This is helpful for debugging and checking your variables or API responses.
+    
+    ![Manage workflow menu options](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/250a8e6d-c0ad-462e-0fe7-fb36ca07bd00/public)
+    
+    ![Runtime details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/87519ce5-e174-418d-da87-a0f1d84f5b00/public)
+    
+
+### You did it!
+
+You’ve successfully implemented a Kinde user token generation workflow. Now you’ve got superpowers like custom claims, dynamic logic, and all the flexibility to personalize your app experience.


### PR DESCRIPTION
This timely update improves the following three pages:

**Quick start** (quick-start-guide.mdx) — Turns a vague “try workflows” path into a repeatable first-run: from the official template through Git repo connection to a verified execution with runtime log output you can match against. Renaming to “Workflow quickstart guide,” app_context (so it surfaces in-dashboard where people actually get stuck), TOC tuning, and a stronger ai_summary all support discoverability and self-serve success on day one.

**Customize tokens** (customize-token-with-workflow.mdx) — Replaces a one-off Supabase story with a production-oriented guide to the User token generation trigger: required bindings, workflowSettings / failure behavior, and typed accessTokenCustomClaims / idTokenCustomClaims patterns—including shrinking noisy claims (e.g. permissions / feature flags) and a clear “what you can’t touch” map. Impact: readers get copy-pasteable TypeScript and fewer “why didn’t my claim land?” support loops. Address a recent support question on how to remove `permissions` from the access_token.

**Fetch third-party data** (fetch-third-party-data.mdx) — Adds the missing bridge pattern: kinde.fetch during token generation, secrets via Kinde env vars + kinde.env / getEnvironmentVariable, and mapping API JSON into custom access-token claims—the usual way teams enrich tokens without extra round-trips from the app. This is net-new content for a very common integration path that the other two pages don’t fully spell out end-to-end.

All the pages included updated and detailed ai_summary. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start guide with improved structure, screenshots, and runtime examples.
  * Added new tutorial on fetching third-party data in workflows and mapping to token claims.
  * Refactored token customization tutorial with access and ID token examples and required bindings reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->