### PR TITLE
feat: add contentsquare and update other related docs

### DIFF
--- a/src/content/docs/manage-users/view-activity/contentsquare.mdx
+++ b/src/content/docs/manage-users/view-activity/contentsquare.mdx
@@ -1,0 +1,53 @@
+---
+page_id: 34648545-1a2e-4bd0-8f1e-d8a344ab9cf5
+title: Track user activity with Contentsquare
+description: "Guide to integrating Contentsquare with Kinde for tracking user activity and digital experience analytics."
+sidebar:
+  order: 5
+  label: Contentsquare
+tableOfContents:
+  maxHeadingLevel: 3
+relatedArticles:
+  - 8bcdf42c-96d6-42eb-ba58-af77f28024f7
+  - 70ebc1a6-afba-44d9-b1a3-ab57b7e987da
+app_context:
+  - m: settings
+    s: environment_details
+topics:
+  - manage-users
+  - view-activity
+sdk: []
+languages: []
+audience:
+  - admins
+  - product managers
+  - developers
+complexity: beginner
+keywords:
+  - contentsquare
+  - user tracking
+  - digital experience analytics
+  - tag id
+  - third-party analytics
+  - user behavior
+  - session recording
+updated: 2026-05-02
+featured: false
+deprecated: false
+ai_summary: "This page explains how to integrate Contentsquare with Kinde to track user activity in authentication flows. It covers how to add your 13-character Contentsquare Tag ID in Kinde under Settings > Environment > Environment Details > Third-party analytics. Contentsquare is available on Kinde paid plans."
+---
+
+<Aside type="upgrade">
+
+Contentsquare is available on [Kinde paid plans](https://kinde.com/pricing/).
+
+</Aside>
+
+[Contentsquare](https://contentsquare.com/) is a digital experience analytics platform. Use it to track user activity and behavior within your Kinde authentication flows.
+
+## Set up Contentsquare in Kinde
+
+1. Go to **Settings > Environment > Environment Details**
+2. Scroll to the **Third-party analytics > Contentsquare** and enter your 13-character Contentsquare Tag ID in the **Contentsquare** field
+3. Select **Save**
+

--- a/src/content/docs/manage-users/view-activity/hotjar.mdx
+++ b/src/content/docs/manage-users/view-activity/hotjar.mdx
@@ -3,11 +3,12 @@ page_id: 70ebc1a6-afba-44d9-b1a3-ab57b7e987da
 title: Track user behavior with Hotjar
 sidebar:
   order: 4
+  label: Hotjar
 relatedArticles:
   - 8bcdf42c-96d6-42eb-ba58-af77f28024f7
 app_context:
   - m: settings
-    s: business_details
+    s: environment_details
 description: Guide to integrating Hotjar with Kinde for tracking user sign-in events and user behavior analytics.
 sdk: []
 languages: []
@@ -29,7 +30,7 @@ keywords:
 updated: 2026-03-28
 featured: false
 deprecated: false
-ai_summary: Guide to integrating Hotjar with Kinde for user behavior tracking including privacy considerations, security measures, and setup instructions.
+ai_summary: "This page explains how to integrate Hotjar with Kinde to track user behavior on sign-in and sign-up screens. It covers adding your Hotjar Site ID in Settings, and explains that Kinde only injects the Hotjar script on initial auth screens — not on sensitive steps like password, OTP, or MFA entry — so recordings omit that data automatically."
 ---
 
 <Aside type="upgrade">
@@ -38,14 +39,14 @@ Hotjar is available on [Kinde Plus plan or higher](https://kinde.com/pricing/).
 
 </Aside>
 
-[Hotjar](https://www.hotjar.com/) is a tool for recording and tracking user behavior. It is designed to give you insights about how users interact with your site or app. Use Hotjar to track user behavior on your site in Kinde.
+[Hotjar](https://www.hotjar.com/) is a tool for recording and tracking user behavior. It is designed to give you insights into how users interact with your site or app. Use Hotjar to track user behavior on your site in Kinde.
 
 ## Add your Hotjar credentials in Kinde
 
 1. Go to **Settings > Environment > Environment Details**
 2. Scroll down to the **Third-party analytics > Hotjar** section
 3. Add your `Hotjar Site ID`
-4. Select **Save** 
+4. Select **Save**
 
 You can now track user interactions with Hotjar.
 

--- a/src/content/docs/manage-users/view-activity/third-party-tracking.mdx
+++ b/src/content/docs/manage-users/view-activity/third-party-tracking.mdx
@@ -1,0 +1,59 @@
+---
+page_id: f51d127c-d334-46c2-89ef-a0bad6da7958
+title: Add third-party tracking scripts with Kinde
+description: "Overview of supported third-party tracking scripts in Kinde for monitoring user activity and behavior in authentication flows."
+sidebar: 
+  order: 3
+  label: Third-party tracking scripts
+tableOfContents:
+  maxHeadingLevel: 3
+relatedArticles:
+  - 8bcdf42c-96d6-42eb-ba58-af77f28024f7
+  - 70ebc1a6-afba-44d9-b1a3-ab57b7e987da
+  - 34648545-1a2e-4bd0-8f1e-d8a344ab9cf5
+app_context:
+  - m: settings
+    s: environment_details
+topics:
+  - manage-users
+  - view-activity
+sdk: []
+languages: []
+audience:
+  - admins
+  - product managers
+  - developers
+complexity: beginner
+keywords:
+  - third-party tracking
+  - analytics
+  - user activity
+  - authentication flow
+  - tracking scripts
+  - google analytics
+  - hotjar
+  - contentsquare
+updated: 2026-05-02
+featured: false
+deprecated: false
+ai_summary: "This page provides an overview of third-party tracking in Kinde. It explains that tracking scripts can be added to authentication flows via Settings > Environment > Environment Details > Third-party analytics. Supported providers are Google Analytics, Hotjar, and Contentsquare. This feature is available on Kinde paid plans."
+---
+
+<Aside type="upgrade">
+Third-party tracking is available on [Kinde paid plans](https://kinde.com/pricing/).
+</Aside>
+
+With Kinde, you can add third-party tracking scripts to your authentication flows. This allows you to track user activity and behavior outside of Kinde.
+
+## Add a third-party tracking script
+
+1. Go to **Settings > Environment > Environment Details**
+2. Scroll to the **Third-party analytics** section
+3. Add your applicable tracking ID(s)
+4. Select **Save**
+
+## Supported third-party tracking scripts
+
+- [Google Analytics](/manage-users/view-activity/track-user-sign-in-with-google-analytics/)
+- [Hotjar](/manage-users/view-activity/hotjar/)
+- [Contentsquare](/manage-users/view-activity/contentsquare/)

--- a/src/content/docs/manage-users/view-activity/track-user-sign-in-with-google-analytics.mdx
+++ b/src/content/docs/manage-users/view-activity/track-user-sign-in-with-google-analytics.mdx
@@ -3,13 +3,14 @@ page_id: 8bcdf42c-96d6-42eb-ba58-af77f28024f7
 title: Track user sign-in with Google Analytics
 sidebar:
   order: 3
+  label: Google Analytics
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:
   - 70ebc1a6-afba-44d9-b1a3-ab57b7e987da
 app_context:
   - m: settings
-    s: business_details
+    s: environment_details
 description: Guide to integrating Google Analytics with Kinde for tracking user sign-in events and authentication analytics.
 topics:
   - manage-users
@@ -34,7 +35,7 @@ keywords:
 updated: 2026-03-28
 featured: false
 deprecated: false
-ai_summary: Guide to setting up Google Analytics tracking in Kinde for user sign-in events including G-code and UA-code configuration and security considerations.
+ai_summary: "This page explains how to connect Google Analytics to Kinde to track user sign-in and sign-up events. It covers how to find your G-XXXX measurement ID in Google Analytics, how to add it in Kinde under Settings > Environment > Environment Details > Third-party analytics, and notes that Google Tag Manager is not supported due to security concerns."
 ---
 
 <Aside type="upgrade">
@@ -50,7 +51,7 @@ Use Google Analytics to track user sign-in events in Kinde. No activity in Kinde
 1. Sign in to your Google Analytics account
 2. Go to **Admin > Data collection and modifications > Data Streams**
 3. Select the data stream you want (e.g., Website), the details pane opens
-4. The `G-XXXX` code appears under the `MEASUREMENT ID` field, copy the code
+4. The `G-XXXX` code appears under the `MEASUREMENT ID` field. Copy the code
 
 ## Set up Google Analytics in Kinde
 


### PR DESCRIPTION
Adds a new Contentsquare integration doc and updates the related third-party tracking pages. Also adds a new third-party tracking overview page that links to all three supported providers (Google Analytics, Hotjar, Contentsquare). Frontmatter, ai_summary, and body copy updated across all four pages for consistency, with minor grammar fixes.