### PR TITLE
fix: add aside to OTP/MFA expiration duration about it being for scale

### DIFF
--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -88,7 +88,11 @@ See [Sign users in to last organization](/authenticate/manage-authentication/sig
 
 ### Passkeys
 
-<Aside type="upgrade">Passkeys require a [Kinde paid plan](https://kinde.com/pricing/).</Aside>
+<Aside type="upgrade">
+
+Passkeys require a [Kinde paid plan](https://kinde.com/pricing/).
+
+</Aside>
 
 Passkeys let users sign in with biometrics (Face ID, fingerprint) or a device PIN instead of typing a password. They are more secure than passwords alone and faster for users who sign in regularly.
 

--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -88,9 +88,7 @@ See [Sign users in to last organization](/authenticate/manage-authentication/sig
 
 ### Passkeys
 
-<Aside type="upgrade">
-Passkeys require a [Kinde paid plan](https://kinde.com/pricing/).
-</Aside>
+<Aside type="upgrade">Passkeys require a [Kinde paid plan](https://kinde.com/pricing/).</Aside>
 
 Passkeys let users sign in with biometrics (Face ID, fingerprint) or a device PIN instead of typing a password. They are more secure than passwords alone and faster for users who sign in regularly.
 
@@ -105,6 +103,12 @@ Leave it on if you use social or enterprise sign-in. You only need to switch it 
 Some enterprise connections also have their own profile sync setting—both the global policy here and the connection setting need to be enabled for sync to work. See [About users](/manage-users/about/).
 
 ### MFA/OTP Code expiration duration
+
+<Aside type="upgrade">
+
+This is an advanced feature that is only available on the [Kinde Scale plan](https://kinde.com/pricing/).
+
+</Aside>
 
 When users receive a one-time code by email or SMS—for multi-factor authentication, passwordless sign-in, or password reset—this setting controls how long the code stays valid.
 
@@ -139,9 +143,9 @@ This setting works together with the **Members and roles** function of the organ
 
 Global access policies can be overridden at the individual organization level if you are on a [Kinde Scale plan](https://kinde.com/pricing/) and activate the Advanced organization feature.
 
-| To…                                                                                             | Do this…                                                                                          |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Allow anyone to sign up to your applications.                                                   | Select **Allow self sign-up**.                                                                    |
+| To…                                                                                             | Do this…                                                                                      |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Allow anyone to sign up to your applications.                                                   | Select **Allow self sign-up**.                                                                |
 | Allow only people from `specificdomain.com` to sign up to your applications.                    | Select **Allow self sign-up** and enter `specificdomain.com` in the **Allowed domains** list. |
-| Allow anyone to sign up to your applications and create an organization if they are a business. | Select **Allow self sign-up** and **Allow organization creation on sign up**.                     |
-| Let organization members invite other people into their organization.                           | Select **Allow invitations** and choose an **Invite application**.                                |
+| Allow anyone to sign up to your applications and create an organization if they are a business. | Select **Allow self sign-up** and **Allow organization creation on sign up**.                 |
+| Let organization members invite other people into their organization.                           | Select **Allow invitations** and choose an **Invite application**.                            |

--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -110,11 +110,11 @@ Some enterprise connections also have their own profile sync setting—both the 
 
 <Aside type="upgrade">
 
-This is an advanced feature that is only available on the [Kinde Scale plan](https://kinde.com/pricing/).
+Changing the default MFA/OTP expiration value is a feature that requires the [Kinde Scale plan](https://kinde.com/pricing/).
 
 </Aside>
 
-When users receive a one-time code by email or SMS—for multi-factor authentication, passwordless sign-in, or password reset—this setting controls how long the code stays valid.
+When users receive a one-time code by email or SMS for multi-factor authentication, passwordless sign-in, or password reset, this setting controls how long the code stays valid.
 
 - The default expiry duration is 120 minutes (2 hours).
 - The expiry duration appears in your email templates automatically.


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Add an aside to the OTP/MFA expiration duration section about the feature only being available on Scale. 

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted the Passkeys upgrade notice for improved readability.
  * Added a notice explaining that MFA/OTP code expiration settings require the Scale plan.
  * Clarified the MFA/OTP code expiration description.
  * Normalized spacing in the policy quick-reference table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->