### PR TITLE
chore: add TanStack Start to list of SDKs

### DIFF
--- a/src/content/docs/developer-tools/about/our-sdks.mdx
+++ b/src/content/docs/developer-tools/about/our-sdks.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 app_context:
   - m: settings
-    s: apis
+    s: applications
 topics:
   - developer-tools
   - sdks

--- a/src/content/docs/developer-tools/about/our-sdks.mdx
+++ b/src/content/docs/developer-tools/about/our-sdks.mdx
@@ -1,7 +1,7 @@
 ---
 page_id: 684fc526-a338-4a67-9af6-742a39b66aff
 title: Kinde SDKs
-description: "Comprehensive overview of Kinde SDKs including frontend, backend, and native SDKs with version compatibility considerations and community SDK information."
+description: "Overview of all Kinde SDKs — frontend, backend, native, and community — to help you connect your app to Kinde."
 sidebar:
   order: 1
 app_context:
@@ -33,33 +33,31 @@ keywords:
   - backend SDKs
   - native SDKs
   - community SDKs
+  - JavaScript SDK
+  - React SDK
+  - Next.js SDK
+  - Flutter SDK
+  - Android SDK
+  - iOS SDK
+  - React Native SDK
+  - TypeScript SDK
   - version compatibility
-  - tech stack
-updated: 2024-01-15
+updated: 2026-05-14
 featured: false
 deprecated: false
-ai_summary: Comprehensive overview of Kinde SDKs including frontend, backend, and native SDKs with version compatibility considerations and community SDK information.
+ai_summary: "Overview of all Kinde Software Development Kits (SDKs). Kinde SDKs simplify connecting your application to Kinde authentication. Most applications only need one SDK, though multiple SDKs can be used for multi-language products or separate frontend and backend services. Frontend SDKs include JavaScript and React. Backend SDKs cover Elixir, Express.js, .NET, Java, Next.js (App Router and Pages Router), TanStack Start, Nuxt, Node.js, PHP, Python, Remix, Ruby, SvelteKit, and TypeScript. Native SDKs support Android, iOS, React Native, Expo, and Flutter. Other integrations include Apollo GraphQL and Node/Express GraphQL. A community-maintained Angular SDK is also available. Always verify that your tech stack versions are compatible with the SDK you choose before getting started."
 ---
 
-Kinde provides Software Development Kits (SDKs) help you connect your app more easily to Kinde.
+Kinde provides Software Development Kits (SDKs) that help you connect with your codebase.
 
-Generally, you only need one SDK per application or service. But you might use multiple SDKs if your product is comprised of applications or services written in multiple languages.
+Visit your preferred SDK page below to get started. You can also use [Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/).
 
-You can also use different SDKs to support front end and back end behavior, if this suits your setup.
-
-<Aside type="warning" title="Check version compatibility">
-
-Make sure that your tech stack’s versions are compatible with the SDK you want to use.
-
-</Aside>
-
-## **Front end**
+## Front end
 
 - [JavaScript SDK](/developer-tools/sdks/frontend/javascript-sdk/)
 - [React SDK](/developer-tools/sdks/frontend/react-sdk/)
-- [TypeScript SDK](/developer-tools/sdks/backend/typescript-sdk/)
 
-## **Back end**
+## Back end
 
 - [Elixir SDK](/developer-tools/sdks/backend/elixir-sdk/)
 - [Express.js SDK](/developer-tools/sdks/backend/express-sdk/)
@@ -67,6 +65,7 @@ Make sure that your tech stack’s versions are compatible with the SDK you want
 - [Java SDK](/developer-tools/sdks/backend/java-sdk/)
 - [Next.js App Router SDK](/developer-tools/sdks/backend/nextjs-sdk/)
 - [Next.js Pages Router SDK](/developer-tools/sdks/backend/nextjs-prev-sdk/)
+- [TanStack Start React SDK](/developer-tools/sdks/backend/tsr-sdk/)
 - [Nuxt module](/developer-tools/sdks/backend/nuxt-module/)
 - [Node.js SDK](/developer-tools/sdks/backend/nodejs-sdk/)
 - [PHP SDK](/developer-tools/sdks/backend/php-sdk/)
@@ -76,25 +75,23 @@ Make sure that your tech stack’s versions are compatible with the SDK you want
 - [SvelteKit SDK](/developer-tools/sdks/backend/sveltekit-sdk/)
 - [TypeScript SDK](/developer-tools/sdks/backend/typescript-sdk/)
 
-## **Native**
+## Native
 
 - [Android SDK](/developer-tools/sdks/native/android-sdk/)
 - [iOS SDK](/developer-tools/sdks/native/ios-sdk/)
 - [React Native SDK](/developer-tools/sdks/native/react-native-sdk/)
-- [Expo and React Native SDK](/developer-tools/sdks/native/expo/)
-- [Flutter SDK ](/developer-tools/sdks/native/flutter-sdk/)
+- [Expo SDK](/developer-tools/sdks/native/expo/)
+- [Flutter SDK](/developer-tools/sdks/native/flutter-sdk/)
 
-## **Other**
+## Other
 
 - [Node/Apollo GraphQL](/developer-tools/sdks/backend/apollo-graphql/)
 - [Node/Express GraphQL](/developer-tools/sdks/backend/node-express-graphql/)
 
 ## Community SDKs
 
-Community SDKs are developed independently by members of the Kinde developer community.
-
-While we review community SDKs before we link to them, Kinde is not responsible for directly supporting or updating community SDKs. Please contact the author through GitHub.
-
 - [Angular SDK](https://github.com/luukhaijes/kinde-angular)
 
-Contact us via [Slack](https://join.slack.com/t/thekindecommunity/shared_invite/zt-2k5i0aeet-d6Z_2qYphcNCpj0bFa4oCg) or [Discord](https://discord.gg/KdkCXRNTFn) support channels if you want to contribute a community SDK.
+<Aside title="About community SDKs">
+Community SDKs are developed independently by members of the Kinde developer community. While we review community SDKs before we link to them, Kinde is not responsible for directly supporting or updating them. Please contact the author through GitHub if you need help.
+</Aside>


### PR DESCRIPTION
This quick PR adds the new TanStack Start SDK to the list of SDKs. Also cleans up and improves the overall doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized SDK documentation with updated front-end and back-end categorization.
  * Added new TanStack Start React SDK to back-end options.
  * Removed outdated version-compatibility warning.
  * Restructured Native and Community SDK sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kinde-oss/documentation/pull/734)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->