### PR TITLE
Add 2026 security wall of fame researchers

### DIFF
--- a/src/content/docs/trust-center/security/security-wall-of-fame.mdx
+++ b/src/content/docs/trust-center/security/security-wall-of-fame.mdx
@@ -23,7 +23,7 @@ keywords:
   - "bug bounty"
   - "responsible disclosure"
   - "security wall of fame"
-updated: "2026-06-09"
+updated: "2026-08-17"
 featured: false
 deprecated: false
 ai_summary: "Recognition page for security researchers who have responsibly disclosed vulnerabilities to help secure Kinde's systems, organized by year with links to researcher profiles."
@@ -42,6 +42,14 @@ Love your work!
 ### Disclosures
 
 [The Security Company](https://thesecurity.company/)
+
+[Ihor Herasymovych](https://www.linkedin.com/in/mgorunuch)
+
+[Michal Biesiada](https://www.linkedin.com/in/michal-biesiada)
+
+Naveed Qadir
+
+[Imwdev](https://imw.neocities.org/bug-bounty-portfolio)
 
 ## 2025
 


### PR DESCRIPTION
## Summary
- Adds Ihor Herasymovych, Michal Biesiada, Naveed Qadir, and Imwdev to the 2026 Disclosures list on the Security wall of fame
- Links Ihor and Michal to LinkedIn, Imwdev to their bug bounty portfolio; Naveed has no public profile URL
- Updates the page `updated` date

This supersedes #773 (Ihor only, stale vs current `main`).

## Test plan
- [ ] Confirm all four names appear under 2026 Disclosures after The Security Company on https://docs.kinde.com/trust-center/security/security-wall-of-fame/
- [ ] Confirm Ihor → https://www.linkedin.com/in/mgorunuch
- [ ] Confirm Michal → https://www.linkedin.com/in/michal-biesiada
- [ ] Confirm Naveed Qadir is listed without a link
- [ ] Confirm Imwdev → https://imw.neocities.org/bug-bounty-portfolio


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Security Wall of Fame page date to August 17, 2026.
  * Added four new entries to the 2026 security disclosures list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->