### PR TITLE
docs: add self-serve organization member invitations

### DIFF
--- a/src/content/docs/authenticate/custom-configurations/accepting-an-invitation.mdx
+++ b/src/content/docs/authenticate/custom-configurations/accepting-an-invitation.mdx
@@ -25,7 +25,7 @@ keywords:
   - organization members
   - invited users
   - sign-up
-  - self sign-up
+  - self-sign up
 updated: 2026-06-25
 ---
 
@@ -39,7 +39,7 @@ When someone accepts an organization invitation, Kinde tailors the registration 
 
 - **Prefilled details** — the first name, last name, and email from the invitation are pre-populated on the registration form, so the invited user doesn't retype them.
 - **Locked email** — the invited email address is read-only and can't be changed, so the invitation can't be redirected to a different address. The "use phone instead" option is hidden in this flow for the same reason.
-- **Sign-up allowed even when self-registration is off** — invited users can complete registration even when the environment has self-sign-up disabled. Organization-level "Allow registrations" still applies when an organization is in context.
+- **Sign-up allowed even when self-sign up is off** — invited users can complete registration even when the environment has self-sign up disabled. Organization-level "Allow registrations" still applies when an organization is in context.
 
 ## Invitation error states
 

--- a/src/content/docs/authenticate/custom-configurations/accepting-an-invitation.mdx
+++ b/src/content/docs/authenticate/custom-configurations/accepting-an-invitation.mdx
@@ -1,0 +1,50 @@
+---
+page_id: 64a63325-8ede-4d11-89be-3fdeb7778124
+title: Accepting an invitation
+sidebar:
+  order: 5
+relatedArticles:
+  - 66e7bda8-bc17-463b-8b63-980bccf57e86
+  - a2668524-5842-4c68-ab50-30b7e8c3e842
+description: >-
+  How Kinde tailors the sign-up experience for users invited into an
+  organization, including prefilled details, locked email, and invitation error
+  states.
+featured: false
+deprecated: false
+topics:
+  - authenticate
+sdk: []
+languages: []
+audience:
+  - developer
+  - product-manager
+complexity: beginner
+keywords:
+  - invitations
+  - organization members
+  - invited users
+  - sign-up
+  - self sign-up
+updated: 2026-06-25
+---
+
+When organization members invite other people into their organization, the invitees complete sign-up through a tailored registration experience. This page covers what an invited user sees.
+
+To enable invitations, see [Set global access policies](/build/set-up-options/access-policies/) and [Enable self-serve portal for orgs](/build/self-service-portal/self-serve-portal-for-orgs/).
+
+## How invited users complete sign-up
+
+When someone accepts an organization invitation, Kinde tailors the registration experience to the invitation:
+
+- **Prefilled details** — the first name, last name, and email from the invitation are pre-populated on the registration form, so the invited user doesn't retype them.
+- **Locked email** — the invited email address is read-only and can't be changed, so the invitation can't be redirected to a different address. The "use phone instead" option is hidden in this flow for the same reason.
+- **Sign-up allowed even when self-registration is off** — invited users can complete registration even when the environment has self-sign-up disabled. Organization-level "Allow registrations" still applies when an organization is in context.
+
+## Invitation error states
+
+To keep invitation status private, Kinde shows consistent messages rather than revealing exactly what's wrong with a code:
+
+- **Invitation disabled** — shown when invitations are turned off for the environment, or the configured invite application is misconfigured. See [Set global access policies](/build/set-up-options/access-policies/).
+- **Invitation already accepted** — shown when an invitation code is unknown, expired, or already used. The same message is used for all of these, so the validity of a code can't be inferred.
+- **Invitation email mismatch** — shown when the email submitted during sign-up doesn't match the invited email address.

--- a/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
+++ b/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
@@ -1,6 +1,6 @@
 ---
 page_id: 66e7bda8-bc17-463b-8b63-980bccf57e86
-title: Disable self sign-up
+title: Disable self-sign up
 sidebar:
   order: 2
 relatedArticles:
@@ -12,13 +12,14 @@ app_context:
     s: authentication
   - m: settings
     s: environment_details
-description: >-
-  Guide to disabling self sign-up for your business or specific organizations,
-  allowing only selective user addition via import, manual addition, or API.
+description: "Disable self-sign up for invitation-only apps—set environment-wide or per-organization access policies in Kinde"
 featured: false
 deprecated: false
 topics:
   - authenticate
+  - custom-configurations
+  - access-policies
+  - user-management
 sdk: []
 languages: []
 audience:
@@ -28,36 +29,39 @@ audience:
 complexity: beginner
 keywords:
   - disable sign-up
-  - self sign-up
+  - self-sign up
   - invitation only
-  - user management
+  - access policies
   - organization policies
-updated: 2026-06-25
+  - allow self-sign up
+  - user import
+ai_summary: "Dashboard guide to disabling self-sign up at the environment or organization level in Kinde. Covers switching off the Allow self-sign up policy under Settings > Environment > Policies, and disabling self-sign up per organization by turning off Allow org members to be auto-added under Organizations > Policies. Notes that invited users can still complete sign-up when self-sign up is disabled at the environment level, with a link to the accepting an invitation guide. Explains alternatives for adding users when sign-up is blocked: bulk import, manual user creation in the dashboard, and the Kinde Management API. Mentions per-organization self-sign up management on supported plans. Intended for developers, product managers, and enterprise administrators configuring invitation-only or admin-managed access models."
+updated: 2026-07-01
 ---
 
 You can prevent users from signing up to your business, and only add users selectively.
 
 You might do this if you only want to give access to employees or members.
 
