### PR TITLE
Add Ihor Herasymovych to 2026 security wall of fame

### DIFF
--- a/src/content/docs/trust-center/security/security-wall-of-fame.mdx
+++ b/src/content/docs/trust-center/security/security-wall-of-fame.mdx
@@ -23,7 +23,7 @@ keywords:
   - "bug bounty"
   - "responsible disclosure"
   - "security wall of fame"
-updated: "2026-06-09"
+updated: "2026-07-23"
 featured: false
 deprecated: false
 ai_summary: "Recognition page for security researchers who have responsibly disclosed vulnerabilities to help secure Kinde's systems, organized by year with links to researcher profiles."
@@ -42,6 +42,8 @@ Love your work!
 ### Disclosures
 
 [The Security Company](https://thesecurity.company/)
+
+[Ihor Herasymovych](https://www.linkedin.com/in/mgorunuch/)
 
 ## 2025
 


### PR DESCRIPTION
## Summary
- Adds Ihor Herasymovych to the 2026 Disclosures list on the Security wall of fame, with LinkedIn profile link
- Updates the page `updated` date

## Test plan
- [ ] Confirm Ihor appears under 2026 Disclosures after The Security Company on https://docs.kinde.com/trust-center/security/security-wall-of-fame/
- [ ] Confirm LinkedIn link opens https://www.linkedin.com/in/mgorunuch/


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Security Wall of Fame page with the latest revision date.
  * Added a new 2026 security disclosure acknowledgment with a link to the contributor’s LinkedIn profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->