### PR TITLE
docs: improve passwordless testing guides (Playwright + Cypress)

### DIFF
--- a/src/content/docs/testing/cypress/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/cypress/test-passwordless-flows.mdx
@@ -25,18 +25,26 @@ keywords:
   - magic link
   - email OTP
   - Mailosaur
-updated: 2026-04-14
+updated: 2026-07-17
 featured: false
 deprecated: false
 ---
 
-This guide shows you how to automate passwordless authentication testing with Cypress using Mailosaur. Learn more about [testing passwordless flows with Kinde](/testing/testing-passwordless-flows/).
+This guide shows you how to automate passwordless authentication testing with Cypress by intercepting the one-time code email. Learn more about [testing passwordless flows with Kinde](/testing/testing-passwordless-flows/).
+
+The examples use Mailosaur, but any inbox service with an API for reading emails programmatically (for example [MailSlurp](https://www.mailslurp.com/) or [Mailtrap](https://mailtrap.io/)) works the same way: give each test a unique inbox, wait for the code email, extract the code, and enter it in the form.
+
+Kinde one-time codes are always 6 digits, are generated fresh for every request, and expire after 2 hours (120 minutes) by default (configurable per environment). There is no static "test code": intercepting the real email is the supported way to automate these flows.
 
 ### What you need 
 
 - Completed the [Cypress setup](/testing/cypress/)
 - A [test user](/testing/setup-test-user-environment/) and a running Kinde application.
 - A [Mailosaur](https://mailosaur.com/) account (Sign up for free trial)
+
+## Keep OTP tests lean
+
+Waiting on real email delivery is the slowest and most failure-prone part of any test suite. We recommend covering the passwordless UI with a small number of smoke tests, and authenticating the rest of your suite another way: reuse authenticated state with `cy.session` (see [Test authenticated features](/testing/cypress/test-auth-features/)), use an email + password test user, or use a machine-to-machine (M2M) application for API-level setup.
 
 ## Setup Mailosaur
 
@@ -74,9 +82,16 @@ This guide shows you how to automate passwordless authentication testing with Cy
     // cypress/support/utils/mailosaur.js
     const MailosaurClient = require('mailosaur')
 
-    async function getOTPFromEmail(email, apiKey, serverId) {
+    async function getOTPFromEmail(email, apiKey, serverId, receivedAfter) {
       const mailosaur = new MailosaurClient(apiKey)
-      const message = await mailosaur.messages.get(serverId, { sentTo: email })
+      // Pass receivedAfter (an ISO string) when a test reuses an inbox across
+      // runs, so you never pick up a stale code from a previous run's email.
+      const message = await mailosaur.messages.get(
+        serverId,
+        { sentTo: email },
+        { receivedAfter: receivedAfter ? new Date(receivedAfter) : undefined }
+      )
+      // Kinde codes are always exactly 6 digits
       const otpMatch = message.text?.body?.match(/\b(\d{6})\b/)
       const otpCode = otpMatch?.[1]
 
@@ -113,8 +128,8 @@ This guide shows you how to automate passwordless authentication testing with Cy
         baseUrl: 'http://localhost:3000',
         setupNodeEvents(on, config) {
           on('task', {
-            async getOTPFromEmail({ email, apiKey, serverId }) {
-              return await getOTPFromEmail(email, apiKey, serverId)
+            async getOTPFromEmail({ email, apiKey, serverId, receivedAfter }) {
+              return await getOTPFromEmail(email, apiKey, serverId, receivedAfter)
             },
             async deleteEmail({ emailId, apiKey }) {
               await deleteEmail(emailId, apiKey)
@@ -125,6 +140,13 @@ This guide shows you how to automate passwordless authentication testing with Cy
       },
     })
     ```
+
+## Write resilient tests
+
+Two things to know before writing selectors against Kinde's hosted pages:
+
+- **The screens around the code step evolve.** For example, enabling passkeys adds a passkey option to the sign-in screen, and passing `login_hint` can pre-fill (or skip) the email step. Prefer selectors tied to stable attributes over positional ones, and keep the authentication methods on your test environment limited to the ones you are actually testing.
+- **The code entry step itself is stable.** The code input is `input[name="p_confirmation_code"]` (labelled "Code") and accepts exactly 6 digits, and the submit control is `[data-kinde-button-variant="primary"]`.
 
 ## Test passwordless sign-up flow
 
@@ -205,6 +227,10 @@ To test the passwordless sign-in flow:
     // cypress/e2e/passwordless-signin.cy.js
     describe('Passwordless Authentication Flows', () => {
       it('user can sign in with email and code', () => {
+        // This test reuses one inbox on every run, so record the start time and
+        // pass it to the task to avoid reading a code from a previous run.
+        const receivedAfter = new Date().toISOString()
+
         cy.visit(Cypress.env('TEST_APP_URL'))
         cy.get('[data-testid="sign-in-button"]').click()
 
@@ -217,11 +243,12 @@ To test the passwordless sign-in flow:
           cy.get('[data-kinde-button-variant="primary"]').click()
         })
 
-        // Wait for OTP email and extract code
+        // Wait for OTP email and extract code (only emails received after this test started)
         cy.task('getOTPFromEmail', {
           email: Cypress.env('TEST_USER_EMAIL'),
           apiKey: Cypress.env('MAILOSAUR_API_KEY'),
-          serverId: Cypress.env('MAILOSAUR_SERVER_ID')
+          serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
+          receivedAfter
         }).then((result) => {
           cy.origin(Cypress.env('KINDE_ISSUER_URL'), { args: { otpCode: result.otpCode } }, ({ otpCode }) => {
             cy.get('input[name="p_confirmation_code"]').type(otpCode)

--- a/src/content/docs/testing/cypress/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/cypress/test-passwordless-flows.mdx
@@ -1,7 +1,7 @@
 ---
 page_id: 18c6e4e1-bfbf-44b4-845c-011ad82fc82d
 title: Test passwordless flows
-description: "Guide to testing passwordless authentication flows with Cypress with Mailosaur."
+description: "Automate passwordless email code testing in Cypress by intercepting one-time code emails with Mailosaur."
 sidebar:
   order: 3
 tableOfContents:
@@ -14,18 +14,22 @@ topics:
   - passwordless
 sdk: []
 languages:
-  - JavaScript
-  - TypeScript
+  - javascript
+  - typescript
+  - json
+  - bash
 audience: developers
 complexity: intermediate
 keywords:
   - cypress
-  - testing
-  - passwordless
-  - magic link
+  - passwordless testing
   - email OTP
+  - one-time code
   - Mailosaur
-updated: 2026-07-17
+  - cy.task
+  - end-to-end testing
+ai_summary: "Step-by-step guide to automating Kinde passwordless authentication tests with Cypress by intercepting the one-time code (OTP) email. Uses Mailosaur (or any inbox API such as MailSlurp or Mailtrap) to give each test a unique inbox, wait for the email, extract the 6-digit code, and submit it against Kinde's hosted pages. Covers setting up Mailosaur with a Server ID and API key, storing secrets in cypress.env.json, adding getOTPFromEmail and deleteEmail Cypress tasks, and writing resilient selectors against stable attributes like input[name=p_confirmation_code]. Includes complete examples for passwordless sign-up, passwordless sign-in with a reused inbox and receivedAfter guard, and email plus password sign-up where OTP verification is still required. Recommends keeping OTP tests lean by reusing authenticated state with cy.session or using M2M setup. Prerequisites include completing the Cypress setup, a test user, a running Kinde application, and a Mailosaur account. Intended for developers writing end-to-end tests."
+updated: 2026-07-19
 featured: false
 deprecated: false
 ---

--- a/src/content/docs/testing/playwright/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/playwright/test-passwordless-flows.mdx
@@ -25,18 +25,26 @@ keywords:
   - magic link
   - email OTP
   - Mailosaur
-updated: 2026-04-14
+updated: 2026-07-17
 featured: false
 deprecated: false
 ---
 
-This guide shows you how to automate passwordless authentication testing with Playwright using Mailosaur. Learn more about [testing passwordless flows with Kinde](/testing/testing-passwordless-flows/).
+This guide shows you how to automate passwordless authentication testing with Playwright by intercepting the one-time code email. Learn more about [testing passwordless flows with Kinde](/testing/testing-passwordless-flows/).
+
+The examples use Mailosaur, but any inbox service with an API for reading emails programmatically (for example [MailSlurp](https://www.mailslurp.com/) or [Mailtrap](https://mailtrap.io/)) works the same way: give each test a unique inbox, wait for the code email, extract the code, and enter it in the form.
+
+Kinde one-time codes are always 6 digits, are generated fresh for every request, and expire after 2 hours (120 minutes) by default (configurable per environment). There is no static "test code": intercepting the real email is the supported way to automate these flows.
 
 ### What you need 
 
 - Completed the [Playwright setup](/testing/playwright/)
 - A [test user](/testing/setup-test-user-environment/) and a running Kinde application.
 - A [Mailosaur](https://mailosaur.com/) account (Sign up for free trial)
+
+## Keep OTP tests lean
+
+Waiting on real email delivery is the slowest and most failure-prone part of any test suite. We recommend covering the passwordless UI with a small number of smoke tests, and authenticating the rest of your suite another way: reuse authenticated state with Playwright's `storageState` (see [Test authenticated features](/testing/playwright/test-auth-features/)), use an email + password test user, or use a machine-to-machine (M2M) application for API-level setup.
 
 ## Setup Mailosaur
 
@@ -77,12 +85,20 @@ This guide shows you how to automate passwordless authentication testing with Pl
 
     export async function getOTPFromEmail(
       email: string,
+      receivedAfter?: Date,
     ): Promise<{
       emailId: string | undefined
       otpCode: string
       deleteEmail: () => Promise<void>
     }> {
-      const message = await mailosaur.messages.get(serverId, { sentTo: email })
+      // Pass receivedAfter when a test reuses an inbox across runs, so you
+      // never pick up a stale code from a previous run's email.
+      const message = await mailosaur.messages.get(
+        serverId,
+        { sentTo: email },
+        { receivedAfter },
+      )
+      // Kinde codes are always exactly 6 digits
       const otpMatch = message.text?.body?.match(/\b(\d{6})\b/)
       const otpCode = otpMatch?.[1]
 
@@ -99,6 +115,13 @@ This guide shows you how to automate passwordless authentication testing with Pl
       }
     }
     ```
+
+## Write resilient tests
+
+Two things to know before writing selectors against Kinde's hosted pages:
+
+- **The screens around the code step evolve.** For example, enabling passkeys adds a passkey option to the sign-in screen, and passing `login_hint` can pre-fill (or skip) the email step. Prefer role- and label-based selectors (`getByRole`, `getByLabel`) over positional ones, and keep the authentication methods on your test environment limited to the ones you are actually testing.
+- **The code entry step itself is stable.** The code input is `input[name="p_confirmation_code"]` (labelled "Code") and accepts exactly 6 digits.
 
 ## Test passwordless sign-up flow
 
@@ -181,6 +204,10 @@ To test the passwordless sign-in flow:
 
     test.describe('Passwordless Authentication Flows', () => {
       test('user can sign in with email and code', async ({ page }) => {
+        // This test reuses one inbox on every run, so record the start time and
+        // pass it to the helper to avoid reading a code from a previous run.
+        const testStart = new Date()
+
         await page.goto(process.env.TEST_APP_URL!)
         await page.click('[data-testid="sign-in-button"]')
 
@@ -191,9 +218,10 @@ To test the passwordless sign-in flow:
         await page.fill('input[name="p_email"]', process.env.TEST_USER_EMAIL!)
         await page.click('button[type="submit"]')
 
-        // Wait for OTP email and extract code
+        // Wait for OTP email and extract code (only emails received after this test started)
         const { otpCode, deleteEmail } = await getOTPFromEmail(
-          process.env.TEST_USER_EMAIL!
+          process.env.TEST_USER_EMAIL!,
+          testStart
         )
 
         try {

--- a/src/content/docs/testing/playwright/test-passwordless-flows.mdx
+++ b/src/content/docs/testing/playwright/test-passwordless-flows.mdx
@@ -1,7 +1,7 @@
 ---
 page_id: dc3c5aab-0e1e-4fb3-9a8a-8417032ee1a8
 title: Test passwordless flows
-description: "Guide to testing passwordless authentication flows with Playwright and Mailosaur."
+description: "Automate passwordless email code testing in Playwright by intercepting one-time code emails with Mailosaur."
 sidebar:
   order: 3
 tableOfContents:
@@ -14,18 +14,21 @@ topics:
   - passwordless
 sdk: []
 languages:
-  - JavaScript
-  - TypeScript
+  - javascript
+  - typescript
+  - bash
 audience: developers
 complexity: intermediate
 keywords:
   - playwright
-  - testing
-  - passwordless
-  - magic link
+  - passwordless testing
   - email OTP
+  - one-time code
   - Mailosaur
-updated: 2026-07-17
+  - storageState
+  - end-to-end testing
+ai_summary: "Step-by-step guide to automating Kinde passwordless authentication tests with Playwright by intercepting the one-time code (OTP) email. Uses Mailosaur (or any inbox API such as MailSlurp or Mailtrap) to give each test a unique inbox, wait for the email, extract the 6-digit code, and submit it against Kinde's hosted pages. Covers installing the Mailosaur client, storing the Server ID and API key in a .env file, writing a reusable getOTPFromEmail helper in TypeScript, and using role- and label-based selectors for resilience. Includes complete examples for passwordless sign-up, passwordless sign-in with a reused inbox and receivedAfter guard, and email plus password sign-up where OTP verification is still required. Recommends keeping OTP tests lean by reusing authenticated state with Playwright storageState or using M2M setup. Prerequisites include completing the Playwright setup, a test user, a running Kinde application, and a Mailosaur account. Intended for developers writing end-to-end tests."
+updated: 2026-07-19
 featured: false
 deprecated: false
 ---


### PR DESCRIPTION
## Context

Follow-up to a review of whether https://docs.kinde.com/testing/playwright/test-passwordless-flows/ is still the best way for customers to test passwordless flows. The core approach — intercepting the real one-time-code email via Mailosaur — was verified as still correct (there is no customer-usable static/test OTP and no API to read/set one). This PR revises the guide with five documentation improvements plus one real bug fix, and applies the same changes to the Cypress twin for consistency.

## Changes (both Playwright and Cypress pages)

- **Intro / overview** — reframed around inbox interception generally (Mailosaur remains the worked example; note that any inbox service with a read API, e.g. MailSlurp / Mailtrap, works the same way). Documents the code format: Kinde one-time codes are always 6 digits, generated fresh per request, and expire after 2 hours (120 minutes) by default.
- **New "Keep OTP tests lean" section** — recommends covering the passwordless UI with a few smoke tests and authenticating the rest of the suite another way: `storageState` (Playwright) / `cy.session` (Cypress), an email + password test user, or M2M for API-level setup. Links to the in-repo *Test authenticated features* guide.
- **New "Write resilient tests" section** — warns that the screens around the code step evolve (passkeys add an option to the sign-in screen; `login_hint` can pre-fill or skip the email step), recommends attribute/role/label-based selectors, and confirms the code-entry step is stable.
- **Bug fix (stale OTP):** the sign-in example reuses a single inbox on every run but fetched emails without a time filter, so a rerun could read a code from a previous run's email. `getOTPFromEmail` now accepts a `receivedAfter` timestamp and the sign-in test passes its start time. For Cypress this threads through the helper, the `cypress.config.js` task, and the `cy.task` payload (passed as an ISO string, re-hydrated to a `Date` in the helper).
- Bumped the `updated:` frontmatter date. All selectors, the three test examples, setup steps, and screenshots are preserved.

Note: the expiry wording matches existing docs ("2 hours") and deliberately avoids citing a specific dashboard nav path, since the exact Settings location for code expiry isn't documented elsewhere.

## Verification

- Ran the Astro dev server and loaded both pages: HTTP 200, no compile errors, both new sections render and appear in the table of contents, and the updated code samples display correctly.
- `git diff` reviewed to confirm only the intended additions/edits changed and no selector names or examples were altered unintentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Cypress and Playwright passwordless testing guides with clearer Mailosaur setup instructions.
  - Added guidance for keeping OTP tests lean by reusing authenticated state where appropriate.
  - Added recommendations for resilient selectors and documented OTP code-entry behavior.

- **Bug Fixes**
  - Passwordless test examples now use only OTP emails received after the current test begins, preventing stale codes from being selected when inboxes are reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->