### PR TITLE
Update SOC 2 report access details in compliance.mdx

### DIFF
--- a/src/content/docs/trust-center/privacy-and-compliance/compliance.mdx
+++ b/src/content/docs/trust-center/privacy-and-compliance/compliance.mdx
@@ -59,7 +59,7 @@ Kinde has completed a SOC 2 Type 2 with report and attestation from [AssuranceLa
 
 You can download a copy of our [Attestation Status Confirmation](/assets/images/docs/certificates/Kinde-SOC-2-Type-2-Attestation-Status.pdf).
 
-Access to the full SOC 2 report is part of our Scale and Enterprise plans. Reach out to our team if you need a copy and note that you will require an NDA as there’s sensitive information in the report.
+Access to the full SOC 2 report is included in our paid plans (Pro, Plus, and Scale) but is not currently available on the Free plan. Reach out to our team if you need a copy and note that you will require an NDA as there’s sensitive information in the report.
 
 A [SOC 2 examination](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) is a report on controls at a service organization relevant to security, availability, processing integrity, confidentiality, or privacy. SOC 2 reports are intended to meet the needs of a broad range of users that need detailed information and assurance about the controls at a service organization relevant to security, availability, and processing integrity of the systems the service organization uses to process users’ data and the confidentiality and privacy of the information processed by these systems.
 


### PR DESCRIPTION



#### Description 

Clarified access to the full SOC 2 report in compliance.mdx, **specifying that it is included in paid plans (Pro, Plus, and Scale) and not available on the Free plan, to align with the Pricing page**.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SOC 2 report access policy to include Pro, Plus, and Scale plans.
  * Clarified that the Free plan does not include SOC 2 report access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->