### PR TITLE
Add Parth Narula to the security wall of fame

### DIFF
--- a/src/content/docs/trust-center/security/security-wall-of-fame.mdx
+++ b/src/content/docs/trust-center/security/security-wall-of-fame.mdx
@@ -23,7 +23,7 @@ keywords:
   - "bug bounty"
   - "responsible disclosure"
   - "security wall of fame"
-updated: "2025-10-22"
+updated: "2026-06-09"
 featured: false
 deprecated: false
 ai_summary: "Recognition page for security researchers who have responsibly disclosed vulnerabilities to help secure Kinde's systems, organized by year with links to researcher profiles."
@@ -42,6 +42,8 @@ Love your work!
 ### Disclosures
 
 [Pentest Consultants](https://www.pentestconsultants.co.uk)
+
+[Parth Narula](https://www.linkedin.com/in/parth-narula-86283821a/)
 
 [Shambhi Reddy Chemikala](https://www.linkedin.com/in/shambhi-reddy-chemikala-6ba670263)
 

--- a/src/content/docs/trust-center/security/security-wall-of-fame.mdx
+++ b/src/content/docs/trust-center/security/security-wall-of-fame.mdx
@@ -23,7 +23,7 @@ keywords:
   - "bug bounty"
   - "responsible disclosure"
   - "security wall of fame"
-updated: "2026-06-05"
+updated: "2026-06-09"
 featured: false
 deprecated: false
 ai_summary: "Recognition page for security researchers who have responsibly disclosed vulnerabilities to help secure Kinde's systems, organized by year with links to researcher profiles."
@@ -48,6 +48,8 @@ Love your work!
 ### Disclosures
 
 [Pentest Consultants](https://www.pentestconsultants.co.uk)
+
+[Parth Narula](https://www.linkedin.com/in/parth-narula-86283821a/)
 
 [Shambhi Reddy Chemikala](https://www.linkedin.com/in/shambhi-reddy-chemikala-6ba670263)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Add Parth Narula to the Security wall of fame under the 2025 Disclosures section, placed directly after Pentest Consultants. This recognizes their Oct 2025 responsible disclosure and links to their LinkedIn profile.

#### Related issues & labels (optional)

- Closes #
- Suggested label: documentation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the security wall of fame page to include an additional security contributor in the 2025 Disclosures section.
  * Refreshed the page’s “updated” timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->