### PR TITLE
Add Cloudflare as customer support sub-processor

### DIFF
--- a/src/components/SubProcessorsForm.astro
+++ b/src/components/SubProcessorsForm.astro
@@ -145,6 +145,18 @@
         }
       },
       {
+        service: "Cloudflare",
+        entityType: "Customer support",
+        link: "https://cloudflare.com/",
+        locations: {
+          "Australia": "Australia",
+          "Canada": "Australia",
+          "Europe": "Australia",
+          "United Kingdom": "Australia", 
+          "United States": "Australia"
+        }
+      },
+      {
         service: "Discord",
         entityType: "Customer support",
         link: "https://discord.com/",
@@ -278,6 +290,18 @@
           "Europe": "Ireland",
           "United Kingdom": "United Kingdom",
           "United States": "United States"
+        }
+      },
+      {
+        service: "Cloudflare",
+        entityType: "Customer support",
+        link: "https://cloudflare.com/",
+        locations: {
+          "Australia": "Australia",
+          "Canada": "Australia",
+          "Europe": "Australia",
+          "United Kingdom": "Australia",
+          "United States": "Australia"
         }
       },
       {

--- a/src/content/docs/trust-center/privacy-and-compliance/sub-processors.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/sub-processors.mdx
@@ -65,6 +65,7 @@ Customer support: We do not recommend sending external user personal information
 | AWS              | SMS services         | [https://aws.amazon.com](https://aws.amazon.com/)              | Australia, Canada, Ireland, United Kingdom, United States |
 | AWS              | Email services       | [https://aws.amazon.com](https://aws.amazon.com/)              | Australia                                                 |
 | Temporal         | Webhooks             | [https://temporal.io](https://temporal.io/)                    | Australia, Canada, Ireland, United Kingdom, United States |
+| Cloudflare       | Customer support     | [https://cloudflare.com/](https://cloudflare.com/)             | Australia                                                 |
 | Discord          | Customer support     | [https://discord.com/](https://discord.com/)                   | United States                                             |
 | Google           | Customer support     | [https://workspace.google.com/](https://workspace.google.com/) | United States                                             |
 | InKeep           | Customer support     | [https://inkeep.com/](https://inkeep.com/)                     | United States                                             |
@@ -91,6 +92,7 @@ Customer support: We do not recommend sending external user personal information
 | AWS              | Email services        | [https://aws.amazon.com](https://aws.amazon.com/)              | Australia                                                 |
 | Stripe           | Billing and invoicing | [https://stripe.com](https://stripe.com/)                      | United States                                             |
 | Temporal         | Webhooks              | [https://temporal.io](https://temporal.io/)                    | Australia, Canada, Ireland, United Kingdom, United States |
+| Cloudflare       | Customer support      | [https://cloudflare.com/](https://cloudflare.com/)             | Australia                                                 |
 | Discord          | Customer support      | [https://discord.com/](https://discord.com/)                   | United States                                             |
 | Google           | Customer support      | [https://workspace.google.com/](https://workspace.google.com/) | United States                                             |
 | InKeep           | Customer support      | [https://inkeep.com/](https://inkeep.com/)                     | United States                                             |


### PR DESCRIPTION
Document Cloudflare as a customer support tool in the sub-processors pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare as an additional sub-processor under authentication and billing services, with associated support links and regional location mappings.

* **Documentation**
  * Updated trust center privacy and compliance documentation to include Cloudflare sub-processor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->