### PR TITLE
Add SAML metadata hosting guidance to enterprise docs

### DIFF
--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -79,7 +79,7 @@ You can make a connection available only to a specific organization, or you can 
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
-   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
    </Aside>
 

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -76,7 +76,6 @@ You can make a connection available only to a specific organization, or you can 
 2. Enter a random string value for Entity ID, for e.g. `870sa9fbasfasdas23aghkhc12zasfnasd`.
 3. Enter the **IdP metadata URL**. This URL comes from your identity provider.
 
-   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
@@ -85,6 +84,9 @@ You can make a connection available only to a specific organization, or you can 
    </Aside>
 
 4. Enter a **sign in URL** if your IdP requires a specific URL.
+
+   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
 5. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.
 6. Select a **Name ID** format. This helps identify and link user identities between your IdP and Kinde. 
 7. Enter an **Email key attribute**. This is the attribute in the SAML token that contains the user’s email. Setting this value ensures that the email address returned in the SAML response is correctly retrieved. We do not recommend leaving this field blank, but if you do we will set ‘email’ as the attribute.

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -31,6 +31,9 @@ keywords:
   - enterprise auth
   - SSO
   - access policies
+  - metadata URL
+  - metadata hosting
+  - XML
 updated: 2025-01-16
 ---
 
@@ -74,6 +77,12 @@ You can make a connection available only to a specific organization, or you can 
 3. Enter the **IdP metadata URL**. This URL comes from your identity provider.
 
    ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
+   <Aside title="No metadata URL? Host the XML file yourself">
+
+   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+
+   </Aside>
 
 4. Enter a **sign in URL** if your IdP requires a specific URL.
 5. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -101,7 +101,6 @@ Depending on your SAML set up, you may need to include advanced configurations f
 3. If Microsoft is your provider and your app is a bit older, you may need to add `spn:` to the beginning of the **Entity ID** string in Kinde, e.g. `spn:5836g209gbhw09r8y0913`. This is not required for newly created apps.
 4. Enter the **IdP metadata URL**. This URL comes from your identity provider.
 
-   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
@@ -110,6 +109,9 @@ Depending on your SAML set up, you may need to include advanced configurations f
    </Aside>
 
 5. Enter a **sign in URL** if your IdP requires a specific URL.
+ 
+   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
 6. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.
 7. Select a **Name ID** format. This helps identify and link user identities between your IdP and Kinde. 
 8. Enter an **Email key attribute**. This is the attribute in the SAML token that contains the user’s email. Setting this value ensures that the email address returned in the SAML response is correctly retrieved. We do not recommend leaving this field blank, but if you do we will set ‘email’ as the attribute.

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -104,7 +104,7 @@ Depending on your SAML set up, you may need to include advanced configurations f
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
-   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
    </Aside>
 

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -39,6 +39,9 @@ keywords:
   - certificate
   - private key
   - JIT provisioning
+  - metadata URL
+  - metadata hosting
+  - XML
 updated: 2026-04-20
 ai_summary: "Kinde acts as a SAML service provider (SP), requiring an external identity provider (IdP) such as Google, Microsoft, or Cloudflare. Before setup, users can be provisioned via bulk import, API, manual entry, or just-in-time (JIT) provisioning during connection setup. Security can optionally be increased by adding a signed certificate and private key pair (generated via OpenSSL or obtained from the IdP). To configure the connection, provide a unique Entity ID (must match exactly in both Kinde and the IdP; older Microsoft Azure apps may need an `spn:` prefix), the IdP metadata URL, sign-in URL, sign request algorithm, protocol binding, and Name ID format. The Email Key Attribute should always be set to ensure correct email retrieval from the SAML response. Home realm domains route users to the correct sign-in page and must be unique across all connections. The ACS URL (or custom domain URL) must be copied into the IdP configuration. JIT provisioning auto-creates user records on first sign-in. Upstream parameters can optionally be passed to the IdP if supported. Once configured, enable the connection, assign it to apps or organizations, save, and test by attempting a sign-in through the application."
 ---
@@ -99,6 +102,12 @@ Depending on your SAML set up, you may need to include advanced configurations f
 4. Enter the **IdP metadata URL**. This URL comes from your identity provider.
 
    ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
+   <Aside title="No metadata URL? Host the XML file yourself">
+
+   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+
+   </Aside>
 
 5. Enter a **sign in URL** if your IdP requires a specific URL.
 6. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -29,6 +29,9 @@ keywords:
   - enterprise application
   - group claims
   - federation metadata
+  - metadata URL
+  - metadata hosting
+  - XML
 updated: 2026-03-26
 ---
 
