### PR TITLE
Update Azure authentication instructions to include platform type during setup

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -127,17 +127,16 @@ You can make a connection available only to a specific organization, or you can 
 
 12. Copy the **Callback URL**. You'll need to enter this in your Entra ID app.
 
-13. Add any [upstream params](/authenticate/auth-guides/pass-params-idp/) that you want to pass to the IdP.
-
-14. Select **Save**.
+13. Add any [upstream params](/authenticate/auth-guides/p
 
 ## Step 3: Add the callback URL to your Entra ID app
 
-1. Open your application in the [Portal](https://entra.microsoft.com/#home).
-2. Select the **Redirect URIs** links on the right.
-3. Select **Add URI**.
-4. In the relevant field, enter your callback URL (from the 'Configure the connection' procedure above)
-5. Select **Save**.
+1. Open your application in the [Portal](https://entra.microsoft.com/#home).
+2. Select the **Redirect URIs** links on the right.
+3. Select **Add URI**.
+4. In the relevant field, enter your callback URL (from the 'Configure the connection' procedure above).
+5. Select **Web** as the platform type for the redirect URI—not **SPA**—even if your application is a single-page app. Microsoft redirects to Kinde's server to complete authentication, not directly to your app. SPA platform settings use different OAuth rules and will cause login failures.
+6. Select **Save**.
 
 ## Step 4: Enable the connection in Kinde
 

--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -127,7 +127,7 @@ You can make a connection available only to a specific organization, or you can 
 
 12. Copy the **Callback URL**. You'll need to enter this in your Entra ID app.
 
-13. Add any [upstream params](/authenticate/auth-guides/p
+13. Add any [upstream params](/authenticate/auth-guides/pass-params-idp/) that you want to pass to the IdP.
 
 ## Step 3: Add the callback URL to your Entra ID app
 


### PR DESCRIPTION
#### Description 


Updates **Step 3: Add the callback URL to your Entra ID app** in the Microsoft Entra ID enterprise connection doc to clarify that the redirect URI platform type in Entra must be **Web**, not **SPA**, even when the customer’s application is a single-page app.

Microsoft redirects to Kinde’s server to complete authentication, not directly to the browser app. SPA platform settings use different OAuth rules and cause login failures in this flow. This change addresses customer feedback from a support thread, where a customer reported confusion because Web worked but SPA did not.

#### Related issues & labels 

- Suggested label: `documentation`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Step 2/Step 3 flow in the Azure enterprise connection guide for a smoother setup.
  * Added explicit instruction to set the redirect URI platform to Web (not SPA) for correct Entra ID redirects.
  * Moved "add any upstream params" before callback URL configuration and expanded step-by-step callback/redirect-URI instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->