### PR TITLE
Document ASP.NET Identity v2 user import

### DIFF
--- a/src/content/docs/get-started/switch-to-kinde/aspnet-identity-to-kinde.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/aspnet-identity-to-kinde.mdx
@@ -1,0 +1,252 @@
+---
+page_id: 1977cf9a-cde0-4d88-85a7-92173771b191
+title: Migrate to Kinde from ASP.NET Identity
+sidebar:
+  order: 9
+  label: ASP.NET Identity
+tableOfContents:
+  maxHeadingLevel: 3
+relatedArticles:
+  - c4bc277a-5ec7-418c-ba1c-4d58c9ddfd7d
+  - f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
+  - e89d246a-5cdf-4993-9cee-94b31ec27583
+  - fbdb6a7c-d01d-49ca-8d7f-c4b49bab83f5
+description: Export ASP.NET Identity users and v2 password hashes from SQL Server and import them into Kinde without requiring a password reset.
+topics:
+  - get-started
+  - switch-to-kinde
+sdk: []
+languages:
+  - sql
+  - csv
+audience:
+  - developers
+  - admins
+complexity: intermediate
+keywords:
+  - ASP.NET Identity migration
+  - ASP.NET Identity v2
+  - migrate from ASP.NET Identity
+  - AspNetUsers
+  - PBKDF2
+  - password hash migration
+  - SQL Server user export
+  - CSV import
+  - UTF-16 CSV
+  - bulk user import
+updated: 2026-08-05
+featured: false
+deprecated: false
+ai_summary: "Step-by-step guide for migrating users from ASP.NET Identity 2.x on the .NET Framework to Kinde. It explains how to identify supported v2 PBKDF2-HMAC-SHA1 password hashes, distinguish unsupported ASP.NET Core Identity v3 hashes, export the AspNetUsers table with SQL Server Management Studio or bcp, and import UTF-8 or UTF-16 CSV through the dedicated ASP.NET Identity import type. The guide documents accepted column names, identity and phone handling, empty passwords, re-import behavior, first-sign-in bcrypt rehashing, and setting individual ASP.NET Identity v2 hashes through the Management API."
+---
+
+Migrate your users from ASP.NET Identity to Kinde. ASP.NET Identity has no built-in
+export tool, so you export the `AspNetUsers` table from your database as CSV. User
+details and password hashes are imported together, so most users keep their existing
+password with no reset required.
+
+### What you need
+
+- A Kinde account with **Admin** access
+- A Kinde account configured to match your current auth provider — see
+  [before you migrate](/get-started/switch-to-kinde/switch-to-kinde-for-user-authentication/#before-you-migrate)
+- Read access to your ASP.NET Identity database
+- SQL Server Management Studio (SSMS), `bcp`, or another tool that can export a query
+  result as CSV
+
+## Key considerations
+
+- **ASP.NET Identity v2 password hashes are supported** — these are the hashes produced
+  by ASP.NET Identity 2.x on the .NET Framework. The salt and other parameters are
+  embedded in each hash, so there is nothing extra to configure.
+- **ASP.NET Core Identity v3 hashes are not supported** — ASP.NET Core uses v3 hashes by
+  default, which Kinde cannot verify. Check
+  [which hash format you have](#which-hash-format-do-i-have) before exporting.
+- **CSV format** — files must be 49MB or less and encoded as UTF-8 or UTF-16 with a byte
+  order mark (BOM). Split larger exports into batches, or
+  [contact support](https://kinde.com/support) for help.
+- **Email, username, and phone identities** — the importer reads identity columns from
+  `AspNetUsers`. External logins such as Google, Microsoft, and Facebook are stored in
+  `AspNetUserLogins` and are not included.
+- **Organizations, roles, and permissions are not imported** — ASP.NET Identity roles
+  are stored in `AspNetRoles` and `AspNetUserRoles`. Use a
+  [Custom CSV import](/manage-users/add-and-edit/import-users-in-bulk/) or a follow-up
+  import to bring across roles, permissions, or organizations.
+- **Username case sensitivity** — Kinde treats usernames as case-insensitive. Check that
+  usernames remain unique when letter casing is ignored.
+
+## Which hash format do I have?
+
+ASP.NET Identity has used two password hash formats. Kinde supports v2.
+
+| Format | Produced by                                | First decoded byte | Supported |
+| ------ | ------------------------------------------ | ------------------ | --------- |
+| v2     | ASP.NET Identity 2.x on the .NET Framework | `0x00`             | Yes       |
+| v3     | ASP.NET Core Identity                      | `0x01`             | No        |
+
+A v2 hash is a 49-byte blob: a `0x00` marker, a 16-byte salt, and a 32-byte
+PBKDF2-HMAC-SHA1 subkey. Its base64 representation is 68 characters and ends in `==`. A
+v3 hash is longer and typically starts with `AQAAAA` when base64-encoded.
+
+Rows containing v3 or otherwise invalid password hashes are reported as errors and are
+not imported. To import those users without their passwords, clear the `PasswordHash`
+value before importing. They can then set a password the first time they sign in.
+
+## Migration guide
+
+### 1. Export users from ASP.NET Identity
+
+Run this query against your ASP.NET Identity database:
+
+```sql
+SELECT
+  Id,
+  Email,
+  EmailConfirmed,
+  UserName,
+  PhoneNumber,
+  PhoneNumberConfirmed,
+  PasswordHash
+FROM dbo.AspNetUsers;
+```
+
+If you extended `AspNetUsers` with name columns, include `FirstName` and `LastName` too.
+
+Choose an export method:
+
+- **SQL Server Management Studio** — run the query, right-click the results grid, and
+  select **Save Results As**. Before exporting, go to **Tools > Options > Query Results >
+  SQL Server > Results to Grid** and turn on **Include column headers when copying or
+  saving the results**. Open a new query window after changing the setting. Save the file
+  as UTF-8 or UTF-16 with a BOM; available encoding options depend on your SSMS version.
+- **bcp** — use `queryout`, set a comma field terminator, and choose `-w` for UTF-16 or
+  `-c -C 65001` for UTF-8. For example:
+
+  ```bash
+  bcp "SELECT Id, Email, EmailConfirmed, UserName, PhoneNumber, PhoneNumberConfirmed, PasswordHash FROM dbo.AspNetUsers" queryout users.csv -w -t, -T -S server-name -d database-name
+  ```
+
+  `bcp` does not add column headers or quote values that contain commas or line breaks.
+  Add the header row using the same encoding as the data. If your selected fields can
+  contain delimiters, use SSMS or another CSV-aware export tool instead.
+
+<Aside>
+
+Check for literal `NULL` text in the exported file. Kinde treats `NULL` in the
+`PasswordHash` column as no password, but in other columns it is treated as a value and
+can cause validation errors. Replace those values with empty fields before importing.
+
+</Aside>
+
+Kinde reads these columns:
+
+| AspNetUsers column     | Used for                                                      |
+| ---------------------- | ------------------------------------------------------------- |
+| `Id`                   | Stable external identifier used to match records on re-import |
+| `Email`                | Email identity                                                |
+| `EmailConfirmed`       | Whether the email identity is verified                        |
+| `UserName`             | Username identity, imported only when it differs from `Email` |
+| `PhoneNumber`          | Phone identity, imported only when it uses E.164 format       |
+| `PhoneNumberConfirmed` | Whether the phone identity is verified                        |
+| `PasswordHash`         | ASP.NET Identity v2 password hash                             |
+| `FirstName`            | Given name, if your schema includes this column               |
+| `LastName`             | Family name, if your schema includes this column              |
+
+Headers can use the PascalCase names above exactly as exported, or their lowercase or
+snake_case equivalents, such as `passwordhash` or `password_hash`. Other columns are
+ignored.
+
+Your final CSV should look like this:
+
+```csv
+Id,Email,EmailConfirmed,UserName,PhoneNumber,PhoneNumberConfirmed,PasswordHash
+a1b2c3d4-0001,bills@company.com,True,bills@company.com,+61555111555,True,AAARIjNEVWZ3iJmqu8zd7v/vo7NU7QKxVXNpT34wHaq3A//dAREesiNmmrsO8K46cQ==
+a1b2c3d4-0002,carlosg@company.com,False,carlosg,,False,AP/u3cy7qpmId2ZVRDMiEQBb0476O+sFgGq7T5oh2MR9HmY+l7xCK+9G0tEmntXYbQ==
+a1b2c3d4-0003,lliu@company.com,True,lliu@company.com,,False,
+```
+
+#### How identities are treated on import
+
+`UserName` commonly contains the user's email address. Kinde creates a separate username
+identity only when `UserName` differs from `Email`, preventing duplicate identities for
+the same value.
+
+Phone numbers are imported only when they use E.164 format, with a leading `+` and
+country code. ASP.NET Identity does not enforce a format on `PhoneNumber`, so
+national-format numbers such as `0555 111 555` are skipped. Normalize them before export
+if you want to import them.
+
+Users with an empty `PasswordHash`, which commonly includes external-login users, are
+imported without a password. They can set one or sign in another way when they first
+visit.
+
+### 2. Import into Kinde
+
+1. In Kinde, go to **Users**, then select **Import users**.
+2. Select **ASP.NET Identity**.
+3. Follow the on-screen prompts to upload your CSV file (49MB or less).
+4. Review any [import errors](/manage-users/add-and-edit/troubleshoot-user-import-errors/)
+   reported after import. Fix the file and re-import to resolve them.
+
+<Aside>
+
+Kinde does not duplicate users with existing identifiers. Records that were already
+imported and are unchanged are ignored on re-import.
+
+</Aside>
+
+See the [bulk import guide](/get-started/switch-to-kinde/migrate-users-bulk-import/) for
+more about file formats and post-import handling.
+
+### 3. Test the migration
+
+1. Sign in as a user from your ASP.NET Identity export.
+2. Verify they can sign in with their existing password.
+3. Notify users of changes to their sign-in experience before going live.
+
+## Import individual passwords with the API
+
+For a gradual migration, or to catch a user who registered after the export, set an
+individual user's password through the
+[Set user password API](/kinde-apis/management/#tag/users/put/api/v1/users/{user_id}/password).
+Send:
+
+- `hashed_password` — the `PasswordHash` value exactly as exported
+- `hashing_method` — `aspnet-identity-v2`
+
+Do not send `salt`, `salt_position`, `iterations`, or `variant`. The salt and other
+parameters are embedded in the hash, so these fields are rejected for this method.
+
+## After import
+
+### Impact on end users
+
+Importing users and passwords together should mean your users do not notice anything
+when they next sign in. The first time an imported user signs in, Kinde verifies the
+password against the ASP.NET Identity hash and re-hashes it with bcrypt. However:
+
+- If a user changes their password after the export and during the migration, they will
+  need to reset their password in Kinde.
+- If you set up a new authentication method, such as passwordless, users will be prompted
+  to use it on sign-in.
+- If you add or remove roles or permissions, users may gain or lose access to parts of
+  your system.
+
+### Re-importing can update user info
+
+If an imported user starts authenticating through Kinde, a later import containing
+changes, such as an updated name, updates their Kinde record. Do not use imports for
+ongoing user management; make later updates through the Kinde admin or
+[Management API](/kinde-apis/management/) instead.
+
+### Communication to users
+
+Kinde does not send notifications or invitations when users are imported. The goal is a
+seamless experience that feels like nothing has changed.
+
+If you changed the sign-in experience, such as adding multi-factor authentication,
+consider contacting users before the cutover.
+
+## Get support
+
+If you need help with your migration, contact [Kinde support](https://kinde.com/support).

--- a/src/content/docs/get-started/switch-to-kinde/aspnet-identity-to-kinde.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/aspnet-identity-to-kinde.mdx
@@ -11,33 +11,32 @@ relatedArticles:
   - f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
   - e89d246a-5cdf-4993-9cee-94b31ec27583
   - fbdb6a7c-d01d-49ca-8d7f-c4b49bab83f5
-description: Export ASP.NET Identity users and v2 password hashes from SQL Server and import them into Kinde without requiring a password reset.
+description: "Export ASP.NET Identity users and v2 hashes from SQL Server and import into Kinde—users keep their existing password, no reset required"
 topics:
   - get-started
   - switch-to-kinde
 sdk: []
 languages:
   - sql
+  - bash
   - csv
 audience:
   - developers
   - admins
 complexity: intermediate
 keywords:
-  - ASP.NET Identity migration
-  - ASP.NET Identity v2
-  - migrate from ASP.NET Identity
+  - asp.net identity migration
+  - asp.net identity to kinde
+  - migrate from asp.net identity
   - AspNetUsers
   - PBKDF2
   - password hash migration
-  - SQL Server user export
-  - CSV import
-  - UTF-16 CSV
+  - csv import
   - bulk user import
-updated: 2026-08-05
+updated: 2026-08-15
 featured: false
 deprecated: false
-ai_summary: "Step-by-step guide for migrating users from ASP.NET Identity 2.x on the .NET Framework to Kinde. It explains how to identify supported v2 PBKDF2-HMAC-SHA1 password hashes, distinguish unsupported ASP.NET Core Identity v3 hashes, export the AspNetUsers table with SQL Server Management Studio or bcp, and import UTF-8 or UTF-16 CSV through the dedicated ASP.NET Identity import type. The guide documents accepted column names, identity and phone handling, empty passwords, re-import behavior, first-sign-in bcrypt rehashing, and setting individual ASP.NET Identity v2 hashes through the Management API."
+ai_summary: "Step-by-step guide for migrating users from ASP.NET Identity 2.x on the .NET Framework to Kinde. User details and v2 PBKDF2-HMAC-SHA1 password hashes are exported from the AspNetUsers table as UTF-8 or UTF-16 CSV and imported together through Users, Import users, ASP.NET Identity, so most users keep their existing password. Covers identifying supported v2 hashes versus unsupported ASP.NET Core Identity v3 hashes, exporting with SQL Server Management Studio or bcp, accepted column names in PascalCase, lowercase, or snake_case, and how email, username, and E.164 phone identities are treated. Documents empty passwords, literal NULL values, username case sensitivity, the 49MB file limit, and that roles, organizations, and external logins in AspNetUserLogins are not imported. Also covers first-sign-in bcrypt rehashing, re-import behavior, and setting individual aspnet-identity-v2 hashes through the Management API. Intended for developers and admins moving authentication from ASP.NET Identity to Kinde."
 ---
 
 Migrate your users from ASP.NET Identity to Kinde. ASP.NET Identity has no built-in
@@ -56,24 +55,13 @@ password with no reset required.
 
 ## Key considerations
 
-- **ASP.NET Identity v2 password hashes are supported** — these are the hashes produced
-  by ASP.NET Identity 2.x on the .NET Framework. The salt and other parameters are
-  embedded in each hash, so there is nothing extra to configure.
-- **ASP.NET Core Identity v3 hashes are not supported** — ASP.NET Core uses v3 hashes by
-  default, which Kinde cannot verify. Check
-  [which hash format you have](#which-hash-format-do-i-have) before exporting.
-- **CSV format** — files must be 49MB or less and encoded as UTF-8 or UTF-16 with a byte
-  order mark (BOM). Split larger exports into batches, or
-  [contact support](https://kinde.com/support) for help.
-- **Email, username, and phone identities** — the importer reads identity columns from
-  `AspNetUsers`. External logins such as Google, Microsoft, and Facebook are stored in
-  `AspNetUserLogins` and are not included.
-- **Organizations, roles, and permissions are not imported** — ASP.NET Identity roles
-  are stored in `AspNetRoles` and `AspNetUserRoles`. Use a
-  [Custom CSV import](/manage-users/add-and-edit/import-users-in-bulk/) or a follow-up
-  import to bring across roles, permissions, or organizations.
-- **Username case sensitivity** — Kinde treats usernames as case-insensitive. Check that
-  usernames remain unique when letter casing is ignored.
+- **Password hash support** — v2 hashes from ASP.NET Identity 2.x on the .NET Framework are supported; v3 hashes are not. See [which hash format do I have?](#which-hash-format-do-i-have).
+- **CSV format** — files must be encoded as UTF-8 or UTF-16 with a byte
+  order mark (BOM). Maximum file size is 49MB. Split larger exports into batches.
+- **Email, username, and phone identities** — the importer reads identity columns from `AspNetUsers`. External logins such as Google, Microsoft, and Facebook are stored in `AspNetUserLogins` and are not included.
+- **Organizations, roles, and permissions are not imported** — ASP.NET Identity roles are stored in `AspNetRoles` and `AspNetUserRoles`. Use a
+  [Custom CSV import](/manage-users/add-and-edit/import-users-in-bulk/) or a follow-up import to bring across roles, permissions, or organizations.
+- **Username case sensitivity** — Kinde treats usernames as case-insensitive. Check that usernames remain unique when letter casing is ignored.
 
 ## Which hash format do I have?
 
@@ -96,47 +84,47 @@ value before importing. They can then set a password the first time they sign in
 
 ### 1. Export users from ASP.NET Identity
 
-Run this query against your ASP.NET Identity database:
+There are two ways to export users from ASP.NET Identity:
 
-```sql
-SELECT
-  Id,
-  Email,
-  EmailConfirmed,
-  UserName,
-  PhoneNumber,
-  PhoneNumberConfirmed,
-  PasswordHash
-FROM dbo.AspNetUsers;
-```
+- SQL Server Management Studio
+- `bcp` command-line tool
 
-If you extended `AspNetUsers` with name columns, include `FirstName` and `LastName` too.
+#### SQL Server Management Studio
 
-Choose an export method:
+1. Go to **Tools > Options > Query Results > SQL Server > Results to Grid** and turn on **Include column headers when copying or saving the results**.
+2. Open a new query window so the header setting applies.
+3. Run this query against your ASP.NET Identity database:
 
-- **SQL Server Management Studio** — run the query, right-click the results grid, and
-  select **Save Results As**. Before exporting, go to **Tools > Options > Query Results >
-  SQL Server > Results to Grid** and turn on **Include column headers when copying or
-  saving the results**. Open a new query window after changing the setting. Save the file
-  as UTF-8 or UTF-16 with a BOM; available encoding options depend on your SSMS version.
-- **bcp** — use `queryout`, set a comma field terminator, and choose `-w` for UTF-16 or
-  `-c -C 65001` for UTF-8. For example:
+    ```sql
+    SELECT
+      Id,
+      Email,
+      EmailConfirmed,
+      UserName,
+      PhoneNumber,
+      PhoneNumberConfirmed,
+      PasswordHash
+    FROM dbo.AspNetUsers;
+    ```
+    <Aside>
+    If you extended `AspNetUsers` with name columns, include `FirstName` and `LastName` too.
+    </Aside>
 
-  ```bash
-  bcp "SELECT Id, Email, EmailConfirmed, UserName, PhoneNumber, PhoneNumberConfirmed, PasswordHash FROM dbo.AspNetUsers" queryout users.csv -w -t, -T -S server-name -d database-name
-  ```
+4. Right-click the results grid and select **Save Results As**.
+5. Save the file as UTF-8 or UTF-16 with a BOM. Available encoding options depend on your SSMS version.
 
-  `bcp` does not add column headers or quote values that contain commas or line breaks.
-  Add the header row using the same encoding as the data. If your selected fields can
-  contain delimiters, use SSMS or another CSV-aware export tool instead.
+#### `bcp` command-line tool
 
-<Aside>
+1. Open a command prompt.
+2. Run `bcp` with `queryout`, a comma field terminator, and `-w` for UTF-16 or `-c -C 65001` for UTF-8. For example:
 
-Check for literal `NULL` text in the exported file. Kinde treats `NULL` in the
-`PasswordHash` column as no password, but in other columns it is treated as a value and
-can cause validation errors. Replace those values with empty fields before importing.
+    ```bash
+    bcp "SELECT Id, Email, EmailConfirmed, UserName, PhoneNumber, PhoneNumberConfirmed, PasswordHash FROM dbo.AspNetUsers" queryout users.csv -w -t, -T -S server-name -d database-name
+    ```
 
-</Aside>
+    <Aside>
+    `bcp` does not add column headers or quote values that contain commas or line breaks. Add the header row using the same encoding as the data. If your selected fields can contain delimiters, use SSMS or another CSV-aware export tool instead.
+    </Aside>
 
 Kinde reads these columns:
 
@@ -167,23 +155,26 @@ a1b2c3d4-0003,lliu@company.com,True,lliu@company.com,,False,
 
 #### How identities are treated on import
 
-`UserName` commonly contains the user's email address. Kinde creates a separate username
-identity only when `UserName` differs from `Email`, preventing duplicate identities for
-the same value.
-
-Phone numbers are imported only when they use E.164 format, with a leading `+` and
-country code. ASP.NET Identity does not enforce a format on `PhoneNumber`, so
-national-format numbers such as `0555 111 555` are skipped. Normalize them before export
-if you want to import them.
-
-Users with an empty `PasswordHash`, which commonly includes external-login users, are
-imported without a password. They can set one or sign in another way when they first
-visit.
+- `UserName` commonly contains the user's email address. Kinde creates a separate username
+  identity only when `UserName` differs from `Email`, preventing duplicate identities for
+  the same value.
+- Phone numbers are imported only when they use E.164 format, with a leading `+` and
+  country code. ASP.NET Identity does not enforce a format on `PhoneNumber`, so
+  national-format numbers such as `0555 111 555` are skipped. Normalize them before export
+  if you want to import them.
+- Users with an empty `PasswordHash`, including many external-login users, are imported
+  without a password. They can set one or sign in another way when they first sign in.
+- Kinde treats `NULL` in the `PasswordHash` column as no password, but in other columns it
+  is treated as a value and can cause validation errors. Check for literal `NULL` text in
+  the exported file and replace those values with empty fields before importing.
 
 ### 2. Import into Kinde
 
 1. In Kinde, go to **Users**, then select **Import users**.
 2. Select **ASP.NET Identity**.
+
+    ![import from asp.net identity](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/39ecb54c-4de6-44d2-7f2c-359d901b4b00/socialsharingimage)
+
 3. Follow the on-screen prompts to upload your CSV file (49MB or less).
 4. Review any [import errors](/manage-users/add-and-edit/troubleshoot-user-import-errors/)
    reported after import. Fix the file and re-import to resolve them.
@@ -225,8 +216,8 @@ Importing users and passwords together should mean your users do not notice anyt
 when they next sign in. The first time an imported user signs in, Kinde verifies the
 password against the ASP.NET Identity hash and re-hashes it with bcrypt. However:
 
-- If a user changes their password after the export and during the migration, they will
-  need to reset their password in Kinde.
+- If a user changes their password after the export and while the migration is in
+  progress, they will need to reset their password in Kinde.
 - If you set up a new authentication method, such as passwordless, users will be prompted
   to use it on sign-in.
 - If you add or remove roles or permissions, users may gain or lose access to parts of

--- a/src/content/docs/get-started/switch-to-kinde/clerk-to-kinde.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/clerk-to-kinde.mdx
@@ -9,7 +9,7 @@ tableOfContents:
 relatedArticles:
   - c4bc277a-5ec7-418c-ba1c-4d58c9ddfd7d
   - f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
-  - b338980f-7dd6-4ba5-90aa-330247a45536
+  - 1977cf9a-cde0-4d88-85a7-92173771b191
   - e89d246a-5cdf-4993-9cee-94b31ec27583
 description: Export users and hashed passwords from Clerk and import them into Kinde. Clerk supports bcrypt exports, so users keep their existing passwords.
 topics:
@@ -36,7 +36,7 @@ keywords:
   - authentication migration
   - clerk export
   - clerk csv
-updated: 2026-05-05
+updated: 2026-08-05
 featured: false
 deprecated: false
 ai_summary: "Step-by-step guide for migrating users from Clerk to Kinde using a bulk CSV import. Clerk supports exporting bcrypt-hashed passwords, and Kinde supports bcrypt natively, so users can sign in with their existing passwords without a forced reset — no drip-feed migration required. The guide covers: exporting users from the Clerk dashboard via Configure > Settings > User exports; renaming CSV columns to match Kinde's expected format, including primary_email_address to email, password_digest to hashed_password, password_hasher to hashing_method, and primary_phone_number to phone; removing columns Kinde does not use such as username, verified_email_addresses, totp_secret, and created_at; enabling password authentication in Kinde before importing; and uploading the prepared CSV via Users > Import users > Custom CSV. Errors flagged during import can be fixed by editing the CSV and re-importing — already-imported records are skipped. Links to the full bulk import guide for additional CSV fields covering organizations, roles, and permissions."
@@ -46,7 +46,7 @@ Migrate your users from Clerk to Kinde. Clerk supports exporting hashed password
 
 ### What you need
 
-- A Kinde account with **Admin** access 
+- A Kinde account with **Admin** access
 - Kinde account configured to match your current auth provider - see [before you migrate](/get-started/switch-to-kinde/switch-to-kinde-for-user-authentication/#before-you-migrate)
 - Clerk account with user export permissions
 
@@ -74,16 +74,16 @@ See Clerk's documentation on [exporting users](https://clerk.com/docs/guides/dev
 
 Rename the columns in your Clerk export to match what Kinde expects. The only required column is `email` — everything else is optional but recommended.
 
-| Clerk column | Rename to | Notes |
-|---|---|---|
-| `primary_email_address` | `email` | Required — primary sign-in identifier |
-|  | `email_verified` | `TRUE` or `FALSE` |
-| `id` | `id` | Keep as-is — helps match records on re-import |
-| `first_name` | `first_name` | Keep as-is |
-| `last_name` | `last_name` | Keep as-is |
-| `primary_phone_number` | `phone` | International format, e.g. `+61555111555` |
-| `password_digest` | `hashed_password` | bcrypt hash — preserves existing passwords |
-| `password_hasher` | `hashing_method` | Value will be `bcrypt` |
+| Clerk column            | Rename to         | Notes                                         |
+| ----------------------- | ----------------- | --------------------------------------------- |
+| `primary_email_address` | `email`           | Required — primary sign-in identifier         |
+|                         | `email_verified`  | `TRUE` or `FALSE`                             |
+| `id`                    | `id`              | Keep as-is — helps match records on re-import |
+| `first_name`            | `first_name`      | Keep as-is                                    |
+| `last_name`             | `last_name`       | Keep as-is                                    |
+| `primary_phone_number`  | `phone`           | International format, e.g. `+61555111555`     |
+| `password_digest`       | `hashed_password` | bcrypt hash — preserves existing passwords    |
+| `password_hasher`       | `hashing_method`  | Value will be `bcrypt`                        |
 
 For the full list of supported CSV fields — including organizations, roles, and permissions — see [Prepare your CSV](/get-started/switch-to-kinde/migrate-users-bulk-import/#3-prepare-your-csv) in the bulk import guide.
 

--- a/src/content/docs/get-started/switch-to-kinde/create-users-with-api.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/create-users-with-api.mdx
@@ -3,7 +3,7 @@ page_id: 98a6a913-a9ba-474c-8b01-6db706d08b4c
 title: Create users with the Kinde API during migration
 description: Use the Kinde Management API to create users programmatically during a migration — catching new sign-ups and password changes in real time.
 sidebar:
-  order: 10
+  order: 11
   label: Create users with API
 tableOfContents:
   maxHeadingLevel: 3
@@ -38,10 +38,12 @@ keywords:
   - real-time user sync
   - set password api
   - identity migration
-updated: 2026-05-05
+  - ASP.NET Identity v2
+  - aspnet-identity-v2
+updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: "This guide explains how to use the Kinde Management API to create and provision users programmatically during a migration. It covers three primary use cases — acting as a real-time safety net during a migration window to capture new sign-ups and password changes, integrating with custom auth systems where the developer controls the login form, and syncing passwords when users authenticate against a legacy system. The guide walks through four core API steps: checking whether a user already exists to avoid duplicates (GET /api/v1/users?email=), creating a new user with profile and identity data (POST /api/v1/user), setting a password using either a hashed value with a supported hashing method (bcrypt, md5, sha256, crypt, wordpress) or plaintext (PUT /api/v1/users/{user_id}/password), and optionally forcing a password reset when credentials may be out of sync. It also covers the end-to-end migration window pattern — bulk importing existing users first, intercepting live traffic during the transition via API, and running a final sync post-cutover — along with rate limit guidance and when to prefer CSV bulk import over the API approach."
+ai_summary: "Guide to using the Kinde Management API to create users and synchronize passwords during a migration window. It covers finding and creating users, setting plaintext or hashed passwords with supported methods including ASP.NET Identity v2, forcing password resets, handling live registrations and password changes, and choosing between API synchronization and bulk import."
 ---
 
 Use the Kinde Management API to create and provision users programmatically — the right approach when you need to intercept live sign-ups or password changes during a migration window, or when you control the login form in a custom auth system and can hook directly into the sign-in path.
@@ -118,7 +120,17 @@ Content-Type: application/json
 }
 ```
 
-Supported `hashing_method` values: `bcrypt`, `md5`, `sha256`, `crypt`, `wordpress`.
+Supported `hashing_method` values: `bcrypt`, `md5`, `sha256`, `crypt`, `wordpress`,
+and `aspnet-identity-v2`.
+
+<Aside title="ASP.NET Identity v2">
+
+For `aspnet-identity-v2`, send the `PasswordHash` value from `AspNetUsers` as
+`hashed_password`. Do not send `salt`, `salt_position`, `iterations`, or `variant`
+because those parameters are embedded in the hash. See
+[Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/).
+
+</Aside>
 
 If you have access to the user's plaintext password at the time of login (because your app owns the login form), you can set it directly:
 

--- a/src/content/docs/get-started/switch-to-kinde/create-users-with-api.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/create-users-with-api.mdx
@@ -120,8 +120,12 @@ Content-Type: application/json
 }
 ```
 
-Supported `hashing_method` values: `bcrypt`, `md5`, `sha256`, `crypt`, `wordpress`,
-and `aspnet-identity-v2`.
+Supported `hashing_method` values: `bcrypt`, `crypt`, `md5`, `sha256`, `wordpress`,
+`pbkdf2`, `firebase-scrypt`, and `aspnet-identity-v2`. Each method requires different
+parameters — `pbkdf2` needs a `variant`, and `firebase-scrypt` needs your project's
+`signer_key`, `salt_separator`, `rounds`, and `mem_cost`. See the
+[Set user password API reference](/kinde-apis/management#tag/users/put/api/v1/users/{user_id}/password)
+for the full parameter rules.
 
 <Aside title="ASP.NET Identity v2">
 

--- a/src/content/docs/get-started/switch-to-kinde/drip-feed-migration.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/drip-feed-migration.mdx
@@ -2,7 +2,7 @@
 page_id: f3dc6458-7d1e-407e-bc4c-62ac0ee4c075
 title: Drip-feed migration to Kinde
 sidebar:
-  order: 11
+  order: 12
   label: Drip-feed migration
 tableOfContents:
   maxHeadingLevel: 3
@@ -36,7 +36,7 @@ keywords:
   - kinde workflows
   - gradual migration
   - password validation
-updated: 2026-05-05
+updated: 2026-08-05
 featured: false
 deprecated: false
 ai_summary: "Drip-feed migration is a lazy, on-demand approach to moving users from a legacy auth system to Kinde — users are migrated automatically the first time they sign in, with no downtime and no forced password resets. It relies on the user:existing_password_provided Kinde workflow trigger, which fires when a user attempts to sign in with a password Kinde does not yet recognize. The workflow checks whether the user exists in Kinde; if not, it validates the submitted password against the legacy system via a secure API call. On a successful match, it creates the user in Kinde and sets their password so all future logins are handled by Kinde directly. Users who never sign in during the migration window can be handled separately via bulk import or the Management API. This approach requires no changes to the application's login flow — only a Kinde workflow and a validation endpoint on the legacy system. It suits large user bases where a one-time bulk migration is risky or impractical. Once all active users have migrated naturally, the legacy system can be safely decommissioned. This page is an overview; a full step-by-step implementation tutorial is linked at the bottom."

--- a/src/content/docs/get-started/switch-to-kinde/fusionauth-to-kinde.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/fusionauth-to-kinde.mdx
@@ -9,7 +9,7 @@ tableOfContents:
 relatedArticles:
   - c4bc277a-5ec7-418c-ba1c-4d58c9ddfd7d
   - f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
-  - b338980f-7dd6-4ba5-90aa-330247a45536
+  - 1977cf9a-cde0-4d88-85a7-92173771b191
   - e89d246a-5cdf-4993-9cee-94b31ec27583
 description: Export FusionAuth users and password hashes as NDJSON and import into Kinde—users sign in with existing credentials, no reset required
 topics:
@@ -32,7 +32,7 @@ keywords:
   - pbkdf2
   - bcrypt
   - bulk user import
-updated: 2026-06-18
+updated: 2026-08-05
 featured: false
 deprecated: false
 ai_summary: "Step-by-step guide for migrating users from FusionAuth to Kinde using bulk NDJSON import via Users > Import users > FusionAuth. FusionAuth exports user details and password hashes together, so Kinde imports both in one step with no separate password import. Covers exporting from FusionAuth via direct database export (snake_case fields) or the FusionAuth API (camelCase fields), both of which Kinde accepts. Documents field mapping for email, username, phone, names, verification status, and password hash attributes. Supported password schemes include salted-pbkdf2-hmac-sha256, salted-pbkdf2-hmac-sha256-512, salted-pbkdf2-hmac-sha512-512, and bcrypt; users on unsupported schemes import successfully but reset on first sign-in. Social and federated logins are not included. Import files must be 49MB or less. Includes guidance on username case sensitivity, testing migrated sign-in, re-import behavior, migration window edge cases, and user communication. Intended for developers and admins moving authentication from FusionAuth to Kinde."
@@ -66,19 +66,19 @@ Kinde accepts both naming styles, so use whichever export method suits you. Each
 
 Kinde reads the following fields from each user record:
 
-| FusionAuth field | Used for |
-|---|---|
-| `id` | Stable external identifier — used to match records on re-import |
-| `email` | Email identity |
-| `username` | Username identity |
-| `mobile_phone` / `mobilePhone` | Phone identity |
-| `first_name` / `firstName` | Given name |
-| `last_name` / `lastName` | Family name |
-| `verified` | Whether the identity is verified |
-| `encryption_scheme` / `encryptionScheme` | Password hashing variant |
-| `salt` | Password salt (base64) |
-| `factor` / `iterations` | PBKDF2 iteration count |
-| `password` | Password hash (base64 derived key) |
+| FusionAuth field                         | Used for                                                        |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `id`                                     | Stable external identifier — used to match records on re-import |
+| `email`                                  | Email identity                                                  |
+| `username`                               | Username identity                                               |
+| `mobile_phone` / `mobilePhone`           | Phone identity                                                  |
+| `first_name` / `firstName`               | Given name                                                      |
+| `last_name` / `lastName`                 | Family name                                                     |
+| `verified`                               | Whether the identity is verified                                |
+| `encryption_scheme` / `encryptionScheme` | Password hashing variant                                        |
+| `salt`                                   | Password salt (base64)                                          |
+| `factor` / `iterations`                  | PBKDF2 iteration count                                          |
+| `password`                               | Password hash (base64 derived key)                              |
 
 #### Supported password hashing
 
@@ -100,7 +100,7 @@ Kinde imports the email, username, and phone identities found on each FusionAuth
 1. In Kinde, go to **Users**, then select **Import users**.
 2. Select **FusionAuth**.
 
-    ![import from fusionauth](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/7101c8f3-4f88-4410-fd1e-02477cbd9500/socialsharingimage)
+   ![import from fusionauth](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/7101c8f3-4f88-4410-fd1e-02477cbd9500/socialsharingimage)
 
 3. Follow the on-screen prompts to upload your NDJSON file (49MB or less).
 4. Review any [import errors](/manage-users/add-and-edit/troubleshoot-user-import-errors/) reported after import. Fix the file and re-import to resolve them.

--- a/src/content/docs/get-started/switch-to-kinde/migrate-users-bulk-import.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/migrate-users-bulk-import.mdx
@@ -85,9 +85,9 @@ Import files must be 49MB or less. This applies to Custom CSV, Auth0 NDJSON, Fus
 
 **Required column:**
 
-| Column  | Notes                  |
-| ------- | ---------------------- |
-| `email` | Minimum required field |
+| Column             | Notes                                                          |
+| ------------------ | -------------------------------------------------------------- |
+| `email` or `phone` | At least one login identity is required. You can include both. |
 
 **Recommended columns:**
 
@@ -96,7 +96,7 @@ Import files must be 49MB or less. This applies to Custom CSV, Auth0 NDJSON, Fus
 | `first_name`, `last_name`  | User's name                                                             |
 | `email_verified`           | `TRUE` or `FALSE`                                                       |
 | `id`                       | Your provider's user ID — helps match records during re-imports         |
-| `phone`                    | International format, e.g. `+61555111555`                               |
+| `phone`                    | International format, e.g. `+61555111555`. Required if you omit `email` |
 | `external_organization_id` | Organization ID to import the user into. Comma-separate multiple values |
 | `role_key`                 | Role key(s) to assign. Comma-separate multiple values                   |
 | `permission_key`           | Permission key(s) to assign. Comma-separate multiple values             |
@@ -118,6 +118,8 @@ Include these if you're migrating hashed passwords:
 | `salt`            | Optional — extra characters added to strengthen the hash |
 | `salt_position`   | `prefix` or `suffix` — required if salt is included      |
 | `salt_format`     | Format of the salt, e.g. `hex` or `string`               |
+| `variant`         | PBKDF2 only — required. See below                        |
+| `iterations`      | PBKDF2 only — optional. See below                        |
 
 **Supported hashing methods:**
 
@@ -141,6 +143,15 @@ Kinde substitutes `$2b` with `$2a` on import. These are interchangeable unless t
 <Aside title="sha256">
 
 Provide the hash in hex format. For `salt_format`, specify `hex` for a hex-encoded salt (e.g. `68656c6c6f` for `hello`). By default, the salt is treated as a plain string.
+
+</Aside>
+
+<Aside title="pbkdf2">
+
+Include a base64-encoded `salt` and a `variant` of `salted-pbkdf2-hmac-sha256`,
+`salted-pbkdf2-hmac-sha256-512`, or `salted-pbkdf2-hmac-sha512-512`. `iterations` is
+optional and defaults to 24000. See
+[password data](/manage-users/add-and-edit/import-users-in-bulk/#password-data-optional).
 
 </Aside>
 

--- a/src/content/docs/get-started/switch-to-kinde/migrate-users-bulk-import.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/migrate-users-bulk-import.mdx
@@ -2,7 +2,7 @@
 page_id: f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
 title: Bulk import users to Kinde
 sidebar:
-  order: 9
+  order: 10
   label: Bulk import
 tableOfContents:
   maxHeadingLevel: 3
@@ -35,10 +35,13 @@ keywords:
   - NDJSON import
   - firebase import
   - firebase scrypt
-updated: 2026-07-19
+  - ASP.NET Identity import
+  - ASP.NET Identity v2
+  - UTF-16 CSV
+updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: "This guide explains how to bulk import users into Kinde using CSV or NDJSON files (49MB or less). It covers the full migration workflow: configuring your Kinde business with matching auth strategies, exporting users from providers like Auth0, Clerk, Supabase, Firebase, AWS Cognito, or Azure B2C, preparing a properly formatted file, and running the import via the Kinde dashboard. The guide details required and optional CSV columns including email, name, email verification status, organization IDs, roles, and permissions. It also covers migrating hashed passwords, with support for bcrypt, MD5, SHA256, crypt, and WordPress hashing methods, including salt configuration. Post-import guidance addresses handling new registrations and password changes during the migration window, recommending re-imports, forced password resets, or parallel API usage. The guide also notes that Kinde does not notify users on import, advising teams to plan their own communication strategy, and lists edge cases such as password changes mid-migration and how newly added authentication methods affect returning users."
+ai_summary: "Guide to bulk importing users into Kinde with CSV or NDJSON files up to 49MB. It covers provider exports, UTF-8 and UTF-16-with-BOM CSV requirements, supported user and organization fields, and password migration with bcrypt, MD5, SHA256, crypt, WordPress, PBKDF2, Firebase scrypt, and ASP.NET Identity v2 hashes. It lists the dedicated Auth0, FusionAuth, Firebase, and ASP.NET Identity import types, explains salt configuration, and covers re-imports, migration-window changes, and user communication."
 ---
 
 Export your users from your existing auth system, prepare a CSV, and import them into Kinde. Users with migrated password hashes can sign in immediately with no password reset required.
@@ -72,30 +75,31 @@ Export instructions vary by provider. Select yours:
 - [Firebase →](/get-started/switch-to-kinde/firebase-to-kinde/)
 - [AWS Cognito →](/get-started/switch-to-kinde/aws-cognito-to-kinde/)
 - [Azure B2C →](/get-started/switch-to-kinde/azure-b2c-to-kinde/)
+- [ASP.NET Identity →](/get-started/switch-to-kinde/aspnet-identity-to-kinde/)
 
 If you are migrating from your own system, prepare the data to match the format described below.
 
 ### 3. Prepare your CSV
 
-Import files must be 49MB or less. This applies to Custom CSV, Auth0 NDJSON, FusionAuth NDJSON, Custom NDJSON, and Firebase NDJSON imports. Format your export with the following columns.
+Import files must be 49MB or less. This applies to Custom CSV, Auth0 NDJSON, FusionAuth NDJSON, Custom NDJSON, Firebase NDJSON, and ASP.NET Identity CSV imports. CSV files must be encoded as UTF-8 or UTF-16 with a byte order mark (BOM). Format your export with the following columns.
 
 **Required column:**
 
-| Column | Notes |
-|--------|-------|
+| Column  | Notes                  |
+| ------- | ---------------------- |
 | `email` | Minimum required field |
 
 **Recommended columns:**
 
-| Column | Notes |
-|--------|-------|
-| `first_name`, `last_name` | User's name |
-| `email_verified` | `TRUE` or `FALSE` |
-| `id` | Your provider's user ID — helps match records during re-imports |
-| `phone` | International format, e.g. `+61555111555` |
+| Column                     | Notes                                                                   |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `first_name`, `last_name`  | User's name                                                             |
+| `email_verified`           | `TRUE` or `FALSE`                                                       |
+| `id`                       | Your provider's user ID — helps match records during re-imports         |
+| `phone`                    | International format, e.g. `+61555111555`                               |
 | `external_organization_id` | Organization ID to import the user into. Comma-separate multiple values |
-| `role_key` | Role key(s) to assign. Comma-separate multiple values |
-| `permission_key` | Permission key(s) to assign. Comma-separate multiple values |
+| `role_key`                 | Role key(s) to assign. Comma-separate multiple values                   |
+| `permission_key`           | Permission key(s) to assign. Comma-separate multiple values             |
 
 <Aside>
 
@@ -107,24 +111,26 @@ Import files must be 49MB or less. This applies to Custom CSV, Auth0 NDJSON, Fus
 
 Include these if you're migrating hashed passwords:
 
-| Column | Notes |
-|--------|-------|
-| `hashed_password` | The hashed password string |
-| `hashing_method` | See supported methods below |
-| `salt` | Optional — extra characters added to strengthen the hash |
-| `salt_position` | `prefix` or `suffix` — required if salt is included |
-| `salt_format` | Format of the salt, e.g. `hex` or `string` |
+| Column            | Notes                                                    |
+| ----------------- | -------------------------------------------------------- |
+| `hashed_password` | The hashed password string                               |
+| `hashing_method`  | See supported methods below                              |
+| `salt`            | Optional — extra characters added to strengthen the hash |
+| `salt_position`   | `prefix` or `suffix` — required if salt is included      |
+| `salt_format`     | Format of the salt, e.g. `hex` or `string`               |
 
 **Supported hashing methods:**
 
-| Method | Salt | Salt position |
-|--------|------|---------------|
-| `bcrypt` | — | — |
-| `md5` | Optional | Required if salt included |
-| `sha256` | Optional | Required if salt included |
-| `crypt` | Optional | — |
-| `wordpress` | Optional | — |
-| `firebase-scrypt` | Required | — |
+| Method               | Salt                 | Salt position             |
+| -------------------- | -------------------- | ------------------------- |
+| `bcrypt`             | —                    | —                         |
+| `md5`                | Optional             | Required if salt included |
+| `sha256`             | Optional             | Required if salt included |
+| `crypt`              | Optional             | —                         |
+| `wordpress`          | Optional             | —                         |
+| `pbkdf2`             | Required (base64)    | —                         |
+| `firebase-scrypt`    | Required             | —                         |
+| `aspnet-identity-v2` | Embedded in the hash | —                         |
 
 <Aside title="bcrypt $2b variant">
 
@@ -138,6 +144,16 @@ Provide the hash in hex format. For `salt_format`, specify `hex` for a hex-encod
 
 </Aside>
 
+<Aside title="aspnet-identity-v2">
+
+Use the `PasswordHash` value from the ASP.NET Identity `AspNetUsers` table exactly as
+exported. The salt and other parameters are embedded in the hash, so do not include
+`salt`, `salt_position`, `iterations`, or `variant`. Rows containing those values are
+rejected. Kinde supports ASP.NET Identity v2 hashes, not ASP.NET Core Identity v3 hashes.
+See [Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/).
+
+</Aside>
+
 **Check for errors before importing:**
 
 Review the CSV for missing or duplicate values. Kinde will report errors after import. Records that have already been imported without changes are skipped on re-import.
@@ -146,9 +162,11 @@ Review the CSV for missing or duplicate values. Kinde will report errors after i
 
 1. In Kinde, go to **Users**, then select **Import users**.
 2. Select your import type:
+
    - **Auth0** — for NDJSON files exported from Auth0
    - **FusionAuth** — for NDJSON files exported from FusionAuth
    - **Firebase** — for NDJSON files prepared from a Firebase Authentication export (`firebase auth:export`)
+   - **ASP.NET Identity** — for a CSV export of the `AspNetUsers` table
    - **Custom NDJSON** — for NDJSON files exported from other providers
    - **Custom CSV** — for all other providers
 

--- a/src/content/docs/get-started/switch-to-kinde/supabase-to-kinde.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/supabase-to-kinde.mdx
@@ -9,7 +9,7 @@ tableOfContents:
 relatedArticles:
   - c4bc277a-5ec7-418c-ba1c-4d58c9ddfd7d
   - f6eaf29b-d8d9-4caf-bc1d-5319b6fb8ffc
-  - 8b3e1d47-2f96-4a0c-c8d5-6e7a2b9f3150
+  - 1977cf9a-cde0-4d88-85a7-92173771b191
   - e89d246a-5cdf-4993-9cee-94b31ec27583
 description: Export users and hashed passwords from Supabase Auth and import them into Kinde. Supabase uses bcrypt, which Kinde supports natively — users keep their existing passwords.
 topics:
@@ -38,7 +38,7 @@ keywords:
   - bulk import
   - sql export
   - social login migration
-updated: 2026-05-05
+updated: 2026-08-05
 featured: false
 deprecated: false
 ai_summary: "Step-by-step guide for migrating users from Supabase Auth to Kinde using a bulk CSV import. Supabase stores passwords as bcrypt hashes in the auth.users table, which is not accessible via the standard API. Users are exported by running a SQL query in the Supabase SQL Editor — selecting id, email, encrypted_password, email_verified (derived from email_confirmed_at), and name fields from raw_user_meta_data. The exported CSV requires one column rename (encrypted_password to hashed_password) and a new hashing_method column set to bcrypt for every row. Social and OAuth users stored in auth.identities can be imported by email and will re-link their social login on first sign-in. The prepared CSV is imported in Kinde via Users > Import users > Custom CSV. Password authentication must be enabled in Kinde before importing hashed passwords. Links to the full bulk import guide for additional CSV fields covering organizations, roles, and permissions."
@@ -48,7 +48,7 @@ Migrate your users from Supabase Auth to Kinde. Supabase stores passwords as bcr
 
 ### What you need
 
-- A Kinde account with **Admin** access 
+- A Kinde account with **Admin** access
 - Kinde account configured to match your current auth provider - see [before you migrate](/get-started/switch-to-kinde/switch-to-kinde-for-user-authentication/#before-you-migrate)
 - Supabase account with SQL editor permissions
 
@@ -67,17 +67,17 @@ Migrate your users from Supabase Auth to Kinde. Supabase stores passwords as bcr
 2. Go to **SQL Editor** in the sidebar.
 3. Run the following query:
 
-    ```sql
-    SELECT
-      id,
-      email,
-      encrypted_password AS hashed_password,
-      CASE WHEN email_confirmed_at IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS email_verified,
-      raw_user_meta_data->>'first_name' AS first_name,
-      raw_user_meta_data->>'last_name'  AS last_name
-    FROM auth.users
-    WHERE email IS NOT NULL;
-    ```
+   ```sql
+   SELECT
+     id,
+     email,
+     encrypted_password AS hashed_password,
+     CASE WHEN email_confirmed_at IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS email_verified,
+     raw_user_meta_data->>'first_name' AS first_name,
+     raw_user_meta_data->>'last_name'  AS last_name
+   FROM auth.users
+   WHERE email IS NOT NULL;
+   ```
 
 4. In the results panel, set the row limit to **No Limit** so all users are returned.
 5. Select **Export** and choose **Download CSV**.
@@ -92,15 +92,15 @@ If your app stores names under different keys in `raw_user_meta_data` (e.g. `ful
 
 The SQL query exports columns that mostly match Kinde's expected names. Rename the one that differs and add the `hashing_method` column.
 
-| Supabase column | Rename to | Notes |
-|---|---|---|
-| `email` | `email` | Required — primary sign-in identifier |
-| `id` | `id` | Keep as-is |
-| `email_verified` | `email_verified` | Keep as-is — `TRUE` or `FALSE` |
-| `first_name` | `first_name` | Keep as-is |
-| `last_name` | `last_name` | Keep as-is |
-| `encrypted_password` | `hashed_password` | bcrypt hash — preserves existing passwords |
-| *(new column)* | `hashing_method` | Add this column and set every row to `bcrypt` |
+| Supabase column      | Rename to         | Notes                                         |
+| -------------------- | ----------------- | --------------------------------------------- |
+| `email`              | `email`           | Required — primary sign-in identifier         |
+| `id`                 | `id`              | Keep as-is                                    |
+| `email_verified`     | `email_verified`  | Keep as-is — `TRUE` or `FALSE`                |
+| `first_name`         | `first_name`      | Keep as-is                                    |
+| `last_name`          | `last_name`       | Keep as-is                                    |
+| `encrypted_password` | `hashed_password` | bcrypt hash — preserves existing passwords    |
+| _(new column)_       | `hashing_method`  | Add this column and set every row to `bcrypt` |
 
 For the full list of supported CSV fields — including organizations, roles, and permissions — see [Prepare your CSV](/get-started/switch-to-kinde/migrate-users-bulk-import/#3-prepare-your-csv) in the bulk import guide.
 

--- a/src/content/docs/get-started/switch-to-kinde/switch-to-kinde-for-user-authentication.mdx
+++ b/src/content/docs/get-started/switch-to-kinde/switch-to-kinde-for-user-authentication.mdx
@@ -35,13 +35,14 @@ keywords:
   - supabase to kinde
   - aws cognito to kinde
   - azure b2c to kinde
+  - ASP.NET Identity to Kinde
   - hashed password migration
   - zero downtime migration
   - user export
-updated: 2026-07-19
+updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: "This page is the top-level migration hub for teams moving user authentication to Kinde. It covers what data can be migrated — users, hashed passwords (bcrypt, sha256, md5, crypt, WordPress, and Firebase modified scrypt), organizations, and roles and permissions — and what to configure in Kinde before importing. It then presents four migration strategies: bulk import (export users to CSV or JSON and import in one go, with hashed password support), API-based user creation (provision users programmatically by intercepting sign-ins or sign-ups during a migration window), drip-feed migration (users migrate automatically on first login using a Kinde workflow that validates credentials against the legacy system — zero downtime, no bulk export needed, recommended for most teams), and hard cutover (planned maintenance window with a full export and import). Each strategy includes a best-for summary and a link to the detailed guide. The page also links to provider-specific export guides for Auth0, Clerk, Supabase, Firebase, AWS Cognito, and Azure B2C."
+ai_summary: "Migration hub for moving user authentication to Kinde. It lists migratable user data and supported password hashes, including PBKDF2, Firebase scrypt, and ASP.NET Identity v2, and explains what to configure before migration. It compares bulk import, API-based provisioning, drip-feed migration, and hard cutover strategies, then links to provider guides for Auth0, FusionAuth, Clerk, Supabase, Firebase, AWS Cognito, Azure B2C, and ASP.NET Identity."
 ---
 
 Moving to Kinde from another auth provider? Choose a migration method below, then follow the export guide for your current provider.
@@ -49,7 +50,7 @@ Moving to Kinde from another auth provider? Choose a migration method below, the
 ## What you can migrate
 
 - **Users** — email, name, phone, external ID
-- **Hashed passwords** — bcrypt, sha256, md5, crypt, wordpress, and Firebase modified scrypt supported
+- **Hashed passwords** — bcrypt, sha256, md5, crypt, wordpress, pbkdf2, Firebase scrypt, and ASP.NET Identity v2 supported
 - **Organizations** — for multi-tenant apps
 - **Roles and permissions** — assigned per user and per organization
 
@@ -106,3 +107,4 @@ Each provider has its own export format and limitations. Select your current pro
 - [Firebase →](/get-started/switch-to-kinde/firebase-to-kinde/)
 - [AWS Cognito →](/get-started/switch-to-kinde/aws-cognito-to-kinde/)
 - [Azure B2C →](/get-started/switch-to-kinde/azure-b2c-to-kinde/)
+- [ASP.NET Identity →](/get-started/switch-to-kinde/aspnet-identity-to-kinde/)

--- a/src/content/docs/manage-users/access-control/set-temporary-password.mdx
+++ b/src/content/docs/manage-users/access-control/set-temporary-password.mdx
@@ -27,10 +27,12 @@ keywords:
   - salt
   - security warning
   - api password
-updated: 2024-01-15
+  - ASP.NET Identity v2
+  - aspnet-identity-v2
+updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: Guide to setting temporary passwords for users including security considerations, API methods, hashing algorithms, and single-use password management.
+ai_summary: Guide to setting temporary passwords in the Kinde admin or setting hashed passwords through the Management API. Covers security considerations, single-use passwords, supported hashing methods including ASP.NET Identity v2, and salt configuration.
 ---
 
 If you have set up [password authentication](/authenticate/authentication-methods/password-authentication/) for your users, you might want to set or update their password. Kinde lets you set a single-use, temporary password to enable authentication. There are a number of reasons why you might need to do this, for example:
@@ -80,30 +82,46 @@ We only accept password hashes and will never allow plain text passwords
 
 Include the following information for the password API:
 
-- `hashed_password` - the user’s password encrypted using a hashing method or algorithm
-- `hashing_method` - the name of the algorithm used to encrypt the user’s password. Currently **crypt**, **bcrypt**, **md5**, **SHA256**, and **wordpress** are supported.
+- `hashed_password` — the user's hashed password
+- `hashing_method` — the algorithm used to hash the password. Supported values are
+  `crypt`, `bcrypt`, `md5`, `sha256`, `wordpress`, and `aspnet-identity-v2`.
 
-    <Aside title="bcrypt $2b variant support">
+<Aside title="bcrypt $2b variant support">
 
-  If you are importing bcrypt hashes with the $2b variant, Kinde will substitute this for the $2a variant. These are interchangeable as long as you were not running OpenBSD at the time the hashes were generated.
+Kinde substitutes bcrypt `$2b` hashes with `$2a`. These are interchangeable unless the
+hashes were generated on OpenBSD.
 
-    </Aside>
+</Aside>
 
-    <Aside title="sha256 support:">
+<Aside title="ASP.NET Identity v2 support">
 
-  Provide the hash in hex format. For the `salt_format`, specify how the salt should be interpreted: e.g. **hex** for a hex-encoded string (68656c6c6f for hello). By default, the salt is treated as a plain string, and escape sequences (like \n or \v) are treated as literal characters.
+For `aspnet-identity-v2`, send the `PasswordHash` value from the ASP.NET Identity
+`AspNetUsers` table as `hashed_password`. Do not send `salt`, `salt_position`,
+`iterations`, or `variant` because those parameters are embedded in the hash. See
+[Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/).
 
-    </Aside>
+</Aside>
 
-- `salt` - extra characters added to passwords to make them stronger
-- `salt_position` - position of salt in password string. Prefix (before) or suffix (after).
+<Aside title="sha256 support">
 
-  | Hashing method | Salt     | Salt position             |
-  | -------------- | -------- | ------------------------- |
-  | md5            | Optional | required if salt included |
-  | bcrypt         |          |                           |
-  | crypt          | Optional |                           |
-  | wordpress      | Optional |                           |
-  | SHA256         | Optional | required if salt included |
+Provide the hash in hex format. For `salt_format`, use `hex` for a hex-encoded string,
+such as `68656c6c6f` for `hello`. By default, Kinde treats the salt as a plain string and
+treats escape sequences such as `\n` or `\v` as literal characters.
 
-- `is_temporary_password` - indicates a single use password, the user will be prompted to set a new password after the first time they use it.
+</Aside>
+
+- `salt` — extra characters added to passwords before hashing
+- `salt_position` — position of the salt in the password string, either `prefix` or
+  `suffix`
+
+| Hashing method       | Salt                 | Salt position             |
+| -------------------- | -------------------- | ------------------------- |
+| `md5`                | Optional             | Required if salt included |
+| `bcrypt`             | —                    | —                         |
+| `crypt`              | Optional             | —                         |
+| `wordpress`          | Optional             | —                         |
+| `sha256`             | Optional             | Required if salt included |
+| `aspnet-identity-v2` | Embedded in the hash | —                         |
+
+- `is_temporary_password` — indicates a single-use password. The user is prompted to set
+  a new password after using it once.

--- a/src/content/docs/manage-users/access-control/set-temporary-password.mdx
+++ b/src/content/docs/manage-users/access-control/set-temporary-password.mdx
@@ -84,7 +84,10 @@ Include the following information for the password API:
 
 - `hashed_password` — the user's hashed password
 - `hashing_method` — the algorithm used to hash the password. Supported values are
-  `crypt`, `bcrypt`, `md5`, `sha256`, `wordpress`, and `aspnet-identity-v2`.
+  `bcrypt`, `crypt`, `md5`, `sha256`, `wordpress`, `pbkdf2`, `firebase-scrypt`, and
+  `aspnet-identity-v2`. The
+  [Set user password API reference](/kinde-apis/management#tag/users/put/api/v1/users/{user_id}/password)
+  is the source of truth for which parameters each method requires.
 
 <Aside title="bcrypt $2b variant support">
 
@@ -110,18 +113,37 @@ treats escape sequences such as `\n` or `\v` as literal characters.
 
 </Aside>
 
+<Aside title="pbkdf2 support">
+
+Send the base64-encoded `salt` and a `variant` of `salted-pbkdf2-hmac-sha256`,
+`salted-pbkdf2-hmac-sha256-512`, or `salted-pbkdf2-hmac-sha512-512`. `iterations` is
+optional and defaults to 24000 when omitted.
+
+</Aside>
+
+<Aside title="firebase-scrypt support">
+
+Send the user's base64-encoded `salt` plus your Firebase project's `signer_key`,
+`salt_separator`, `rounds`, and `mem_cost`. See
+[importing from Firebase](/manage-users/add-and-edit/import-users-in-bulk/#importing-from-firebase)
+for where to find these values.
+
+</Aside>
+
 - `salt` — extra characters added to passwords before hashing
 - `salt_position` — position of the salt in the password string, either `prefix` or
   `suffix`
 
-| Hashing method       | Salt                 | Salt position             |
-| -------------------- | -------------------- | ------------------------- |
-| `md5`                | Optional             | Required if salt included |
-| `bcrypt`             | —                    | —                         |
-| `crypt`              | Optional             | —                         |
-| `wordpress`          | Optional             | —                         |
-| `sha256`             | Optional             | Required if salt included |
-| `aspnet-identity-v2` | Embedded in the hash | —                         |
+| Hashing method       | Salt                        | Salt position             |
+| -------------------- | --------------------------- | ------------------------- |
+| `md5`                | Optional                    | Required if salt included |
+| `bcrypt`             | —                           | —                         |
+| `crypt`              | Optional                    | —                         |
+| `wordpress`          | Optional                    | —                         |
+| `sha256`             | Optional                    | Required if salt included |
+| `pbkdf2`             | Required (base64)           | —                         |
+| `firebase-scrypt`    | Required (base64, per user) | —                         |
+| `aspnet-identity-v2` | Embedded in the hash        | —                         |
 
 - `is_temporary_password` — indicates a single-use password. The user is prompted to set
   a new password after using it once.

--- a/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
+++ b/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
@@ -420,6 +420,10 @@ The more data that you include for import, the easier we can set up your users i
 - `salt_position` — position of the salt in the password string, either `prefix` or
   `suffix`
 - `salt_format` — format of the salt, such as `hex` or `string`
+- `variant` — PBKDF2 only. The hashing variant used to derive the hash. Required for
+  `pbkdf2`.
+- `iterations` — PBKDF2 only. The iteration count (factor) used to derive the hash.
+  Optional for `pbkdf2`.
 - `signer_key` — Firebase only. The base64-encoded signer key from your Firebase project's
   password hash parameters.
 - `salt_separator` — Firebase only. The base64-encoded salt separator from your Firebase
@@ -457,6 +461,24 @@ Provide the hash in hex format and import the salt using the `salt` column. For
 `salt_format`, use `hex` for a hex-encoded string, such as `68656c6c6f` for `hello`. By
 default, Kinde treats the salt as a plain string and treats escape sequences such as `\n`
 or `\v` as literal characters.
+
+</Aside>
+
+<Aside title="pbkdf2 support">
+
+Provide the base64-encoded `salt` for each user, plus a `variant` column. Kinde supports
+these variants:
+
+- `salted-pbkdf2-hmac-sha256` (HMAC-SHA256, 256-bit)
+- `salted-pbkdf2-hmac-sha256-512` (HMAC-SHA256, 512-bit)
+- `salted-pbkdf2-hmac-sha512-512` (HMAC-SHA512, 512-bit)
+
+The `iterations` column is optional. If you leave it empty, Kinde verifies the hash using
+an iteration count of 24000. Set it explicitly if your system used a different factor,
+otherwise migrated users will not be able to sign in.
+
+Both columns are specific to PBKDF2. Rows that set them alongside `firebase-scrypt` or
+`aspnet-identity-v2` are rejected.
 
 </Aside>
 

--- a/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
+++ b/src/content/docs/manage-users/add-and-edit/import-users-in-bulk.mdx
@@ -36,22 +36,37 @@ keywords:
   - organization assignment
   - external_organization_id
   - username case sensitivity
+  - ASP.NET Identity import
+  - ASP.NET Identity v2
+  - UTF-16 CSV
+  - UTF-16 NDJSON
 updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: "Guide to importing users in bulk to Kinde using UTF-8 CSV or NDJSON files up to 49MB. Covers file requirements, username case-insensitivity, and preparing data so users link to roles, permissions, organizations, feature flags, properties, identities, and API scopes. Includes the full NDJSON schema and CSV preparation for user and password data. Supported CSV password hashes include crypt, bcrypt, sha256, md5, wordpress, and Firebase scrypt. Firebase scrypt imports require a per-user base64 salt and the project's signer key, salt separator, rounds, and memory cost; these passwords can also be supplied through the Management API. Explains Firebase and Auth0 migration paths, import steps, error handling, re-import behavior, and the end-user sign-in experience. Intended for admins and developers managing large-scale user migrations."
+ai_summary: "Guide to importing users in bulk to Kinde using UTF-8 or BOM-marked UTF-16 CSV and NDJSON files up to 49MB. Covers file requirements, username case-insensitivity, and preparing data so users link to roles, permissions, organizations, feature flags, properties, identities, and API scopes. Includes the full NDJSON schema and CSV preparation for user and password data. Supported CSV password hashes include crypt, bcrypt, sha256, md5, wordpress, PBKDF2, Firebase scrypt, and ASP.NET Identity v2. Firebase scrypt imports require a per-user base64 salt and the project's signer key, salt separator, rounds, and memory cost; these passwords can also be supplied through the Management API. Explains Auth0, Firebase, and ASP.NET Identity migration paths, import steps, error handling, re-import behavior, and the end-user sign-in experience. Intended for admins and developers managing large-scale user migrations."
 ---
 
-You can import users in bulk, from CSV or JSON. If you are moving to Kinde from Auth0 or Firebase, see the dedicated migration guides ([Auth0](/manage-users/add-and-edit/import-users-from-auth0/), [Firebase](/get-started/switch-to-kinde/firebase-to-kinde/)) instead.
+You can import users in bulk from CSV or JSON. If you are moving to Kinde from Auth0,
+Firebase, or ASP.NET Identity, see the dedicated migration guides
+([Auth0](/manage-users/add-and-edit/import-users-from-auth0/),
+[Firebase](/get-started/switch-to-kinde/firebase-to-kinde/), and
+[ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/)).
 
 ## File requirements
 
-- CSV - User details and passwords need to be in UTF-8 encoded CSV format
-- NDJSON - User details and passwords need to be in NDJSON (Newline Delimited JSON) format, one user object per line
-- Firebase NDJSON - Firebase Authentication user objects in NDJSON format (one object per line), prepared from `firebase auth:export`
+- **CSV** — user details and passwords in CSV format, encoded as UTF-8 or UTF-16
+  with a byte order mark (BOM)
+- **NDJSON** — user details and passwords in NDJSON (Newline Delimited JSON) format,
+  one user object per line, encoded as UTF-8 or UTF-16 with a BOM
+- **Firebase NDJSON** — Firebase Authentication user objects in NDJSON format, one
+  object per line, prepared from `firebase auth:export`
+- **ASP.NET Identity CSV** — a CSV export of the `AspNetUsers` table. See
+  [Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/)
+- Files that are neither UTF-8 nor BOM-marked UTF-16 are rejected before rows are imported
 - File size must be 49MB or less
 
-If you’ve got large user sets (over 49MB) or are concerned about file size limits, you might consider importing in batches, or contact us for import support.
+For user sets over 49MB, import in batches or
+[contact Kinde support](https://kinde.com/support).
 
 ## Importing from Firebase
 
@@ -158,7 +173,7 @@ The following schema can be used for importing NDJSON files, note this schema re
         },
         "hashing_algorithm": {
           "type": "string",
-          "enum": ["crypt", "bcrypt", "sha256", "md5", "wordpress"],
+          "enum": ["crypt", "bcrypt", "sha256", "md5", "wordpress", "pbkdf2", "firebase-scrypt"],
           "description": "The algorithm used to hash the password."
         }
       }
@@ -397,40 +412,67 @@ The more data that you include for import, the easier we can set up your users i
 
 ### Password data (optional)
 
-- `hashed_password` - the hashed password.
-- `hashing_method` - the algorithm used to hash the password. One of `bcrypt`, `crypt`, `md5`, `sha256`, `wordpress`, or `firebase-scrypt`.
-- `salt` - extra characters added to the password to make it stronger. See the table below for when this is required.
-- `salt_position` - position of the salt in the password string: `prefix` or `suffix`.
-- `salt_format` - format of the salt, e.g. `hex` or `string`.
-- `signer_key` - Firebase only. The base64-encoded signer key from your Firebase project's password hash parameters.
-- `salt_separator` - Firebase only. The base64-encoded salt separator from your Firebase project's password hash parameters.
-- `rounds` - Firebase only. The scrypt rounds value (1–16) from your Firebase project's password hash parameters.
-- `mem_cost` - Firebase only. The scrypt memory cost value (1–20) from your Firebase project's password hash parameters.
-
-<Aside title="bcrypt $2b variant support:">
-
-Please note if you are importing bcrypt hashes with the $2b variant, Kinde will substitute this for the $2a variant. These are interchangeable as long as you were not running OpenBSD at the time the hashes were generated.
-
-  </Aside>
-
-  <Aside title="sha256 support:">
-
-Provide the hash in hex format. Import the salt using the `salt` column. For the `salt_format`, specify how the salt should be interpreted: e.g. **hex** for a hex-encoded string (68656c6c6f for hello). By default, the salt is treated as a plain string, and escape sequences (like \n or \v) are treated as literal characters.
-
-  </Aside>
+- `hashed_password` — the user's hashed password
+- `hashing_method` — the algorithm used to hash the password. One of `bcrypt`, `crypt`,
+  `md5`, `sha256`, `wordpress`, `pbkdf2`, `firebase-scrypt`, or `aspnet-identity-v2`.
+- `salt` — extra characters added to the password before hashing. See the table below for
+  when this is required.
+- `salt_position` — position of the salt in the password string, either `prefix` or
+  `suffix`
+- `salt_format` — format of the salt, such as `hex` or `string`
+- `signer_key` — Firebase only. The base64-encoded signer key from your Firebase project's
+  password hash parameters.
+- `salt_separator` — Firebase only. The base64-encoded salt separator from your Firebase
+  project's password hash parameters.
+- `rounds` — Firebase only. The scrypt rounds value (1–16) from your Firebase project's
+  password hash parameters.
+- `mem_cost` — Firebase only. The scrypt memory cost value (1–20) from your Firebase
+  project's password hash parameters.
 
 | Hashing method                                | Salt                        | Salt position             |
 | --------------------------------------------- | --------------------------- | ------------------------- |
+| `md5`                                         | Optional                    | Required if salt included |
 | `bcrypt`                                      | Optional                    | —                         |
 | `crypt`                                       | Optional                    | —                         |
-| `md5`                                         | Optional                    | Required if salt included |
-| `sha256`                                      | Optional                    | Required if salt included |
 | `wordpress`                                   | Optional                    | —                         |
+| `sha256`                                      | Optional                    | Required if salt included |
+| `pbkdf2`                                      | Required (base64)           | —                         |
 | [`firebase-scrypt`](#importing-from-firebase) | Required (base64, per user) | —                         |
+| `aspnet-identity-v2`                          | Embedded in the hash        | —                         |
 
 For `firebase-scrypt` passwords, every row must also include the `signer_key`, `salt_separator`, `rounds`, and `mem_cost` columns. These four values are the same for every user in a Firebase project. You can find them in the Firebase console under **Authentication > Users**, in the three-dots menu, as **Password hash parameters**.
 
 You can use the Firebase-style column names (`signerKey`, `saltSeparator`, and `memCost`) instead of the snake_case names if that is how your export is labelled.
+
+<Aside title="bcrypt $2b variant support">
+
+Kinde substitutes bcrypt `$2b` hashes with `$2a` on import. These are interchangeable
+unless the hashes were generated on OpenBSD.
+
+</Aside>
+
+<Aside title="sha256 support">
+
+Provide the hash in hex format and import the salt using the `salt` column. For
+`salt_format`, use `hex` for a hex-encoded string, such as `68656c6c6f` for `hello`. By
+default, Kinde treats the salt as a plain string and treats escape sequences such as `\n`
+or `\v` as literal characters.
+
+</Aside>
+
+<Aside title="aspnet-identity-v2 support">
+
+Provide the `PasswordHash` value from the ASP.NET Identity `AspNetUsers` table exactly as
+exported. The salt and other parameters are embedded in the hash, so leave `salt`,
+`salt_position`, `iterations`, and `variant` empty. Rows containing those values are
+rejected. Kinde supports ASP.NET Identity v2 hashes on the .NET Framework, not ASP.NET
+Core Identity v3 hashes.
+
+For a full database migration, use the dedicated **ASP.NET Identity** import type, which
+maps `AspNetUsers` columns automatically. See
+[Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/).
+
+</Aside>
 
 ### **Example simple csv import**
 
@@ -473,8 +515,9 @@ id,roles,permissions,external_organization_id
 1. In Kinde, go to **Users**, then select **Import users**.
 2. Select the option for your situation:
    - **Firebase** — see [Migrate to Kinde from Firebase Authentication](/get-started/switch-to-kinde/firebase-to-kinde/)
-   - Custom CSV
-   - Custom NDJSON
+   - **ASP.NET Identity** — see [Migrate to Kinde from ASP.NET Identity](/get-started/switch-to-kinde/aspnet-identity-to-kinde/)
+   - **Custom CSV**
+   - **Custom NDJSON**
 3. Follow the on-screen prompts to import the data.
 4. If there are any [errors with the import](/manage-users/add-and-edit/troubleshoot-user-import-errors/), you will be able to view them afterwards.
 5. Most import errors can be fixed by editing the CSV or NDJSON file and then re-importing into Kinde. Any records that have already been successfully imported, will be ignored.

--- a/src/content/docs/manage-users/add-and-edit/move-users.mdx
+++ b/src/content/docs/manage-users/add-and-edit/move-users.mdx
@@ -28,10 +28,12 @@ keywords:
   - organization assignment
   - roles and permissions
   - hashed passwords
-updated: 2025-09-09
+  - pbkdf2
+  - firebase scrypt
+updated: 2026-08-05
 featured: false
 deprecated: false
-ai_summary: You can move users between Kinde environments or businesses by exporting and importing them.
+ai_summary: Move users, identities, passwords, organizations, roles, permissions, properties, feature flags, and API scopes between Kinde environments or businesses with an NDJSON export and import workflow. Includes the supported user schema and password hashing algorithms.
 ---
 
 If you need to move users between Kinde environments or Kinde businesses, you can do this using a JSON export and import routine.
@@ -117,7 +119,7 @@ The following schema can be used for importing NDJSON files, note this schema re
         },
         "hashing_algorithm": {
           "type": "string",
-          "enum": ["crypt", "bcrypt", "sha256", "md5", "wordpress"],
+          "enum": ["crypt", "bcrypt", "sha256", "md5", "wordpress", "pbkdf2", "firebase-scrypt"],
           "description": "The algorithm used to hash the password."
         }
       }

--- a/src/content/docs/manage-users/add-and-edit/troubleshoot-user-import-errors.mdx
+++ b/src/content/docs/manage-users/add-and-edit/troubleshoot-user-import-errors.mdx
@@ -29,12 +29,22 @@ keywords:
   - password hash errors
   - CSV validation
   - duplicate records
+  - invalid email
+  - missing information
+  - organization errors
+  - role errors
+  - permission errors
+  - password errors
   - INVALID_SIGNER_KEY
   - organization role errors
+  - ASP.NET Identity
+  - invalid password hash
+  - file encoding
+  - UTF-16
 updated: 2026-08-09
 featured: false
 deprecated: false
-ai_summary: "Troubleshooting guide for bulk user import errors in Kinde. Explains how Kinde validates import files and surfaces common failures including duplicate records by ID or email, invalid emails, missing or invalid fields, and references to organizations, roles, or permissions that do not exist. Covers viewing the post-import error log, correcting the file, and re-importing without deleting already imported users. Details password import failures such as unmatched users, unsupported hashing algorithms, and incorrect columns, plus Firebase scrypt validation errors for signer key, salt separator, rounds, and memory cost. Also covers remediating bad data from a previous provider and assigning users when organization, role, or permission keys do not match. Intended for admins and developers resolving migration and bulk import issues."
+ai_summary: "Troubleshooting guide for bulk user import errors in Kinde. Explains how Kinde validates import files and surfaces common failures including duplicate records by ID or email, invalid emails, missing or invalid fields, and references to organizations, roles, or permissions that do not exist. Covers viewing the post-import error log, correcting the file, and re-importing without deleting already imported users. Details password import failures such as unmatched users, unsupported hashing algorithms, and incorrect columns, plus Firebase scrypt validation errors for signer key, salt separator, rounds, and memory cost, ASP.NET Identity v2 hash validation, unsupported ASP.NET Core Identity v3 hashes, missing login identities, and UTF-8 or UTF-16 file encoding failures. Also covers remediating bad data from a previous provider and assigning users when organization, role, or permission keys do not match. Intended for admins and developers resolving migration and bulk import issues."
 ---
 
 When you import users in bulk from a file, Kinde checks to see if there are errors that will prevent a new user record from being created or updated.
@@ -82,6 +92,36 @@ If you're importing `firebase-scrypt` passwords, each of the four Firebase hash 
 - **Invalid mem cost** (`INVALID_MEM_COST`) — the `mem_cost` column is missing or outside the range 1–20.
 
 These four values come from the Firebase console: **Authentication > Users > ⋮ > [Password hash parameters](/manage-users/add-and-edit/import-users-in-bulk/#importing-from-firebase)**. They are project-wide, so the fix usually applies to every failed row at once. Correct the values in your file and re-import.
+
+### ASP.NET Identity password errors
+
+When you use the **ASP.NET Identity** import type or the `aspnet-identity-v2` hashing
+method, a password validation error prevents the entire row from being imported. Fix the
+file and re-import the row.
+
+- **The password hash is invalid** — `PasswordHash` must contain a valid
+  [ASP.NET Identity v2 hash](/get-started/switch-to-kinde/aspnet-identity-to-kinde/#which-hash-format-do-i-have).
+  V2 hashes are 68 base64 characters and decode to 49 bytes. ASP.NET Core Identity v3
+  hashes are longer and typically start with `AQAAAA`; Kinde cannot verify them. A value
+  can also become invalid if it is truncated or reformatted in a spreadsheet. To import
+  the user without a password, clear `PasswordHash`. They can then set a password when
+  they first sign in.
+- **The hashing configuration is invalid** — do not provide `salt`, `salt_position`,
+  `iterations`, or `variant` with `aspnet-identity-v2`. These values are embedded in the
+  hash, so clear the corresponding fields.
+- **The row has no login identity** — a row with a password must also have an email,
+  phone number, or username. Add a login identity or remove the password.
+
+### File encoding errors
+
+If the whole import fails before rows are processed, check the file encoding. Kinde
+accepts CSV and NDJSON files encoded as UTF-8 or UTF-16 with a byte order mark (BOM).
+Other encodings, including Windows-1252 and Latin-1, are rejected to prevent corrupted
+names and email addresses.
+
+Re-save the file as UTF-8 or BOM-marked UTF-16 and import it again. In SQL Server
+Management Studio, choose one of those encodings when saving the results. With `bcp`, use
+`-w` for UTF-16 or `-c -C 65001` for UTF-8.
 
 ### Bad data from previous provider
 

--- a/src/content/docs/manage-users/add-and-edit/troubleshoot-user-import-errors.mdx
+++ b/src/content/docs/manage-users/add-and-edit/troubleshoot-user-import-errors.mdx
@@ -99,13 +99,14 @@ When you use the **ASP.NET Identity** import type or the `aspnet-identity-v2` ha
 method, a password validation error prevents the entire row from being imported. Fix the
 file and re-import the row.
 
-- **The password hash is invalid** — `PasswordHash` must contain a valid
+- **The password hash is invalid** — the password field must contain a valid
   [ASP.NET Identity v2 hash](/get-started/switch-to-kinde/aspnet-identity-to-kinde/#which-hash-format-do-i-have).
-  V2 hashes are 68 base64 characters and decode to 49 bytes. ASP.NET Core Identity v3
-  hashes are longer and typically start with `AQAAAA`; Kinde cannot verify them. A value
-  can also become invalid if it is truncated or reformatted in a spreadsheet. To import
-  the user without a password, clear `PasswordHash`. They can then set a password when
-  they first sign in.
+  This is `PasswordHash` for the **ASP.NET Identity** import type, or `hashed_password`
+  for Custom CSV. V2 hashes are 68 base64 characters and decode to 49 bytes. ASP.NET Core
+  Identity v3 hashes are longer and typically start with `AQAAAA`; Kinde cannot verify
+  them. A value can also become invalid if it is truncated or reformatted in a
+  spreadsheet. To import the user without a password, clear the applicable password-hash
+  field. They can then set a password when they first sign in.
 - **The hashing configuration is invalid** — do not provide `salt`, `salt_position`,
   `iterations`, or `variant` with `aspnet-identity-v2`. These values are embedded in the
   hash, so clear the corresponding fields.


### PR DESCRIPTION
#### Description (required)

Adds a dedicated migration guide for importing ASP.NET Identity v2 users and password hashes without requiring password resets.

This change also:

- Documents `AspNetUsers` CSV exports from SSMS and `bcp`, supported v2 hash detection, field mapping, and unsupported ASP.NET Core Identity v3 hashes.
- Updates bulk and custom import guidance for the ASP.NET Identity import type and UTF-8 or BOM-marked UTF-16 files.
- Adds consistent hashing guidance to the migration overview, password API pages, and import troubleshooting.
- Synchronizes supported NDJSON hashing methods and updates navigation and related-article links.

Validation completed:

- `npm run build`
- `node scripts/validate-links.js`
- `node scripts/check-for-duplicate-page-ids.js`
- Prettier validation for all changed MDX files
- ASP.NET Identity sample hashes validated as 49-byte v2 values with a `0x00` marker

#### Related issues & labels (optional)

- Suggested label: New doc

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive ASP.NET Identity migration guidance, including exports, imports, password validation, rehashing, and API-based migration.
  * Added support documentation for ASP.NET Identity v2, PBKDF2, and Firebase scrypt password hashes.
  * Documented UTF-16 BOM CSV and NDJSON imports, expanded import workflows, and dedicated Firebase and ASP.NET Identity options.
* **Documentation**
  * Updated migration guides, metadata, navigation, related links, formatting, and screenshots.
  * Expanded troubleshooting guidance for encoding, password, hash, configuration, and identity errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->