-Disabling sign-ups applies across an environment. Depending on your Kinde plan, you may can also [manage sign-ups per organization](/build/organizations/allow-user-signup-org/).
+Disabling self-sign up applies across an environment. Depending on your Kinde plan, you can also [manage self-sign up per organization](/build/organizations/allow-user-signup-org/).
 
-## Disable self sign-up for your business
+## Disable self-sign up for your business
 
 1. Go to **Settings > Environment > Policies**.
-2. Switch off the **Allow self-sign up** option.
+2. Switch off the **Allow self-sign up** option.
 
-You can then [import users](/manage-users/add-and-edit/import-users-in-bulk/), [add them manually](/manage-users/add-and-edit/add-and-edit-users/), or add them [via the Kinde API](/kinde-apis/management#tag/users/post/api/v1/user).
+You can then [import users](/manage-users/add-and-edit/import-users-in-bulk/), [add them manually](/manage-users/add-and-edit/add-and-edit-users/), or add them [via the Kinde API](/kinde-apis/management#tag/users/post/api/v1/user).
 
-Users who receive an organization invitation can still complete sign-up even when self sign-up is disabled. See [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
+Users who receive an organization invitation can still complete sign-up even when self-sign up is disabled. See [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
 
-## Disable self sign-up to an organization
+## Disable self-sign up for an organization
 
-You can disable self sign-up per organization.
+You can disable self-sign up per organization.
 
-However, if you allow self sign-up in your business (and have not disabled it as per the above procedure), at least one organization must allow sign-ups.
+However, if you allow self-sign up in your business (and have not disabled it as per the above procedure), at least one organization must allow self-sign up.
 
 1. Go to **Organizations**.
-2. Select the organization you want to disable sign-ups for.
+2. Select the organization you want to disable self-sign up for.
 3. Go to **Policies**.
 4. Switch off the **Allow org members to be auto-added** option.
 5. Select **Save**.

--- a/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
+++ b/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
@@ -35,7 +35,7 @@ keywords:
   - organization policies
   - allow self-sign up
   - user import
-ai_summary: "Dashboard guide to disabling self-sign up at the environment or organization level in Kinde. Covers switching off the Allow self-sign up policy under Settings > Environment > Policies, and disabling self-sign up per organization by turning off Allow org members to be auto-added under Organizations > Policies. Notes that invited users can still complete sign-up when self-sign up is disabled at the environment level, with a link to the accepting an invitation guide. Explains alternatives for adding users when sign-up is blocked: bulk import, manual user creation in the dashboard, and the Kinde Management API. Mentions per-organization self-sign up management on supported plans. Intended for developers, product managers, and enterprise administrators configuring invitation-only or admin-managed access models."
+ai_summary: "Dashboard guide to disabling self-sign up at the environment or organization level in Kinde. Covers switching off the Allow self-sign up policy under Settings > Environment > Policies, and disabling self-sign up per organization by turning off Allow org members to be auto-added under Organizations > Policies. Notes that invited users can still complete sign-up when self-sign up is disabled at the environment level, with a link to the invited user sign-up experience guide. Explains alternatives for adding users when sign-up is blocked: bulk import, manual user creation in the dashboard, and the Kinde Management API. Mentions per-organization self-sign up management on supported plans. Intended for developers, product managers, and enterprise administrators configuring invitation-only or admin-managed access models."
 updated: 2026-07-01
 ---
 
@@ -52,7 +52,7 @@ Disabling self-sign up applies across an environment. Depending on your Kinde pl
 
 You can then [import users](/manage-users/add-and-edit/import-users-in-bulk/), [add them manually](/manage-users/add-and-edit/add-and-edit-users/), or add them [via the Kinde API](/kinde-apis/management#tag/users/post/api/v1/user).
 
-Users who receive an organization invitation can still complete sign-up even when self-sign up is disabled. See [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
+Users who receive an organization invitation can still complete sign-up even when self-sign up is disabled. See [Invited user sign-up experience](/authenticate/custom-configurations/invited-user-experience/).
 
 ## Disable self-sign up for an organization
 

--- a/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
+++ b/src/content/docs/authenticate/custom-configurations/disable-sign-up.mdx
@@ -32,7 +32,7 @@ keywords:
   - invitation only
   - user management
   - organization policies
-updated: 2025-01-16
+updated: 2026-06-25
 ---
 
 You can prevent users from signing up to your business, and only add users selectively.
@@ -47,6 +47,8 @@ Disabling sign-ups applies across an environment. Depending on your Kinde plan, 
 2. Switch off the **Allow self-sign up** option.
 
 You can then [import users](/manage-users/add-and-edit/import-users-in-bulk/), [add them manually](/manage-users/add-and-edit/add-and-edit-users/), or add them [via the Kinde API](/kinde-apis/management#tag/users/post/api/v1/user).
+
+Users who receive an organization invitation can still complete sign-up even when self sign-up is disabled. See [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
 
 ## Disable self sign-up to an organization
 

--- a/src/content/docs/authenticate/custom-configurations/invited-user-experience.mdx
+++ b/src/content/docs/authenticate/custom-configurations/invited-user-experience.mdx
@@ -1,19 +1,19 @@
 ---
 page_id: 64a63325-8ede-4d11-89be-3fdeb7778124
-title: Accepting an invitation
+title: Invited user sign-up experience
 sidebar:
   order: 5
 relatedArticles:
   - 66e7bda8-bc17-463b-8b63-980bccf57e86
   - a2668524-5842-4c68-ab50-30b7e8c3e842
-description: >-
-  How Kinde tailors the sign-up experience for users invited into an
-  organization, including prefilled details, locked email, and invitation error
-  states.
+description: "Learn what invited users see at sign-up—prefilled details, locked email, and how invitation errors are handled in Kinde"
 featured: false
 deprecated: false
 topics:
   - authenticate
+  - custom-configurations
+  - invitations
+  - user-management
 sdk: []
 languages: []
 audience:
@@ -21,12 +21,15 @@ audience:
   - product-manager
 complexity: beginner
 keywords:
-  - invitations
-  - organization members
+  - organization invitations
   - invited users
-  - sign-up
-  - self-sign up
-updated: 2026-06-25
+  - invitation sign-up
+  - locked email
+  - prefilled registration
+  - invitation error states
+  - self-sign up disabled
+ai_summary: "Reference guide to the sign-up experience for users invited into a Kinde organization. Explains tailored registration behavior including prefilled first name, last name, and email from the invitation, read-only locked email to prevent redirecting invites to another address, and hidden phone sign-up in this flow. Notes that invited users can complete registration when environment-level self sign-up is disabled, while organization-level Allow registrations still applies when an organization is in context. Documents invitation error states shown to invitees: invitation disabled when invitations are off or the invite application is misconfigured, invitation code not usable for unknown, expired, or already-used codes with a single generic message so validity cannot be inferred, and invitation email mismatch when submitted email does not match the invited address. Links to global access policies and self-serve portal documentation for enabling invitations. No code samples. Intended for developers and product managers designing or supporting organization invitation flows."
+updated: 2026-07-05
 ---
 
 When organization members invite other people into their organization, the invitees complete sign-up through a tailored registration experience. This page covers what an invited user sees.
@@ -46,5 +49,5 @@ When someone accepts an organization invitation, Kinde tailors the registration 
 To keep invitation status private, Kinde shows consistent messages rather than revealing exactly what's wrong with a code:
 
 - **Invitation disabled** — shown when invitations are turned off for the environment, or the configured invite application is misconfigured. See [Set global access policies](/build/set-up-options/access-policies/).
-- **Invitation already accepted** — shown when an invitation code is unknown, expired, or already used. The same message is used for all of these, so the validity of a code can't be inferred.
+- **Invitation code not usable** — shown when a code can't be used, including when it's unknown, expired, or already used. The same user-facing message is shown in every case (which may read "Invitation already accepted"), so the underlying reason can't be inferred.
 - **Invitation email mismatch** — shown when the email submitted during sign-up doesn't match the invited email address.

--- a/src/content/docs/build/self-service-portal/about-self-service-portal.mdx
+++ b/src/content/docs/build/self-service-portal/about-self-service-portal.mdx
@@ -36,7 +36,7 @@ There's two types of portal: one for end users (B2C), and one for organizations 
 
 ## Watch Dave's portal demo in 90 seconds
 
-<YoutubeVideo videoId="Q3HW6Mgj6wA" videoTitle="Customer portal in 90 seconds"/>
+<YoutubeVideo videoId="Q3HW6Mgj6wA" videoTitle="Customer portal in 90 seconds" />
 
 ## Self-serve portal for organizations
 
@@ -45,7 +45,7 @@ In the organization portal, you can allow org members to manage:
 - Account details
 - Payment details (if you have billing set up)
 - API Keys (Paid plans)
-- Members and roles (Coming soon - Paid plans only)
+- [Members and roles](/build/self-service-portal/self-serve-portal-for-orgs/#invite-members-from-the-portal) (Paid plans only)
 - SSO enterprise connections (Coming soon - Kinde Scale plan only)
 
 You can enable all functions or limit them to what you offer. [Set up a self-serve portal for an org](/build/self-service-portal/self-serve-portal-for-orgs/)

--- a/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
+++ b/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
@@ -105,7 +105,7 @@ A member can only invite others and assign roles if they have sufficient permiss
     - Unavailable roles are disabled.
 5. Select **Save**. 
 
-    The person receives an email invitation to join the organization. They can set up a new account or sign in to an existing one to accept. For more on what the invitee sees, see [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
+    The person receives an email invitation to join the organization. They can set up a new account or sign in to an existing one to accept. For more on what the invitee sees, see [Invited user sign-up experience](/authenticate/custom-configurations/invited-user-experience/).
 
 ### Revoke a pending invitation
 

--- a/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
+++ b/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
@@ -1,18 +1,23 @@
 ---
 page_id: a2668524-5842-4c68-ab50-30b7e8c3e842
-title: Enable self-serve portal for orgs
-description: Guide for enabling self-serve portals for organizations including business details management, billing access, permission controls, and portal link generation methods.
+title: Enable self-serve portal for organizations
+description: "Let org admins self-manage billing, members, and settings—configure the portal, invitations, roles, and link generation."
 sidebar:
   order: 2
+  label: Enable self-serve portal for orgs
 relatedArticles:
   - f36bce4a-52bb-4785-865b-6b33356f9838
   - ab20745f-0918-403a-8103-fc5749082dba
+tableOfContents:
+  maxHeadingLevel: 3
 topics:
   - self-serve-portal
   - organizations
+  - member-invitations
   - billing
 sdk:
   - react
+  - kinde-management-api
 languages:
   - javascript
   - jsx
@@ -22,13 +27,15 @@ keywords:
   - organization portal
   - self-serve portal
   - org management
-  - billing portal
+  - member invitations
   - portal permissions
   - organization alias
-updated: 2026-06-25
+  - portal link
+  - kinde management api
+updated: 2026-07-01
 featured: false
 deprecated: false
-ai_summary: Guide for enabling self-serve portals for organizations including business details management, billing access, permission controls, and portal link generation methods.
+ai_summary: "Guide to enabling and configuring the Kinde self-serve portal for organizations (B2B). Covers dashboard setup including return URL, organization alias, and selecting which functions org admins can manage such as business details, payment details, API keys, members and roles, SSO connections, and MFA. Explains how authorized members can invite new users, assign roles with org:write:members and role-based gating, and revoke pending invitations when Members and roles is enabled and environment-level invitations are allowed. Describes portal access control through system permissions such as org:write:billing, custom role assignment, and auto-assignment options. Documents generating one-time portal links via the React PortalLink component, the Account API portal_link endpoint, or the Kinde Management API generate_url endpoint with optional return_url, sub_nav, and organization_code. Notes Scale plan per-organization portal configuration. Intended for developers integrating org portal access into applications."
 ---
 
 You can configure a self-serve portal to enable authorized organization members to be able to self-manage functions provided by Kinde. Authorized org members can update:
@@ -54,6 +61,21 @@ If you are on the Kinde Scale plan, you can configure the [portal per organizati
    ![Options for showing hiding settings for org members](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/5f99fef4-86e5-4a67-5a80-43ae34cbbd00/public)
 5. Select **Save**.
 
+## Portal access control with system permissions
+
+Each core function within the self-serve portal is governed by a corresponding system permission. For example, the `org:write:billing` permission allows users to update billing details.
+
+These permissions can be included in your custom roles and assigned to organization members.
+
+We recommend creating custom roles with varying levels of portal access, which you can then assign as needed. For instance, you might create a role that allows members to view billing details but not update them. You can select these permissions within your existing roles, or when you create them.
+
+![Roles with system permissions for self-serve portal](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1e90e72e-00d5-4063-8d34-79d1a9b8f000/public)
+
+When [configuring org roles](/billing/get-started/add-billing-role/), you can specify whether it should be:
+
+- Automatically assigned to all new organization members.
+- Automatically assigned to the organization creator.
+
 ## Invite members from the portal
 
 When you enable the **Members and roles** function, authorized members can invite other people into their organization directly from the portal, without you adding users manually or via the API.
@@ -75,11 +97,15 @@ A member can only invite others and assign roles if they have sufficient permiss
 
 1. Open the organization portal and go to **Members**.
 2. Select **Add member**.
-3. Enter the new member's **First name**, **Last name**, and **Email**.
-4. Select the **Roles** the member will have in the organization. You can select more than one; unavailable roles are disabled.
-5. Select **Save**. The person receives an email invitation to join the organization. They can set up a new account or sign in to an existing one to accept. For more on what the invitee sees, see [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
 
-{/* TODO: screenshot — Add member dialog in the organization portal showing First name, Last name, Email and Roles fields */}
+    ![add member dialog in the organization portal](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/bf8b9e65-af74-49fb-312f-d626f9a97400/socialsharingimage)
+3. Enter the new member's **First name**, **Last name**, and **Email**.
+4. Select the **Roles** the member will have in the organization. 
+    - You can select more than one.
+    - Unavailable roles are disabled.
+5. Select **Save**. 
+
+    The person receives an email invitation to join the organization. They can set up a new account or sign in to an existing one to accept. For more on what the invitee sees, see [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
 
 ### Revoke a pending invitation
 
@@ -90,22 +116,7 @@ Pending invitations appear in an **Invitations** list on the **Members** screen,
 
 ### When invitations are turned off
 
-If invitations are disabled for the environment, the **Add member** option and the **Invitations** list are hidden, and opening the add-member screen shows an "Invitations are disabled" message.
-
-## Portal access control with system permissions
-
-Each core function within the self-serve portal is governed by a corresponding system permission. For example, the `org:write:billing` permission allows users to update billing details.
-
-These permissions can be included in your custom roles and assigned to organization members.
-
-We recommend creating custom roles with varying levels of portal access, which you can then assign as needed. For instance, you might create a role that allows members to view billing details but not update them. You can select these permissions within your existing roles, or when you create them.
-
-![Roles with system permissions for self-serve portal](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1e90e72e-00d5-4063-8d34-79d1a9b8f000/public)
-
-When [configuring org roles](/billing/get-started/add-billing-role/), you can specify whether it should be:
-
-- Automatically assigned to all new organization members.
-- Automatically assigned to the organization creator.
+If invitations are disabled for the environment, the **Add member** option and the **Invitations** list are hidden in the portal when members browse **Members** normally. A bookmarked or direct URL to the add-member screen still loads that page and shows an "Invitations are disabled" message instead of the invite form.
 
 ## Generate the self-serve portal link
 

--- a/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
+++ b/src/content/docs/build/self-service-portal/self-serve-portal-for-orgs.mdx
@@ -25,7 +25,7 @@ keywords:
   - billing portal
   - portal permissions
   - organization alias
-updated: 2025-11-12
+updated: 2026-06-25
 featured: false
 deprecated: false
 ai_summary: Guide for enabling self-serve portals for organizations including business details management, billing access, permission controls, and portal link generation methods.
@@ -36,7 +36,7 @@ You can configure a self-serve portal to enable authorized organization members 
 - [Business details](/manage-your-account/business-information/update-your-details/)
 - [Payment details](/manage-your-account/profile-and-plan/update-kinde-payment/) (if you have billing set up)
 - [API Keys](/manage-your-apis/add-manage-api-keys/self-serve-api-keys/)
-- Members and roles
+- [Members and roles](#invite-members-from-the-portal) — invite new members into the organization, assign their roles, and revoke pending invitations
 - [SSO enterprise connections](/authenticate/self-serve-sso/add-sso-self-serve/) (in beta)
 - Multi-factor auth settings (coming soon)
 
@@ -53,6 +53,44 @@ If you are on the Kinde Scale plan, you can configure the [portal per organizati
 4. In the **Organization profile** section, select the functions you want organization admins to be able to manage.
    ![Options for showing hiding settings for org members](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/5f99fef4-86e5-4a67-5a80-43ae34cbbd00/public)
 5. Select **Save**.
+
+## Invite members from the portal
+
+When you enable the **Members and roles** function, authorized members can invite other people into their organization directly from the portal, without you adding users manually or via the API.
+
+<Aside>
+
+Member invitations must also be enabled at the environment level. Go to **Settings > Environment > Policies**, switch on **Allow invitations**, and choose the **Invite application** that invitation links should open. See [Set global access policies](/build/set-up-options/access-policies/).
+
+</Aside>
+
+### Who can invite members
+
+A member can only invite others and assign roles if they have sufficient permission in the organization:
+
+- The member needs the `org:write:members` permission to open the **Add member** flow.
+- Each role in the **Add member** dialog is gated individually—a member can only assign a role if they hold the permission required to grant it. Roles they can't assign appear disabled. This mirrors the role gating used for Kinde team members, so a member can never grant access broader than their own.
+
+### Invite a member
+
+1. Open the organization portal and go to **Members**.
+2. Select **Add member**.
+3. Enter the new member's **First name**, **Last name**, and **Email**.
+4. Select the **Roles** the member will have in the organization. You can select more than one; unavailable roles are disabled.
+5. Select **Save**. The person receives an email invitation to join the organization. They can set up a new account or sign in to an existing one to accept. For more on what the invitee sees, see [Accepting an invitation](/authenticate/custom-configurations/accepting-an-invitation/).
+
+{/* TODO: screenshot — Add member dialog in the organization portal showing First name, Last name, Email and Roles fields */}
+
+### Revoke a pending invitation
+
+Pending invitations appear in an **Invitations** list on the **Members** screen, showing each invitee's name, email, role, and the date invited.
+
+1. Find the invitation in the **Invitations** list.
+2. Select the actions menu next to it, then select **Revoke invitation**.
+
+### When invitations are turned off
+
+If invitations are disabled for the environment, the **Add member** option and the **Invitations** list are hidden, and opening the add-member screen shows an "Invitations are disabled" message.
 
 ## Portal access control with system permissions
 
@@ -71,7 +109,7 @@ When [configuring org roles](/billing/get-started/add-billing-role/), you can sp
 
 ## Generate the self-serve portal link
 
-Access to the portal is granted via a one-time link. You then use the link on an 'account' or 'profile' button in your app to open the Kinde portal screens. 
+Access to the portal is granted via a one-time link. You then use the link on an 'account' or 'profile' button in your app to open the Kinde portal screens.
 
 There are two main ways to generate this link:
 

--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -1,62 +1,127 @@
 ---
 page_id: 10d87520-542b-4881-9d63-9b7128766e60
-title: Set global access policies
-description: Guide for setting global access policies including self-signup controls, domain restrictions, organization creation, and social profile synchronization settings.
+title: Set global access policies for your business
+description: "Control how users join and sign in—set global policies for sign-up, domains, org creation, invitations, and MFA"
 sidebar:
   order: 6
+  label: Set global access policies
 relatedArticles:
   - bc69e746-1ade-4433-8b0f-f2bc7d8a7a6a
   - 43e8aa2d-76a4-4445-ae90-84d3f1a55fcb
+tableOfContents:
+  maxHeadingLevel: 3
 topics:
   - access-policies
+  - organizations
   - security
   - user-management
 sdk: []
 languages: []
-audience: developers
+audience:
+  - developers
+  - product-manager
+  - business owners
 complexity: intermediate
 keywords:
-  - access policies
+  - global access policies
+  - self sign-up
   - domain restrictions
-  - self signup
   - organization creation
-  - social profile sync
-  - global policies
-updated: 2026-06-25
+  - member invitations
+  - passkeys
+  - profile sync
+  - MFA OTP expiration
+updated: 2026-07-01
 featured: false
 deprecated: false
-ai_summary: Guide for setting global access policies including self-signup controls, domain restrictions, organization creation, and social profile synchronization settings.
+ai_summary: "Guide to configuring global access policies at the environment level in Kinde via Settings > Environment > Policies. Explains how settings apply to all organizations by default and can be overridden per organization on the Kinde Scale plan. Covers allowing or disabling self sign-up, restricting sign-up to allowed email domains, enabling organization creation during registration for B2B self-serve onboarding, signing users into their most recent organization, passkeys on paid plans, syncing user profiles from social and enterprise identity providers on sign-in, MFA and OTP code expiration duration, and member invitations including invite application selection. Includes a quick reference table for common policy combinations and links to related guides for per-organization policies, disabling sign-up, organization creation flows, and the self-serve portal. Intended for business owners, product managers, and developers configuring onboarding and authentication access rules."
 ---
 
-This topic is about setting user access policies at the environment level. If you want to apply user access policies per organization, see [Set access policies for an organization](/build/organizations/organization-access-policies/)
+Access policies are the ground rules for who can join your product and how sign-in works across your entire Kinde environment. Settings here apply to every organization by default, so they are the first place to shape onboarding, security, and the experience your customers have when they register or sign in.
 
-This topic covers the following tasks:
+With access policies, you can:
 
-- Allow anyone to sign-up for an account
-- Create an organization when someone signs up (for B2B businesses usually)
-- Allow only users from specific domains to sign up (i.e. restrict sign up based on email domain)
-- Enable profiles from social providers to sync with Kinde profiles (recommended if you allow social sign in)
+- Allow anyone to sign up for an account
+- Create an organization when someone signs up (usually for B2B businesses)
+- Allow only users from specific domains to sign up (e.g., @yourdomain.com only)
+- Enable profiles from social providers to sync with Kinde profiles (recommended if you allow social sign-in)
+
+If you need different rules for specific customers, you can override these defaults per organization on the [Kinde Scale plan](https://kinde.com/pricing/). See [Set access policies for an organization](/build/organizations/organization-access-policies/).
 
 ## Set policies for all organizations
 
 1. In Kinde, go to **Settings > Environment > Policies**.
-2. If you want users to be able to sign up or register to your application, select **Allow self sign-up**.
-3. If you want to restrict which domains can sign up to your applications, enter domains in the **Allowed domains** list. Use the format `domain.com` and not `https://www.domain.com`. If you leave this empty, users from any domain can sign up.
-4. Choose if you want to **Allow organization creation on sign up**. This is common for B2B businesses.
-5. Select **Sync user profiles on sign in** if you want to keep basic user profile data provided by third-party sources (like Google, GitHub, etc.) in sync with Kinde profiles. You only need to select this if you allow sign-up and sign-in using social providers.
-6. Configure how long authentication codes remain valid using the **MFA/OTP Code expiration duration** setting. Set shorter expiry times for higher security environments, or extend them for workflows where users need more time. The expiry duration now appears in your email templates automatically. The default is 120 minutes (2 hours).
-7. Select **Save**.
+2. Make the required changes and select **Save** when you're done.
 
-## Invitations
+### Allow self sign-up
 
-If member invitations are available on your plan, an **Invitations** section appears on the **Policies** page. These settings control whether organization members can invite other people into their organization, and which application invitation links open.
+Let people create their own accounts without you adding them manually. **Allow self sign-up** is enabled by default.
 
-1. Go to **Settings > Environment > Policies**.
-2. Switch on **Allow invitations** to let users invite others into their organization.
-3. In **Invite application**, select the application that invitation links should use. The list contains your standard **Front-end and mobile** and **Back-end web** applications. This determines where invited users land when they accept an invitation.
-4. Select **Save**.
+Turn this off if you want an invitation-only or admin-managed model—for example, internal tools, enterprise customers you onboard yourself, or apps where every user must be approved first. You can still add users manually, import them, or send invitations. See [Disable self sign-up](/authenticate/custom-configurations/disable-sign-up/).
 
-When **Allow invitations** is off, invitation features are hidden across the organization self-serve portal, and any attempt to accept an existing invitation is blocked.
+### Allowed domains
+
+Limit sign-up to specific email domains—for example, only `@yourcompany.com` for an internal app, or `@partner.com` for a partner portal.
+
+Enter domains in the **Allowed domains** list. This only applies when **Allow self sign-up** is enabled.
+
+- Use the format `domain.com` and not `https://www.domain.com`.
+- If you leave this empty, users from any domain can sign up.
+
+On the [Kinde Scale plan](https://kinde.com/pricing/), you can also set domain restrictions per organization. See [Set access policies for an organization](/build/organizations/organization-access-policies/).
+
+### Allow organization creation on sign up
+
+Let new customers create their own organization (workspace, account, team—whatever you call it in your product) when they register. This is the foundation of self-serve B2B onboarding: a company signs up, gets its own organization, and becomes the first admin.
+
+Switch this on if you offer a "Start free trial" or "Create your workspace" flow where each customer is a separate business. Switch it off if you create organizations yourself—for example, when you provision accounts for enterprise customers or manage all organizations in the Kinde dashboard.
+
+Your application must route users through the organization-creation sign-up flow for this to take effect. If you have developers on your team, see [Allow organization creation on sign up](/build/organizations/allow-org-create-on-signup/) and [Organizations for developers](/build/organizations/orgs-for-developers/).
+
+### Sign users in to most recent org
+
+When someone belongs to more than one organization, Kinde normally shows an organization picker at sign-in. Enable **Sign users in to most recent org** to skip that screen and sign them straight into the organization they used last.
+
+This works well if your app already has its own organization switcher and you want returning users to land in their last workspace without an extra step. Leave it off if you want users to choose their organization on every sign-in, or if most of your users only belong to one organization.
+
+See [Sign users in to last organization](/authenticate/manage-authentication/sign-in-to-last-org/) for more details.
+
+### Passkeys
+
+<Aside type="upgrade">
+Passkeys require a [Kinde paid plan](https://kinde.com/pricing/).
+</Aside>
+
+Passkeys let users sign in with biometrics (Face ID, fingerprint) or a device PIN instead of typing a password. They are more secure than passwords alone and faster for users who sign in regularly.
+
+### Sync user profiles on sign in
+
+When users sign in through a social provider (Google, GitHub, etc.) or an [enterprise connection](/authenticate/enterprise-connections/about-enterprise-connections/) (Microsoft Entra ID, SAML, and so on), Kinde can refresh their profile details—such as name, email, and picture—from that provider each time they sign in.
+
+Switch this on to keep user records accurate when people update their details at their identity provider. This is especially important if you rely on enterprise SSO, where profile data is managed outside Kinde.
+
+Leave it on if you use social or enterprise sign-in. You only need to switch it off if you intentionally manage profile data only within Kinde and do not want external updates to overwrite it.
+
+Some enterprise connections also have their own profile sync setting—both the global policy here and the connection setting need to be enabled for sync to work. See [About users](/manage-users/about/).
+
+### MFA/OTP Code expiration duration
+
+When users receive a one-time code by email or SMS—for multi-factor authentication, passwordless sign-in, or password reset—this setting controls how long the code stays valid.
+
+- The default expiry duration is 120 minutes (2 hours).
+- The expiry duration appears in your email templates automatically.
+- Set a shorter duration for higher-security environments.
+- Extend it if users often need more time to check their inbox or phone—for example, in regions with slower SMS delivery.
+
+### Invitations
+
+If member invitations are available on your plan, an **Invitations** section appears on the **Policies** page. These settings control whether organization members can invite other people into their organization and which application handles invitation links.
+
+Switch on **Allow invitations** to let users invite others into their organization.
+
+In **Invite application**, select the application that invitation links should use. The list contains your standard **Front-end and mobile** and **Back-end web** applications. This determines where invited users land when they accept an invitation.
+
+When **Allow invitations** is disabled, invitation features are hidden across the organization self-serve portal, and any attempt to accept an existing invitation is blocked.
 
 <Aside type="warning">
 
@@ -72,11 +137,11 @@ This setting works together with the **Members and roles** function of the organ
 
 ## Policy setting quick reference
 
-Note that global access policies can be overriden at the individual organization level if you are on a [Kinde Scale plan](https://kinde.com/pricing/) and activate the Advanced organization feature.
+Global access policies can be overridden at the individual organization level if you are on a [Kinde Scale plan](https://kinde.com/pricing/) and activate the Advanced organization feature.
 
 | To…                                                                                             | Do this…                                                                                          |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | Allow anyone to sign up to your applications.                                                   | Select **Allow self sign-up**.                                                                    |
-| Allow only people from `specificdomain.com` to sign up to your applications.                    | Select **Allow self sign-up** and enter the specificdomain.com into the **Allowed domains** list. |
+| Allow only people from `specificdomain.com` to sign up to your applications.                    | Select **Allow self sign-up** and enter `specificdomain.com` in the **Allowed domains** list. |
 | Allow anyone to sign up to your applications and create an organization if they are a business. | Select **Allow self sign-up** and **Allow organization creation on sign up**.                     |
 | Let organization members invite other people into their organization.                           | Select **Allow invitations** and choose an **Invite application**.                                |

--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -22,7 +22,7 @@ keywords:
   - organization creation
   - social profile sync
   - global policies
-updated: 2026-01-30
+updated: 2026-06-25
 featured: false
 deprecated: false
 ai_summary: Guide for setting global access policies including self-signup controls, domain restrictions, organization creation, and social profile synchronization settings.
@@ -31,7 +31,8 @@ ai_summary: Guide for setting global access policies including self-signup contr
 This topic is about setting user access policies at the environment level. If you want to apply user access policies per organization, see [Set access policies for an organization](/build/organizations/organization-access-policies/)
 
 This topic covers the following tasks:
-- Allow anyone to sign-up for an account 
+
+- Allow anyone to sign-up for an account
 - Create an organization when someone signs up (for B2B businesses usually)
 - Allow only users from specific domains to sign up (i.e. restrict sign up based on email domain)
 - Enable profiles from social providers to sync with Kinde profiles (recommended if you allow social sign in)
@@ -46,6 +47,29 @@ This topic covers the following tasks:
 6. Configure how long authentication codes remain valid using the **MFA/OTP Code expiration duration** setting. Set shorter expiry times for higher security environments, or extend them for workflows where users need more time. The expiry duration now appears in your email templates automatically. The default is 120 minutes (2 hours).
 7. Select **Save**.
 
+## Invitations
+
+If member invitations are available on your plan, an **Invitations** section appears on the **Policies** page. These settings control whether organization members can invite other people into their organization, and which application invitation links open.
+
+1. Go to **Settings > Environment > Policies**.
+2. Switch on **Allow invitations** to let users invite others into their organization.
+3. In **Invite application**, select the application that invitation links should use. The list contains your standard **Front-end and mobile** and **Back-end web** applications. This determines where invited users land when they accept an invitation.
+4. Select **Save**.
+
+When **Allow invitations** is off, invitation features are hidden across the organization self-serve portal, and any attempt to accept an existing invitation is blocked.
+
+<Aside type="warning">
+
+If invitations are enabled but the selected **Invite application** is missing or not fully configured (no initiate-login URL), invitation links are blocked and the invitee sees an error. Make sure the chosen application has a valid login URL configured.
+
+</Aside>
+
+<Aside>
+
+This setting works together with the **Members and roles** function of the organization self-serve portal. See [Enable self-serve portal for orgs](/build/self-service-portal/self-serve-portal-for-orgs/).
+
+</Aside>
+
 ## Policy setting quick reference
 
 Note that global access policies can be overriden at the individual organization level if you are on a [Kinde Scale plan](https://kinde.com/pricing/) and activate the Advanced organization feature.
@@ -55,3 +79,4 @@ Note that global access policies can be overriden at the individual organization
 | Allow anyone to sign up to your applications.                                                   | Select **Allow self sign-up**.                                                                    |
 | Allow only people from `specificdomain.com` to sign up to your applications.                    | Select **Allow self sign-up** and enter the specificdomain.com into the **Allowed domains** list. |
 | Allow anyone to sign up to your applications and create an organization if they are a business. | Select **Allow self sign-up** and **Allow organization creation on sign up**.                     |
+| Let organization members invite other people into their organization.                           | Select **Allow invitations** and choose an **Invite application**.                                |

--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -60,7 +60,7 @@ When **Allow invitations** is off, invitation features are hidden across the org
 
 <Aside type="warning">
 
-If invitations are enabled but the selected **Invite application** is missing or not fully configured (no initiate-login URL), invitation links are blocked and the invitee sees an error. Make sure the chosen application has a valid login URL configured.
+If invitations are enabled but the selected **Invite application** is missing or not fully configured (no **Application login URI**), invitation links are blocked and the invitee sees an error. Make sure the chosen application has a valid login URL configured.
 
 </Aside>
 


### PR DESCRIPTION
## Summary

Documents the new **self-serve organization member invitations** feature: authorized org members can invite other people into their own organization from the self-serve portal, gated by a new environment-level policy. Covers three customer-facing surfaces.

### Changes

**1. Org self-serve portal** — `self-serve-portal-for-orgs.mdx`
- Updated the "Members and roles" manageable-function item
- New `## Invite members from the portal` section: who can invite (`org:write:members` + per-role gating), how to invite, revoking a pending invitation, and behavior when invitations are off

**2. Environment Policies** — `access-policies.mdx`
- New `## Invitations` section (Allow invitations toggle + Invite application selector, off-state behavior, misconfigured-app warning)
- Added a quick-reference table row

**3. New page** — `accepting-an-invitation.mdx`
- Standalone page under Auth & access > Custom configurations covering the invited-user sign-up experience (prefilled/locked fields, sign-up when self-registration is off) and the three invitation error states

**Cross-references**
- `about-self-service-portal.mdx`: removed "Coming soon" from Members and roles, linked to the portal section
- `disable-sign-up.mdx`: added a pointer that invited users can still complete sign-up

### Conventions
Uses repo conventions throughout: `<Aside>` callouts, absolute `/` links, `##`/`###` headings, full YAML frontmatter, `updated: 2026-06-25`. Files run through the repo's prettier lint.

### Verification
- `npm run build` passes; the new page renders. Only pre-existing/unrelated build warnings remain.

### Follow-ups (owned by docs/design)
- Exact live English copy for the three error states (resolved at runtime from the translations store, not in this repo)
- Actual screenshot for the Add member dialog (placeholder TODO left in the MDX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for self sign-up controls, including environment-wide and organization-level settings.
  * Added a new page explaining the invited-user sign-up experience and invitation-based registration flow.
  * Updated self-service portal docs with clearer member, role, and invitation details.
  * Reworked access policy docs with broader setup guidance, new policy topics, and a quick reference for invitation settings.
  * Improved links, formatting, and metadata across the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->