### PR TITLE
Move billing trial + interval from beta to GA

### DIFF
--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -37,7 +37,7 @@ keywords:
   - VAT
   - sales tax
   - invoicing
-updated: 2026-04-07
+updated: 2026-07-01
 ---
 
 Kinde billing gives you the ability to charge customers for your services and collect revenue.
@@ -47,6 +47,7 @@ As part of using this feature, you can:
 - Create and manage plans, and make them visible to your customers
 - Create and customize a pricing table for plan selection
 - Implement specific pricing models to suit your product
+- Configure billing intervals (daily, weekly, monthly, or yearly) on fixed plan charges
 - Offer free trial periods that automatically convert to paid subscriptions
 - Offer annual subscriptions with custom yearly pricing (beta)
 - Use Stripe for secure handling of payments and invoicing

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -47,7 +47,7 @@ As part of using this feature, you can:
 - Create and manage plans, and make them visible to your customers
 - Create and customize a pricing table for plan selection
 - Implement specific pricing models to suit your product
-- Offer free trial periods that automatically convert to paid subscriptions (beta)
+- Offer free trial periods that automatically convert to paid subscriptions
 - Offer annual subscriptions with custom yearly pricing (beta)
 - Use Stripe for secure handling of payments and invoicing
 - Link organizations (B2B) and individual customers (B2C) to a plan
@@ -57,7 +57,7 @@ As part of using this feature, you can:
 
 <Aside>
 
-Trial periods and annual subscriptions are beta features. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get them enabled and help us test them.
+Annual subscriptions are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
 
 </Aside>
 

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -35,7 +35,7 @@ keywords:
   - VAT
   - self-serve portal
 updated: 2026-07-01
-ai_summary: "Overview of the Kinde billing feature for charging customers and collecting revenue. Summarizes capabilities including creating and managing plans, customizing pricing tables, supporting multiple pricing models and billing intervals on fixed charges, offering free trial periods that convert to paid subscriptions, annual subscriptions with custom yearly pricing as a beta feature, Stripe-backed payment processing and invoicing, linking B2B organizations and B2C users to plans, handling upgrades downgrades and cancellations, and enabling self-serve account management. Explains that sales tax and VAT are handled through Stripe account configuration and Stripe Tax rather than Kinde plan builder controls. Lists known limitations including no custom billing intervals beyond daily weekly monthly or yearly, no billing cycle anniversary customization, and no per-subscription add-ons or discounts. Notes this is an initial billing release with ongoing improvements and invites feedback via support. Intended for developers, product managers, and business owners evaluating or adopting Kinde billing."
+ai_summary: "Overview of the Kinde billing feature for charging customers and collecting revenue. Summarizes capabilities including creating and managing plans, customizing pricing tables, supporting multiple pricing models and billing intervals on fixed charges, offering free trial periods that convert to paid subscriptions, annual subscriptions with custom yearly pricing, Stripe-backed payment processing and invoicing, linking B2B organizations and B2C users to plans, handling upgrades downgrades and cancellations, and enabling self-serve account management. Explains that sales tax and VAT are handled through Stripe account configuration and Stripe Tax rather than Kinde plan builder controls. Lists known limitations including no custom billing intervals beyond daily weekly monthly or yearly, no billing cycle anniversary customization, and no per-subscription add-ons or discounts. Notes this is an initial billing release with ongoing improvements and invites feedback via support. Intended for developers, product managers, and business owners evaluating or adopting Kinde billing."
 ---
 
 Kinde billing gives you the ability to charge customers for your services and collect revenue.
@@ -45,20 +45,13 @@ As part of using this feature, you can:
 - Create and manage plans, and make them visible to your customers
 - Create and customize a pricing table for plan selection
 - Implement specific pricing models to suit your product
-- Configure billing intervals (daily, weekly, monthly, or yearly) on fixed plan charges
+- Configure billing intervals (daily, weekly, monthly, or yearly) on fixed plan charges, and optionally offer annual subscriptions with custom yearly pricing
 - Offer free trial periods that automatically convert to paid subscriptions
-- Offer annual subscriptions with custom yearly pricing (beta)
 - Use Stripe for secure handling of payments and invoicing
 - Link organizations (B2B) and individual customers (B2C) to a plan
 - Handle plan upgrade, downgrade, and cancellation
 - Enable self-serve account management for customers
 - Customize the pricing table to make the whole experience on-brand
-
-<Aside>
-
-Annual subscriptions are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
 
 Billing helps you manage the customer lifecycle across your business—from registration and plan selection through authorization, provisioning, releases, and upgrades.
 

--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -1,8 +1,9 @@
 ---
 page_id: bd6757e3-81d5-48d6-89c8-dd4c222ac647
-title: About billing
+title: About Kinde billing feature
 sidebar:
   order: 1
+  label: About billing
 relatedArticles:
   - 9d1daf85-1a2c-4cc5-879a-230c950bed12
   - e6dde80d-2977-419f-a05a-62ad0a7ac6de
@@ -10,13 +11,13 @@ relatedArticles:
 app_context:
   - m: billing
     s: plans
-description: >-
-  Overview of Kinde billing capabilities including plan management, pricing
-  tables, payment processing, and customer lifecycle management.
+description: "Charge customers and manage subscriptions with Kinde billing—plans, pricing tables, Stripe payments, trials, and self-serve account management"
 featured: false
 deprecated: false
 topics:
   - billing
