### PR TITLE
update: add read-only notes to team members roles page

### DIFF
--- a/src/content/docs/get-started/team-and-account/team-member-roles.mdx
+++ b/src/content/docs/get-started/team-and-account/team-member-roles.mdx
@@ -99,10 +99,17 @@ Specialist roles (Engineer, Marketing, Finance, Customer success, and Security s
 
 ## Change the role of a team member
 
-You need sufficient role permissions to be able to change member roles. An owner can make any changes. An Admin can make any changes (except to the Owner role).
+<Aside>
+You need sufficient role permissions to be able to change member roles. 
 
-1. On the Kinde home page, select the avatar menu on the bottom left, and then select **Team members**. A list of your current team is shown.
-2. Select the three dots next to the team member who's role you want to change.
+- An **Owner** can make any changes. 
+- An **Admin** can make any changes (except to the Owner role).
+</Aside>
+
+1. On the Kinde home page, select the avatar menu on the bottom left, and then select **Team members**. You will be taken to the **Members** page.
+
+    <img src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/d046011f-9cab-48fe-b83d-6fb3a8516e00/socialsharingimage" alt="kinde users menu Team members page" width="300px" />
+2. In the **Members** page, select the **three dots** next to the team member who's role you want to change.
 3. In the menu that appears, select **Edit roles**.
-4. Using the toggles, change the roles they will have in the business. This can be more than one. Note you are restricted by your own role as to your ability to change roles for others.
+4. Enable the roles you want the team member to have in the business. You can enable more than one role for a team member. 
 5. Select **Save**. 

--- a/src/content/docs/get-started/team-and-account/team-member-roles.mdx
+++ b/src/content/docs/get-started/team-and-account/team-member-roles.mdx
@@ -3,12 +3,18 @@ page_id: b7428a8b-253b-4308-a1eb-66c48b12d44c
 title: Team member roles in Kinde
 sidebar:
   order: 2
+tableOfContents:
+  maxHeadingLevel: 3
 app_context:
   - m: team
-description: Guide to managing roles and permissions for team members in Kinde.
+description: "Control who can manage your Kinde business with Owner, Admin, and specialist roles across free and paid plans"
 relatedArticles: 
    - 279aba75-6db9-4bd6-a4a1-9ce10470c0fa
    - b1e5506a-d378-4b73-a6f5-f96bd45b56f1
+topics:
+  - get-started
+  - team-and-account
+  - access-control
 sdk: []
 languages: []
 audience:
@@ -16,47 +22,73 @@ audience:
   - business owners
 complexity: beginner
 keywords:
-  - team members
-  - member roles
-  - owner
-  - admin
-  - invitations
+  - team member roles
+  - owner role
+  - admin role
+  - specialist roles
+  - read-only access
+  - engineer role
   - access control
-updated: 2024-01-15
+  - role permissions
+updated: 2026-07-20
 featured: false
 deprecated: false
-ai_summary: Guide to managing roles and permissions for team members in Kinde, including owners, admins, and security specialists.
+ai_summary: "Guide to managing team member roles in Kinde. Covers Owner and Admin roles available on all plans including free, and paid-plan specialist roles: Engineer, Marketing, Finance, Customer success, Security specialist, and Read-only. Explains that specialist roles can manage their own area while retaining read access across the business, including user lists and organization details. Describes how roles can be combined, how only Owners can promote other Owners, and how role changes are gated by permissions. Includes dashboard steps to change a team member's roles. Intended for admins and business owners controlling team access."
 ---
 
 You can invite other team members and give them access to your business on Kinde. To simplify access control, Kinde has provided a number of pre-defined roles. 
 
-## Team member roles (Paid plans)
+## Owner and Admin (all plans)
+
+Every Kinde plan, including the free plan, comes with the **Owner** and **Admin** roles. If you have a free plan, you will be limited to just these two roles.
+
+### Owner
+
+The person who creates the business in Kinde is automatically the Owner. They have the highest access level in the Kinde business. Only an owner can approve data export from Kinde.
+
+### Admin
+
+All other team members in Kinde are created as Admins. They have access to all Kinde features, except data export approval and the ability to change the Owner role.
+
+## Specialist roles (paid plans)
+
+<Aside type="upgrade">
+You need a paid plan to assign specialist roles. See [Kinde pricing](https://kinde.com/pricing/) for more information.
+</Aside>
 
 On Kinde paid plans, there are a range of specific roles that can be assigned to team members. This allows you to restrict actions that you may want limited to certain people in your business.
 
-**Owner** - The person who creates the business in Kinde is automatically the Owner. They have the highest access level in the Kinde business and can assign any role to anyone. Only an owner can approve data export from Kinde.
+<Aside title="These roles can view everything">
+Specialist roles can manage their own area, but they also have read access across your entire Kinde business — including user lists and organization details.
+</Aside>
 
-**Admin** - Comprehensive access to manage all aspects of the system, excluding the ability to assign or modify the Owner role.
+### Engineer
 
-**Customer success** - Manage user accounts, subscriptions, and organization settings to support customer onboarding and retention.
+Configure applications, APIs, environments, feature flags, and integrations. Access audit logs for debugging and monitoring.
 
-**Engineer** - Configure applications, APIs, environments, feature flags, and integrations. Access audit logs for debugging and monitoring.
+### Marketing
 
-**Finance** - Oversee your business’s subscription to Kinde, including plan type and payment details.
+Manage branding elements, email templates, and content-related settings to ensure a consistent user experience.
 
-**Marketing** - Manage branding elements, email templates, and content-related settings to ensure a consistent user experience.
+### Finance
 
-**Read-only** - Read-only access across all system areas for monitoring and review purposes without the ability to make changes.
+Oversee your business’s subscription to Kinde, including plan type and payment details.
 
-**Security specialist** - Manage authentication methods, multi-factor authentication (MFA), and security policies for your business.
+### Customer success
 
-## Team member roles (Free plan)
+Manage user accounts, subscriptions, and organization settings to support customer onboarding and retention.
 
-The Kinde free plan comes with just the Owner and Admin roles.
+### Security specialist
 
-**Owner** - The person who creates the business in Kinde is automatically the Owner. They have the highest access level in the Kinde business. Only an owner can approve data export from Kinde.
+Manage authentication methods, multi-factor authentication (MFA), and security policies for your business.
 
-**Admin** - All other team members in Kinde are created as Admins. They have access to all Kinde features, except data export approval and the ability to change the Owner role.
+### Read-only
+
+Read-only access across all system areas for monitoring and review purposes without the ability to make changes.
+
+## Understanding read access
+
+Specialist roles (Engineer, Marketing, Finance, Customer success, and Security specialist) can manage their own area, but they can also view everything else in your Kinde business — including user lists and organization details. Assign these roles with that visibility in mind. If someone only needs to view information without making changes, use the **Read-only** role instead.
 
 ## How team member roles work
 


### PR DESCRIPTION
This PR adds an important note that all specialists' roles in Kinde account also grants them read-only access to the entire account. The PR also restructures the doc and updates the frontmatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated team member roles guidance with clearer distinctions between Owner, Admin, specialist, and Read-only roles.
  * Reorganized specialist role coverage into “Owner and Admin (all plans)” and “Specialist roles (paid plans)”.
  * Clarified permission scope for role changes and revised step-by-step instructions for updating roles.
  * Expanded explanations of specialist read access and when to use the Read-only role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->