@@ -93,6 +96,13 @@ You can make a connection available only to a specific organization, or you can 
 
 2. For the **Entity ID**, enter a random string like `hEb876ZZlkg99Dwat64Mnbvyh129`. Make a copy of the string as you will add this to your SAML application later. Note that some older Entra ID tenants require the Entity ID to have a prefix of `spn:` If your connection fails, this could be why.
 3. Enter the **IdP metadata URL**. This URL comes from your identity provider. If you don't know it, enter any URL and update this later.
+
+   <Aside title="No metadata URL? Host the XML file yourself">
+
+   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+
+   </Aside>
+
 4. Enter a **sign in URL** if your IdP requires a specific URL.
 
    ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -99,7 +99,7 @@ You can make a connection available only to a specific organization, or you can 
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
-   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
    </Aside>
 

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -108,7 +108,7 @@ After creating the connection, configure these settings:
 
     <Aside title="No metadata URL? Host the XML file yourself">
 
-    If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
     </Aside>
 

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -36,6 +36,9 @@ keywords:
   - service provider
   - SP-initiated
   - enterprise authentication
+  - metadata URL
+  - metadata hosting
+  - XML
 updated: 2025-12-19
 ---
 
@@ -102,6 +105,13 @@ After creating the connection, configure these settings:
 1. **Connection name**: A name to identify this connection (e.g., "Acme Corp SSO")
 2. **Entity ID**: The unique identifier configured in your IdP (e.g., `https://yourapp.kinde.com`)
 3. **IdP metadata URL**: You will add this after finishing setup in your Identity Provider (see Step 3)
+
+    <Aside title="No metadata URL? Host the XML file yourself">
+
+    If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+
+    </Aside>
+
 4. **Sign in URL** (optional): Override the default SSO endpoint with a URL your IdP recognizes
 5. **Sign request algorithm**: Choose the algorithm used to sign SAML requests (RSA-SHA1 or RSA-SHA256)
 6. **Protocol binding**: Choose the protocol binding used to send SAML requests

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -73,7 +73,6 @@ Depending on your SAML set up, you may need to include advanced configurations f
 
 3. Enter the **IdP metadata URL**. This URL comes from your identity provider. If you haven't set up your app yet, you can add this later. 
 
-   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
@@ -82,6 +81,9 @@ Depending on your SAML set up, you may need to include advanced configurations f
    </Aside>
 
 4. Enter a **sign in URL** if your IdP requires a specific URL.
+   
+   ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
 5. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.
 6. Select a **Name ID** format. This helps identify and link user identities between your IdP and Kinde. 
 7. Enter an **Email key attribute**. This is the attribute in the SAML token that contains the user’s email. Setting this value ensures that the email address returned in the SAML response is correctly retrieved. We do not recommend leaving this field blank, but if you do we will set ‘email’ as the attribute.

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -76,7 +76,7 @@ Depending on your SAML set up, you may need to include advanced configurations f
 
    <Aside title="No metadata URL? Host the XML file yourself">
 
-   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
    </Aside>
 

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -30,6 +30,9 @@ keywords:
   - enterprise auth
   - SSO
   - application assignment
+  - metadata URL
+  - metadata hosting
+  - XML
 updated: 2025-01-16
 ---
 
@@ -71,6 +74,12 @@ Depending on your SAML set up, you may need to include advanced configurations f
 3. Enter the **IdP metadata URL**. This URL comes from your identity provider. If you haven't set up your app yet, you can add this later. 
 
    ![optional fields for saml](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4f1851db-5c34-496b-ced1-07c1cd272b00/public)
+
+   <Aside title="No metadata URL? Host the XML file yourself">
+
+   If your identity provider gives you the SAML metadata as an XML file but doesn't provide a hosted metadata URL, you can host the file yourself. Upload it to a publicly accessible location—for example an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website—and enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+
+   </Aside>
 
 4. Enter a **sign in URL** if your IdP requires a specific URL.
 5. If you want, select the **Sign request algorithm** and **Protocol binding**. The options you choose will depend on what your identity provider prefers or requires.


### PR DESCRIPTION
## Summary
- Added guidance explaining that IdP metadata XML can be self-hosted when no metadata URL is provided.
- Included example hosting options such as S3, Cloudflare R2, GitHub Gist, and any public website.
- Added related keyword coverage across the SAML enterprise connection docs.

## Testing
- Not run (documentation-only change).
- Verified the edit scope is limited to five MDX documentation pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SAML enterprise connection guides (Cloudflare, Custom, Entra ID, IdP-Initiated, Okta) with clearer guidance on **IdP metadata URL**—including **metadata hosting** options and the scenario where the IdP provides SAML metadata only as **XML**. Users can host the XML at a publicly accessible URL and enter that link to support signing certificate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->