+  - subscriptions
+  - stripe
 sdk: []
 languages: []
 audience:
@@ -25,19 +26,16 @@ audience:
   - business-owner
 complexity: beginner
 keywords:
-  - billing
-  - plans
-  - pricing
-  - Stripe
-  - customer lifecycle
-  - revenue
-  - subscriptions
-  - trial
-  - tax
-  - VAT
+  - billing overview
+  - stripe integration
+  - pricing table
+  - subscription management
+  - free trial
   - sales tax
-  - invoicing
+  - VAT
+  - self-serve portal
 updated: 2026-07-01
+ai_summary: "Overview of the Kinde billing feature for charging customers and collecting revenue. Summarizes capabilities including creating and managing plans, customizing pricing tables, supporting multiple pricing models and billing intervals on fixed charges, offering free trial periods that convert to paid subscriptions, annual subscriptions with custom yearly pricing as a beta feature, Stripe-backed payment processing and invoicing, linking B2B organizations and B2C users to plans, handling upgrades downgrades and cancellations, and enabling self-serve account management. Explains that sales tax and VAT are handled through Stripe account configuration and Stripe Tax rather than Kinde plan builder controls. Lists known limitations including no custom billing intervals beyond daily weekly monthly or yearly, no billing cycle anniversary customization, and no per-subscription add-ons or discounts. Notes this is an initial billing release with ongoing improvements and invites feedback via support. Intended for developers, product managers, and business owners evaluating or adopting Kinde billing."
 ---
 
 Kinde billing gives you the ability to charge customers for your services and collect revenue.
@@ -62,7 +60,7 @@ Annual subscriptions are a beta feature. Contact Kinde support at [support@kinde
 
 </Aside>
 
-Billing makes the Kinde platform _the_ essential development infrastructure for managing the customer lifecycle across every part of your business. From registration to plan selection, authorization to provisioning, releases to upgrades.
+Billing helps you manage the customer lifecycle across your business—from registration and plan selection through authorization, provisioning, releases, and upgrades.
 
 ## How is sales tax or VAT handled in Kinde billing?
 
@@ -72,11 +70,11 @@ Use the Stripe Dashboard for your connected account to align tax behavior with y
 
 ## Known limitations
 
-These are current limitations that we are aware of and are working on adding.
+These are known limitations we are actively working to address.
 
 - Custom billing intervals (e.g., quarterly) are not supported. Fixed charges are limited to daily, weekly, monthly, or yearly intervals.
-- Changes to the billing cycle (e.g. choose billing anniversaries, etc.)
-- Add-ons and discounts that can be applied to individual subscriptions
+- Changes to the billing cycle (e.g., custom billing anniversaries) are not supported
+- Add-ons and discounts applied to individual subscriptions are not supported
 
 ## This is our first billing release
 

--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -33,7 +33,7 @@ keywords:
   - trial
   - trial period
   - free trial
-updated: 2026-04-07
+updated: 2026-07-01
 ---
 
 'Billing' refers to the broad function of creating plans, setting pricing, collecting payments, etc. Here are some of the common concepts and terms you will come across.
@@ -50,7 +50,7 @@ updated: 2026-04-07
 - **Plan settings** - Configuration options that control subscription behavior, such as whether to require credit card details during signup. The "Ask for credit card" setting allows free plans to skip payment collection for a frictionless experience.
 - **Trial period** - An optional setting on paid plans that lets customers try the plan for a set number of days before being charged. During the trial, the customer has full access to the plan's features. Kinde creates the trial using Stripe's subscription trial. Plans with a trial enabled show a badge on the pricing table.
 - **Features** - Plan features are the specific capabilities or entitlements included in a plan. They can be chargeable (incurring additional fees) or non-chargeable (included at no extra cost). Features can be metered (usage-based) or unmetered (fixed access).
-- **Fixed charges** – Single chargeable items like the subscription base price and other standalone recurring charges. You can set billing intervals (daily, weekly, monthly, or yearly) and optionally offer one charge per plan as annual at a custom yearly price.
+- **Fixed charges** – Single chargeable items like the subscription base price and other standalone recurring charges. Configure the billing interval per charge in the plan editor using the **Billing interval** field (daily, weekly, monthly, or yearly). Optionally, offer one charge per plan as annual at a custom yearly price.
 - **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, per-seat pricing, etc. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when deciding this.
 - **Payments processor** - A payments processor is a third-party service that securely processes customer payments via credit cards, ACH, or other methods - such as Stripe Billing.
 - **Pricing table** - A pricing table is a visual representation of your different subscription plans, showcasing features and prices to help users compare options. You can build one in Kinde and then show it to your customers in the auth flow or self-service portal.

--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -1,18 +1,20 @@
 ---
 page_id: 9d1daf85-1a2c-4cc5-879a-230c950bed12
-title: Billing concepts & terms
+title: Commonly used billing concepts and terms
 sidebar:
   order: 3
+  label: Billing concepts
 relatedArticles:
   - 100f75f1-a0a4-459f-874f-da127f2d0615
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
-description: >-
-  Comprehensive guide to billing concepts and terminology including plan groups,
-  features, pricing models, and common billing terms.
+description: "Master Kinde billing terminology—from plan groups and fixed charges to trials, tiered pricing, and access token claims"
 featured: false
 deprecated: false
 topics:
   - billing
+  - plans
+  - pricing-models
+  - entitlements
 sdk: []
 languages: []
 audience:
@@ -21,52 +23,49 @@ audience:
   - business-owner
 complexity: beginner
 keywords:
-  - billing concepts
+  - billing terminology
   - plan groups
-  - features
-  - pricing models
-  - metered usage
   - fixed charges
-  - billing interval
-  - offer as annual
-  - multi-currency
-  - trial
+  - metered features
+  - tiered pricing
   - trial period
-  - free trial
+  - customer agreement
+  - access token claims
 updated: 2026-07-01
+ai_summary: "Reference guide to commonly used billing concepts and terms in Kinde. Defines billing identifiers such as customer_id and customer_agreement_id and how they differ from user_id and org_id. Covers key concepts including plan groups, plans, plan settings, trial periods, chargeable and non-chargeable features, fixed charges with billing intervals and annual pricing, pricing models, payment processing via Stripe, pricing tables, and the self-serve account portal. Includes a glossary of common terms such as agreement, base price, metered and unmetered features, multi-currency, tiered pricing, unit price, and usage-based pricing. Documents trial-related access token claims has_trial_period and trial_expires_on. Intended for developers, product managers, and business owners learning Kinde billing vocabulary."
 ---
 
 'Billing' refers to the broad function of creating plans, setting pricing, collecting payments, etc. Here are some of the common concepts and terms you will come across.
 
 ## Billing identifiers
 
-- **Customer ID** - A `customer_id` uniquely identifies a user or org who has signed up to a plan. This is different to a `user_id` or `org_id` that identifies the user or org as an entity. 
-- **Customer Agreement ID** - A `customer_agreement_id` identifies the contract or agreement created in Stripe when a plan is signed up to. The agreement ID is then associated with the `customer_id` in Kinde.
+- **Customer ID** - A `customer_id` uniquely identifies a user or org who has signed up for a plan. This is different from a `user_id` or `org_id`, which identify the user or org as an entity.
+- **Customer Agreement ID** - A `customer_agreement_id` identifies the contract or agreement created in Stripe when a customer signs up for a plan. The agreement ID is then associated with the `customer_id` in Kinde.
 
 ## Key concepts
 
 - **Plan groups** - Plan groups organize multiple plans under a common category, helping segment offerings by use case, customer size, or market. A group is scoped to either organizations (B2B) or individual customers (B2C). You can have multiple plan groups, but each plan must belong to a group.
 - **Plans** - Plans define the specific features, usage limits, and pricing tiers offered to customers in a SaaS product.
-- **Plan settings** - Configuration options that control subscription behavior, such as whether to require credit card details during signup. The "Ask for credit card" setting allows free plans to skip payment collection for a frictionless experience.
+- **Plan settings** - Configuration options that control subscription behavior, such as whether to require credit card details during sign-up. The "Ask for credit card" setting allows free plans to skip payment collection for a frictionless experience.
 - **Trial period** - An optional setting on paid plans that lets customers try the plan for a set number of days before being charged. During the trial, the customer has full access to the plan's features. Kinde creates the trial using Stripe's subscription trial. Plans with a trial enabled show a badge on the pricing table.
 - **Features** - Plan features are the specific capabilities or entitlements included in a plan. They can be chargeable (incurring additional fees) or non-chargeable (included at no extra cost). Features can be metered (usage-based) or unmetered (fixed access).
 - **Fixed charges** – Single chargeable items like the subscription base price and other standalone recurring charges. Configure the billing interval per charge in the plan editor using the **Billing interval** field (daily, weekly, monthly, or yearly). Optionally, offer one charge per plan as annual at a custom yearly price.
-- **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, per-seat pricing, etc. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when deciding this.
-- **Payments processor** - A payments processor is a third-party service that securely processes customer payments via credit cards, ACH, or other methods - such as Stripe Billing.
+- **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, or per-seat pricing. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when choosing one.
+- **Payment processor** - A payment processor is a third-party service that securely processes customer payments via credit cards, ACH, or other methods—such as Stripe Billing.
 - **Pricing table** - A pricing table is a visual representation of your different subscription plans, showcasing features and prices to help users compare options. You can build one in Kinde and then show it to your customers in the auth flow or self-service portal.
-- **Self-serve account portal** - Kinde provides a self-serve portal. This allows customers to manage their subscriptions—such as upgrading plans, updating payment information, or cancelling. This reduces support overhead and improves user autonomy. In Kinde, you can decide what your customers can self-manage or remove the functionality completely.
+- **Self-serve account portal** - Kinde provides a self-serve portal that lets customers manage their subscriptions—such as upgrading plans, updating payment information, or canceling. This reduces support overhead and improves user autonomy. In Kinde, you can decide what your customers can self-manage or remove the functionality completely.
 
 ## Common billing terms
 
-- **Agreement** - the term used in Stripe and the Kinde API to refer to a customer's subscription. Both terms are used throughout docs.
+- **Agreement** - The term used in Stripe and the Kinde API to refer to a customer's subscription. Both terms are used throughout the docs.
 - **Base price** – The starting cost of a subscription plan, typically the cost for a core set of features or a minimum level of usage.
 - **Chargeable / Non-chargeable feature** –
   - **Chargeable feature**: Incurs an additional fee when used. Might be metered or per unit price.
-  - **Non-chargeable feature**: Add non-chargeable features for any included features which aren't independently chargeable, but need to be gated in your product.
+  - **Non-chargeable feature**: Included in the plan at no extra cost. Use for features that aren't independently chargeable but need to be gated in your product.
 - **Credit card prompt (trial)** – The number of days before a trial ends when the customer is prompted to add payment details. This helps ensure payment information is collected before the trial expires and the subscription converts to a paid subscription.
-- **Feature** – A specific function or capability of your SaaS product that you provision for app users. In context with a plan, these are chargeable or non-chargeable features that are provisioned to customers.
+- **Feature** – A specific function or capability of your SaaS product that you provision for app users. In the context of a plan, these are chargeable or non-chargeable features provisioned to customers.
 - **Fixed charge** – A recurring fee that does not change based on usage. You can bill at daily, weekly, monthly, or yearly intervals. Use this for a plan’s base price or other flat recurring fees. Optionally, one fixed charge per plan can be offered as annual at a predefined yearly price.
-- **Metered and unmetered feature** – Metered features are provisioned in units, often with pricing per unit, e.g. MAU. An unmetered feature is like a boolean, and is a basic feature with no pricing attached.
+- **Metered and unmetered feature** – Metered features are provisioned in units, often with pricing per unit, e.g., MAU. An unmetered feature behaves like a boolean toggle—a basic entitlement with no pricing attached.
 - **Multi-currency** – The ability to set plan prices in different currencies to support global customers. Kinde supports nearly all currencies, but you can currently only pick one as the default for all plans.
 - **Plan** – A packaged offering of features, prices, and terms available for subscription, typically tiered across a group (e.g., Basic, Pro, Enterprise).
 - **Plan group** – A collection of related plans, often grouped by customer type or usage level, allowing easier management and comparison.
@@ -76,7 +75,7 @@ updated: 2026-07-01
 - **Trial expires on** – The date and time when a customer's trial period ends. This value is available in billing-related access token claims as `trial_expires_on` when a trial is active.
 - **Trial period** – A configurable window of time during which a customer can use a paid plan for free. At the end of the trial, the subscription automatically converts to a paid subscription via Stripe. Trial length is set in days.
 - **Unit price** – Where a price is set per unit of usage, e.g. a seat or license. Unit prices can also be applied to metered features, e.g. x per unit. Unit prices can also be tiered, e.g. x per unit up to 10 units, then y for 10+ units.
-- **Usage-based** **price** – A billing method where charges vary based on the metered consumption of resources or services (e.g., API calls, storage).
+- **Usage-based price** – A billing method where charges vary based on the metered consumption of resources or services (e.g., API calls, storage).
 
 ## What trial-related claims appear in access tokens?
 

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -105,9 +105,7 @@ Yes, when creating or editing a plan, you'll find an **Ask for credit card** tog
 <details>
 <summary><strong>How do I offer a free trial period on a Kinde billing plan?</strong></summary>
 
-Trial periods are currently a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-Once enabled, turn on the trial period toggle in plan settings when creating or editing a plan. Set the trial length in days and configure how many days before the trial ends to prompt for payment details. When a trial is enabled, customers can use the plan without being charged until the trial ends, at which point their subscription automatically converts to a paid subscription via Stripe.
+To set up a trial, turn on the trial period toggle in plan settings when creating or editing a plan. Set the trial length in days and configure how many days before the trial ends to prompt for payment details. When a trial is enabled, customers can use the plan without being charged until the trial ends, at which point their subscription automatically converts to a paid subscription via Stripe.
 
 Trial plans require the **Ask for credit card** option to be enabled. Plans with an active trial display a "Free trial for N day(s)" badge on the pricing table.
 [Configure trial periods](/billing/manage-plans/create-plans/#configure-trial-period) | [About plans](/billing/manage-plans/about-plans/)
@@ -263,7 +261,7 @@ Start by reviewing billing history in the organization portal to verify charge t
 <details>
 <summary><strong>What are current Kinde billing limitations?</strong></summary>
 
-Current limitations include custom billing period support (fortnightly, etc.) and limited plan-versioning options. Free trial periods and annual subscriptions are now available as beta features — contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get them enabled. Share product feedback through support channels to help prioritize roadmap improvements.
+Current limitations include custom billing period support (fortnightly, etc.) and limited plan-versioning options. Annual subscriptions are available as a beta feature — contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled. Share product feedback through support channels to help prioritize roadmap improvements.
 [Current billing limitations](/billing/manage-plans/about-plans/) | [Alternative approaches](/billing/pricing/pricing-models/)
 </details>
 

--- a/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
+++ b/src/content/docs/billing/about-billing/kinde-billing-faqs.mdx
@@ -261,7 +261,7 @@ Start by reviewing billing history in the organization portal to verify charge t
 <details>
 <summary><strong>What are current Kinde billing limitations?</strong></summary>
 
-Current limitations include custom billing period support (fortnightly, etc.) and limited plan-versioning options. Annual subscriptions are available as a beta feature — contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled. Share product feedback through support channels to help prioritize roadmap improvements.
+Current limitations include custom billing period support (fortnightly, etc.) and limited plan-versioning options. Share product feedback through support channels to help prioritize roadmap improvements.
 [Current billing limitations](/billing/manage-plans/about-plans/) | [Alternative approaches](/billing/pricing/pricing-models/)
 </details>
 

--- a/src/content/docs/billing/billing-user-experience/free-trials.mdx
+++ b/src/content/docs/billing/billing-user-experience/free-trials.mdx
@@ -37,12 +37,6 @@ keywords:
 updated: 2026-04-07
 ---
 
-<Aside>
-
-Trial periods are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
-
 You can offer a free trial to your customers with Kinde Billing.
 
 Free trials let customers use a **paid** plan for a limited time before they are charged. They are a common way to reduce signup friction while still moving toward a paid subscription. With Kinde Billing, trials are implemented using **Stripe** subscription trials: the customer gets plan entitlements during the trial window, and the subscription can convert to paid automatically when the trial ends.
@@ -72,7 +66,6 @@ To see how this maps to billing screens (plan selection, payment details, and tr
 
 ## What do I need before offering a trial?
 
-- **Billing trials** must be enabled for your business. This is currently a beta feature. If you do not see trial options in plan settings, contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled.
 - **Stripe** must be connected and working for Kinde Billing, because trials are created as Stripe subscriptions with a trial period.
 - **Ask for credit card** must be **on** for the plan. Trials cannot be enabled on plans where credit card collection is turned off. You can still use a **No credit card required** message in your own marketing; see below.
 

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -79,12 +79,6 @@ Plan settings control additional subscription behavior beyond pricing.
 - **Ask for credit card**: Determines whether users must provide payment details when subscribing. This can be disabled for free plans with no charges, allowing frictionless signups. For plans with any charges (fixed or metered), credit card collection is always required.
 - **Trial period**: When enabled, lets customers try the plan for a set number of days before being charged. You can configure the trial length and how many days before the trial ends to prompt for payment details. Plans with a trial enabled show a "Free trial for N day(s)" badge on the pricing table. See [Create plans — Configure trial period](/billing/manage-plans/create-plans/#configure-trial-period) for configuration details.
 
-<Aside>
-
-Trial periods are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
-
 ### Plan feature pricing
 
 Depending how you manage plans and feature provisioning in your application, plan pricing might be simple or complex in your business.

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -86,12 +86,6 @@ Depending how you manage plans and feature provisioning in your application, pla
 When you set up a plan, you can include a mixture of any of these options:
 
 - **Fixed charges** – A recurring charge that does not change and is invoiced in advance. You can set the billing interval (daily, weekly, monthly, or yearly) and optionally offer one charge per plan as annual at a custom yearly price.
-
-<Aside>
-
-Annual subscriptions are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
 - **Metered features** - usage-based entitlements that define what and how much users’ access, and what they pay to access it. These might be per unit, per tier, or non-chargeable. Such as included and additional MAU.
 - **Unmetered features** - things included in a plan that users don’t pay for separately. Unmetered features are generally used to gate feature access. E.g. X feature is not available on the Free plan, but is on a higher tier plan.
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -1,8 +1,9 @@
 ---
 page_id: fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
-title: Create plans
+title: Create billing plans in Kinde
 sidebar:
   order: 2
+  label: Create plans
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:
@@ -12,13 +13,14 @@ relatedArticles:
 app_context:
   - m: billing
   - s: plans
-description: >-
-  Step-by-step guide to creating plans in Kinde including plan groups, fixed
-  charges, metered features, and tiered pricing configuration.
+description: "Create and publish Kinde billing plans with fixed charges, metered features, tiered pricing, trials, and annual billing options"
 featured: false
 deprecated: false
 topics:
   - billing
+  - manage-plans
+  - plans
+  - tiered-pricing
 sdk: []
 languages: []
 audience:
@@ -31,22 +33,19 @@ keywords:
   - plan groups
   - fixed charges
   - billing interval
-  - offer as annual
   - metered features
   - tiered pricing
-  - plan features
-  - subscription fees
-  - trial
   - free trial
-  - trial period
+  - annual pricing
 updated: 2026-07-01
+ai_summary: "Step-by-step guide to creating billing plans in the Kinde dashboard. Explains that all plans belong to a plan group scoped to users or organizations, and that charges and features can be reused across plans. Covers adding a plan with name, description, key, and default currency; configuring plan settings including the Ask for credit card toggle and trial period with trial length and credit card prompt timing; adding fixed charges with billing intervals and optional Offer as annual yearly pricing; creating free plans with a zero price; adding metered and unmetered features with flat or tiered graduated pricing; and verifying Stripe price sync status. Notes constraints such as credit card collection requirements for paid plans and trials, annual subscriptions as a beta feature, and immutability of feature name, key, and type after creation. Intended for developers and product managers setting up SaaS subscription plans."
 ---
 
 Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.
 
-All plans must belong to a plan group. When you create your first plan, it will be automatically added to the default group. A plan group can only contain either user plans or organization plans. When you create your first plan, we automatically create a group based on the plan type you select. 
+All plans must belong to a plan group. A plan group can contain only user plans or only organization plans—not both. When you create your first plan, Kinde automatically creates a default group based on the plan type you select and adds the plan to it.
 
-Remember you can create one charge or feature that can be used and redefined across all plans. E.g. You can have one ‘Base price’ charge that is defined as `0.00` in a **free plan**, `10.00` in a **Plus plan**, and `25.00` in a **Pro plan**.
+You can define a charge or feature once and reuse it across plans. For example, a **Base price** charge can be set to `0.00` in a **free plan**, `10.00` in a **Plus plan**, and `25.00` in a **Pro plan**.
 
 
 ## Add a plan
@@ -57,7 +56,7 @@ Remember you can create one charge or feature that can be used and redefined acr
     ![Add plans window](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a8a237d5-c242-45dc-453e-a7ad66e33a00/public)
     
 3. Choose whether the plan is for **Organizations** or **Users**, or select the **Group** the plan belongs to. Only one of these options will appear. You cannot change these selections later.
-4. Give the plan a **Name** (e.g., `Free`), a **Description**. This is the name that will also appear in the pricing table (if you use one).
+4. Give the plan a **Name** (e.g., `Free`) and a **Description**. This is the name that will also appear in the pricing table (if you use one).
 5. Give your plan a **Key** (e.g., `free_plan`) for referencing in your code. This cannot be changed after a plan is published.
 6. Select a **Default currency**. This field only appears if one has not been set. You can change this later in **Settings > Billing**, but only before any of your plans are published.
 7. Select **Save**
@@ -103,7 +102,7 @@ Enabling a trial period requires the **Ask for credit card** toggle to be on. Yo
 
 </Aside>
 
-In **Trials** section:
+In the **Trials** section:
 
 1. Enable **Trial period**.
 2. Set the **Trial length (days)** (default: 30, minimum: 1). This is how many days the customer can use the plan for free.
@@ -137,7 +136,7 @@ A fixed charge is a recurring charge such as base price or subscription fee. You
         
         <Aside>
         
-        You only need to create a new charge if the item is unique. For re-usable items such as ‘Base price’, select the existing charge but change the line item description and price for each plan.
+        You only need to create a new charge if the item is unique. For reusable items such as ‘Base price’, select the existing charge but change the line item description and price for each plan.
         
         </Aside>
         
@@ -151,13 +150,13 @@ After entering the charge name and price, configure how often the fixed charge i
 
 1. Use the **Billing interval** dropdown.
 2. Choose **Day**, **Week**, **Month**, or **Year**. The default is **Month**.
-3. The helper text in the UI reads: *Choose how often this charge is billed*.
-4. The interval you select determines how often Stripe bills the customer for this fixed charge.
-5. If you select **Year** as the billing interval, the separate **Offer as annual** toggle does not apply. Annual pricing is a distinct option for charges billed at non-yearly base intervals.
+      - The interval you select determines how often Stripe bills the customer for this fixed charge.
+      - If you select **Year** as the billing interval, the separate **Offer as annual** toggle does not apply. Annual pricing is a distinct option for charges billed at non-yearly base intervals.
 
-- **(Optional) Offer as annual** with a yearly price for this plan.
-- Select **Save** or **Save draft** to commit your changes.
-- Repeat for each fixed charge you want to add, or start adding features.
+3. (Optional) Enable **Offer as annual** with a yearly price for this plan.
+4. Select **Save** or **Save draft** to commit your changes.
+
+Repeat for each fixed charge you want to add, or start adding features.
 
 ### Offer annual pricing
 
@@ -197,7 +196,7 @@ You cannot change the Name, the Key or the Type of feature once you have created
 3. Enter a **Feature name**. Be sure to use something generic if you plan to use this feature again, e.g. `Included seats`.
 4. Enter a **Description**.
 5. Enter a **Key** for referencing the feature. 
-6. If you selected a unmetered feature, select **Save**. You’re done. Repeat from step 1 to add more features. 
+6. If you selected an unmetered feature, select **Save**. You’re done. Repeat from step 1 to add more features. 
 7. If you selected a metered feature, complete the rest of the details:
     
     ![Add feature window, select units](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/de016f2c-2477-4abd-9a2d-00e7c3e99300/public)
@@ -211,9 +210,9 @@ You cannot change the Name, the Key or the Type of feature once you have created
 11. Add a **Line item description**. This appears on the customer invoice, so might be more specific than the name, e.g. `Additional licenses for Pro (5)`.
 12. For a flat unit price, enter the price and select **Save**. You’re finished.
 13. For tiered pricing, select **Tiered - Graduated** and define each tier with unit numbers and add the price per unit. 
-14. Select **Add tier** to add a different price for higher unit tiers. For example, a unit might be $10 each if you use 1-10, but is $9 per unit if you use 11 or more.
+14. Select **Add tier** to add a different price for higher unit tiers. For example, units might cost $10 each for quantities 1–10, and $9 per unit for 11 or more.
     
-    Ensure the tiered units amounts don’t overlap. E.g. make sure they follow a pattern like 1-10, 11-20, 21-30, etc. If you want to make it so an upper limit is limitless, E.g. 1-10, 11-(blank/limitless); use 1-10, 11-1,000,000 (or a very high number). Graduated unit fields can’t be left blank.
+    Ensure the tiered unit amounts don’t overlap—for example, 1–10, 11–20, 21–30. To set a limitless upper tier (e.g., 11+), use a very high number such as 1–10, 11–1,000,000. Graduated unit fields can’t be left blank.
     
 15. Select **Save.**
 16. In the **Plan** window, select **Save** to commit your changes.
@@ -221,6 +220,6 @@ You cannot change the Name, the Key or the Type of feature once you have created
 
 ## Price sync status
 
-If you are successfully connected to Stripe and the plan/feature is part of a published plan, it will show as `price synced`. Otherwise the feature will show as `price not synced`.
+If you are connected to Stripe and the plan or feature is part of a published plan, it will show as `price synced`. Otherwise, it will show as `price not synced`.
 
     ![Price sync status](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/bc88b122-c6d6-4352-1a54-2fe844f23c00/socialsharingimage)

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -95,12 +95,6 @@ This toggle controls whether users must enter credit card details when subscribi
 
 ### Configure trial period
 
-<Aside>
-
-Trial periods are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
-
 Trial periods let customers try a paid plan before being charged. When a trial is active, the customer's Stripe subscription is created with a trial window — no charges are made until the trial expires.
 
 <Aside type="warning">

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -39,7 +39,7 @@ keywords:
   - trial
   - free trial
   - trial period
-updated: 2026-04-07
+updated: 2026-07-01
 ---
 
 Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.
@@ -143,10 +143,21 @@ A fixed charge is a recurring charge such as base price or subscription fee. You
         
     2. If this is a new charge, give it a name (e.g., `Base subscription fee`). If you’ll reuse this charge across plans, choose a generic name. This cannot be changed later.
 2. Add a **Line item description**. This appears on the customer invoice, so might be more specific than the name, e.g. `Base subscription - Pro plan`.
-3. Set the **Price** and choose the **Billing interval**: **Day**, **Week**, **Month**, or **Year**. (You may be asked to set a default currency if you haven’t already).
-4. **(Optional) Offer as annual** with a yearly price for this plan.
-5. Select **Save** or **Save draft** to commit your changes.
-6. Repeat for each fixed charge you want to add, or start adding features.
+3. Set the **Price**. (You may be asked to set a default currency if you haven’t already).
+
+### Set the billing interval
+
+After entering the charge name and price, configure how often the fixed charge is billed:
+
+1. Use the **Billing interval** dropdown.
+2. Choose **Day**, **Week**, **Month**, or **Year**. The default is **Month**.
+3. The helper text in the UI reads: *Choose how often this charge is billed*.
+4. The interval you select determines how often Stripe bills the customer for this fixed charge.
+5. If you select **Year** as the billing interval, the separate **Offer as annual** toggle does not apply. Annual pricing is a distinct option for charges billed at non-yearly base intervals.
+
+- **(Optional) Offer as annual** with a yearly price for this plan.
+- Select **Save** or **Save draft** to commit your changes.
+- Repeat for each fixed charge you want to add, or start adding features.
 
 ### Offer annual pricing
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -38,7 +38,7 @@ keywords:
   - free trial
   - annual pricing
 updated: 2026-07-01
-ai_summary: "Step-by-step guide to creating billing plans in the Kinde dashboard. Explains that all plans belong to a plan group scoped to users or organizations, and that charges and features can be reused across plans. Covers adding a plan with name, description, key, and default currency; configuring plan settings including the Ask for credit card toggle and trial period with trial length and credit card prompt timing; adding fixed charges with billing intervals and optional Offer as annual yearly pricing; creating free plans with a zero price; adding metered and unmetered features with flat or tiered graduated pricing; and verifying Stripe price sync status. Notes constraints such as credit card collection requirements for paid plans and trials, annual subscriptions as a beta feature, and immutability of feature name, key, and type after creation. Intended for developers and product managers setting up SaaS subscription plans."
+ai_summary: "Step-by-step guide to creating billing plans in the Kinde dashboard. Explains that all plans belong to a plan group scoped to users or organizations, and that charges and features can be reused across plans. Covers adding a plan with name, description, key, and default currency; configuring plan settings including the Ask for credit card toggle and trial period with trial length and credit card prompt timing; adding fixed charges with billing intervals and optional Offer as annual yearly pricing; creating free plans with a zero price; adding metered and unmetered features with flat or tiered graduated pricing; and verifying Stripe price sync status. Notes constraints such as credit card collection requirements for paid plans and trials, one annual charge per plan, and immutability of feature name, key, and type after creation. Intended for developers and product managers setting up SaaS subscription plans."
 ---
 
 Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.
@@ -151,20 +151,14 @@ After entering the charge name and price, configure how often the fixed charge i
 1. Use the **Billing interval** dropdown.
 2. Choose **Day**, **Week**, **Month**, or **Year**. The default is **Month**.
       - The interval you select determines how often Stripe bills the customer for this fixed charge.
-      - If you select **Year** as the billing interval, the separate **Offer as annual** toggle does not apply. Annual pricing is a distinct option for charges billed at non-yearly base intervals.
+      - If you select **Year** as the billing interval, the separate **Offer as annual** toggle does not apply—yearly billing is already the interval. The **Offer as annual** toggle is only available for non-yearly intervals (Day, Week, Month), where you can add an optional yearly price on top of the base interval.
 
-3. (Optional) Enable **Offer as annual** with a yearly price for this plan.
+3. (Optional) To bill this charge yearly at a custom price, turn on **Offer as annual**. See [Offer annual pricing](#offer-annual-pricing) below for details.
 4. Select **Save** or **Save draft** to commit your changes.
 
 Repeat for each fixed charge you want to add, or start adding features.
 
 ### Offer annual pricing
-
-<Aside>
-
-Annual subscriptions are a beta feature. Contact Kinde support at [support@kinde.com](mailto:support@kinde.com) to get it enabled and help us test it.
-
-</Aside>
 
 To give customers a yearly option at a fixed annual price, turn on **Offer as annual** and set the **Annual price**. 
 

--- a/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
@@ -27,7 +27,7 @@ keywords:
   - "PCI DSS"
   - "legal compliance"
   - "data rights"
-updated: "2026-06-24"
+updated: "2025-01-27"
 featured: false
 deprecated: false
 ai_summary: "Comprehensive privacy policy covering data collection, processing, storage, and user rights under Australian Privacy Principles and GDPR for both customers and external users of Kinde's platform."
@@ -38,8 +38,6 @@ Kinde Australia Pty Ltd ([ABN 11 655 096 263](https://abr.business.gov.au/ABN/Vi
 This Privacy Policy sets out our commitment to protecting the privacy of personal information provided to us, or collected by us, when interacting with you.
 
 In this Privacy Policy, we may refer to you as our direct customer (**Customer**) or you as a customer of our customer (**External User**).
-
-If you're a **Customer**, Kinde is the data controller of your personal information. If you're an **External User**, the business whose app you're using is the data controller; Kinde only processes your data on their behalf. Check their privacy policy for details, or email us at privacy@kinde.com and we'll help.
 
 Information about Australia’s privacy guidance can be found from the [Office of the Australian Information Commissioner](https://www.oaic.gov.au/) (**OAIC**).
 
@@ -271,6 +269,6 @@ We may, at any time and at our discretion, vary this Privacy Policy by publishin
 
 For any questions or notices, please contact us at [privacy@kinde.com](mailto:privacy@kinde.com).
 
-Last updated June 24, 2026.
+Last updated June 12, 2025.
 
 Kinde Australia Pty Ltd ([ABN 11 655 096 263](https://abr.business.gov.au/ABN/View?abn=11655096263))

--- a/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/privacy-policy.mdx
@@ -27,7 +27,7 @@ keywords:
   - "PCI DSS"
   - "legal compliance"
   - "data rights"
-updated: "2025-01-27"
+updated: "2026-06-24"
 featured: false
 deprecated: false
 ai_summary: "Comprehensive privacy policy covering data collection, processing, storage, and user rights under Australian Privacy Principles and GDPR for both customers and external users of Kinde's platform."
@@ -38,6 +38,8 @@ Kinde Australia Pty Ltd ([ABN 11 655 096 263](https://abr.business.gov.au/ABN/Vi
 This Privacy Policy sets out our commitment to protecting the privacy of personal information provided to us, or collected by us, when interacting with you.
 
 In this Privacy Policy, we may refer to you as our direct customer (**Customer**) or you as a customer of our customer (**External User**).
+
+If you're a **Customer**, Kinde is the data controller of your personal information. If you're an **External User**, the business whose app you're using is the data controller; Kinde only processes your data on their behalf. Check their privacy policy for details, or email us at privacy@kinde.com and we'll help.
 
 Information about Australia’s privacy guidance can be found from the [Office of the Australian Information Commissioner](https://www.oaic.gov.au/) (**OAIC**).
 
@@ -269,6 +271,6 @@ We may, at any time and at our discretion, vary this Privacy Policy by publishin
 
 For any questions or notices, please contact us at [privacy@kinde.com](mailto:privacy@kinde.com).
 
-Last updated June 12, 2025.
+Last updated June 24, 2026.
 
 Kinde Australia Pty Ltd ([ABN 11 655 096 263](https://abr.business.gov.au/ABN/View?abn=11655096263))


### PR DESCRIPTION
## Summary

Billing **free trials** are now generally available. This removes the beta markers and "contact support to enable" language from the trial docs.

Per the docs convention, GA features simply omit beta language (there's no explicit GA badge), so this deletes the trial beta callouts and inline notes.

**Annual subscriptions remain in beta** — combined callouts that mentioned both trials and annual subscriptions are reworded to reference annual subscriptions only.

## Changes

- `free-trials.mdx` — removed top beta `<Aside>` and the "must be enabled / beta feature" prerequisite bullet
- `about-plans.mdx` — removed trial beta `<Aside>`
- `create-plans.mdx` — removed trial beta `<Aside>` under "Configure trial period"
- `kinde-billing-faqs.mdx` — removed beta sentence; reworded "Once enabled" → "To set up a trial"; limitations note now references annual subscriptions only
- `about-billing.mdx` — dropped `(beta)` from trial bullet; shared callout reworded to annual subscriptions only

## Verification

- No remaining `trial` + `beta` co-mentions in `src/content/docs/billing`
- All surviving `beta` references are annual-subscriptions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated billing documentation for clearer plan setup and pricing guidance, including consistent explanations of billing intervals and fixed vs usage-based pricing terminology.
  * Refreshed “About billing” and “Billing concepts & terms” content and metadata, with expanded descriptions of billing capabilities and limitations.
  * Simplified trial-period instructions by removing outdated beta enablement notices across relevant pages.
  * Improved “Create billing plans” guidance with a dedicated billing interval section and clearer annual subscription behavior, plus refreshed FAQ answers and updated plan-page callouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->