### PR TITLE
New Doc:  guide on integrating Kinde with SpacetimeDB

### DIFF
--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -1,0 +1,217 @@
+---
+page_id: 7eaa79ab-49be-4e00-be2a-54950de661e5
+title: Integrate SpacetimeDB with Kinde
+description: Authenticate SpacetimeDB users with a Kinde-issued ID token in a React app, with no server-side configuration.
+sidebar:
+  order: 15
+relatedArticles:
+  - f3dcba7f-fa4f-4ea1-a470-f03af04ba347
+  - 820ec3ab-2b80-4331-937c-644da9f8b339
+topics:
+  - integrate
+  - third-party-tools
+sdk:
+  - React.js
+languages:
+  - bash
+  - typescript
+audience:
+  - developers
+complexity: intermediate
+keywords:
+  - spacetimedb
+  - openid connect
+  - react
+---
+
+Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users from a Kinde-issued ID token with no server-side configuration. This guide shows you how to obtain that token in a React app and pass it to your SpacetimeDB connection.
+
+### What you need
+
+- A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/sdks/typescript/react-quickstart).
+- A [Kinde](https://kinde.com) account.
+
+## Step 1: Install the Kinde React SDK
+
+<PackageManagers pkg="@kinde-oss/kinde-auth-react" />
+
+## Step 2: Set up your Kinde application
+
+1. In the [Kinde dashboard](https://app.kinde.com), add a **Front-end and mobile** application and select **React** as the SDK. For the full walkthrough, see [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/).
+2. On the application's **Details** page, copy the **Client ID** and **Domain** from **App keys**. Both are public values that ship to the browser.
+3. On the same page, set the callback and logout URLs to your Vite dev server origin, `http://localhost:5173`. Learn more about [callback URLs](/get-started/connect/callback-urls/).
+
+These URLs must match exactly what your app sends. If your dev server starts on a different port, Kinde rejects the sign-in with a `redirect_uri` mismatch before authenticating.
+
+## Step 3: Create a KindeTokenProvider component
+
+This component:
+
+- Waits for Kinde to finish initializing.
+- Fetches the ID token once the user is signed in.
+- Exposes the token to the rest of your app through React context.
+
+`KindeTokenProvider.tsx`
+
+```tsx
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
+
+const KindeTokenContext = createContext<string | null>(null);
+
+export function useKindeToken(): string | null {
+  return useContext(KindeTokenContext);
+}
+
+export function KindeTokenProvider({ children }: { children: ReactNode }) {
+  const { isLoading, isAuthenticated, getIdToken } = useKindeAuth();
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (!isAuthenticated) {
+      setToken(null);
+      return;
+    }
+
+    let cancelled = false;
+    getIdToken()
+      .then(idToken => {
+        if (!cancelled) setToken(idToken ?? null);
+      })
+      .catch(err => {
+        console.error('Failed to get Kinde ID token:', err);
+        if (!cancelled) setToken(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, isAuthenticated, getIdToken]);
+
+  return (
+    <KindeTokenContext.Provider value={token}>
+      {children}
+    </KindeTokenContext.Provider>
+  );
+}
+```
+
+Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
+
+## Step 4: Add the providers in main.tsx
+
+<Aside type="info" title="Remove the existing SpacetimeDBProvider">
+Don't forget to remove any existing `SpacetimeDBProvider` from `main.tsx`. The connection is created in `App.tsx` instead, once the token is available.
+</Aside>
+
+`main.tsx`
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { KindeProvider } from '@kinde-oss/kinde-auth-react';
+import { KindeTokenProvider } from './KindeTokenProvider';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <KindeProvider
+      clientId="<YOUR_KINDE_CLIENT_ID>"
+      domain="<YOUR_KINDE_DOMAIN>"
+      redirectUri={window.location.origin}
+      logoutUri={window.location.origin}
+      forceChildrenRender
+    >
+      <KindeTokenProvider>
+        <App />
+      </KindeTokenProvider>
+    </KindeProvider>
+  </StrictMode>
+);
+```
+
+Kinde returns the user to `redirectUri` with an authorization code in the query string, and the SDK completes the exchange when that page mounts. No dedicated callback route is required. `forceChildrenRender` renders your app while Kinde initializes, so you can drive your UI from `isLoading` instead of showing a blank page.
+
+## Step 5: Use the ID token in App.tsx
+
+1. Read the token with `useKindeToken()`.
+2. Build the connection inside `useMemo`, with the token as a dependency.
+
+Mount `SpacetimeDBProvider` only once the token exists. `SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in will not pick the token up afterwards.
+
+`App.tsx`
+
+```tsx
+import { useMemo } from 'react';
+import { SpacetimeDBProvider } from 'spacetimedb/react';
+import { DbConnection } from './module_bindings';
+import { useKindeToken } from './KindeTokenProvider';
+
+export default function App() {
+  const token = useKindeToken();
+
+  const connectionBuilder = useMemo(
+    () =>
+      DbConnection.builder()
+        .withUri('<YOUR SPACETIMEDB URL>')
+        .withDatabaseName('<YOUR SPACETIMEDB MODULE NAME>')
+        .withToken(token ?? undefined)
+        .onConnect((_conn, identity) =>
+          console.log('Connected as:', identity.toHexString())
+        )
+        .onConnectError((_ctx, err) => console.log('Connection error:', err)),
+    [token]
+  );
+
+  if (!token) {
+    return <p>Sign in to continue.</p>;
+  }
+
+  return (
+    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+      {/* Your app */}
+    </SpacetimeDBProvider>
+  );
+}
+```
+
+## Step 6: Add signed-in UI and sign out (optional)
+
+`useKindeAuth` exposes the signed-in user along with `login`, `register`, and `logout`:
+
+```tsx
+import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
+
+function AuthControls() {
+  const { isLoading, isAuthenticated, user, login, register, logout } =
+    useKindeAuth();
+
+  if (isLoading) return <span>Loading…</span>;
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        <button onClick={() => login()}>Sign in</button>
+        <button onClick={() => register()}>Sign up</button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span>{user?.email}</span>
+      <button onClick={() => logout()}>Sign out</button>
+    </>
+  );
+}
+```
+
+Your users are now authenticated with Kinde, and `ctx.sender` in your module is an `Identity` derived from their Kinde `iss` and `sub` claims — stable across devices and sessions. SpacetimeDB verifies the token's signature against Kinde's public keys, but it does not decide *which* issuers or audiences your module accepts. To check those claims, and to authorize what a signed-in user may do, see [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -39,7 +39,7 @@ Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users 
 
 ### What you need
 
-- A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/sdks/typescript/react-quickstart).
+- A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/quickstarts/react/).
 - A [Kinde](https://kinde.com) account.
 
 ## Quickstart
@@ -242,7 +242,7 @@ Your users are now authenticated with Kinde, and `ctx.sender` in your module is 
 
 ## Resources
 
-- [SpacetimeDB React Quickstart](https://spacetimedb.com/docs/sdks/typescript/react-quickstart)
+- [SpacetimeDB React Quickstart](https://spacetimedb.com/docs/quickstarts/react/)
 - [SpacetimeDB Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/)
 - [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/)
 - [Callback URLs](/get-started/connect/callback-urls/)

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -1,7 +1,7 @@
 ---
 page_id: 7eaa79ab-49be-4e00-be2a-54950de661e5
 title: Integrate SpacetimeDB with Kinde
-description: Authenticate SpacetimeDB users with a Kinde-issued ID token in a React app, with no server-side configuration.
+description: "Authenticate SpacetimeDB users with Kinde in minutes. Pass a Kinde ID token to your React app's connection, with no auth server to run."
 sidebar:
   order: 15
 tableOfContents:
@@ -12,18 +12,27 @@ relatedArticles:
 topics:
   - integrate
   - third-party-tools
+  - oauth
 sdk:
-  - React.js
+  - react
 languages:
-  - bash
   - typescript
+  - tsx
+  - bash
 audience:
   - developers
 complexity: intermediate
 keywords:
   - spacetimedb
   - openid connect
-  - react
+  - ID token
+  - react authentication
+  - real-time database
+  - JWT verification
+updated: 2026-08-25
+featured: false
+deprecated: false
+ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The quickstart covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes it to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. An optional step adds user details and sign out. Prerequisites are a working SpacetimeDB project and a Kinde account. Intended for developers adding authentication to real-time SpacetimeDB applications."
 ---
 
 Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users from a Kinde-issued ID token with no server-side configuration. This guide shows you how to obtain that token in a React app and pass it to your SpacetimeDB connection.
@@ -230,3 +239,10 @@ function AuthControls() {
 ## Next steps
 
 Your users are now authenticated with Kinde, and `ctx.sender` in your module is an `Identity` derived from their Kinde `iss` and `sub` claims — stable across devices and sessions. SpacetimeDB verifies the token's signature against Kinde's public keys, but it does not decide *which* issuers or audiences your module accepts. To check those claims, and to authorize what a signed-in user may do, see [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).
+
+## Resources
+
+- [SpacetimeDB React Quickstart](https://spacetimedb.com/docs/sdks/typescript/react-quickstart)
+- [SpacetimeDB Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/)
+- [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/)
+- [Callback URLs](/get-started/connect/callback-urls/)

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -119,6 +119,10 @@ The above code:
 
 Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
 
+<Aside type="warning" title="The sample doesn't restrict who can connect">
+SpacetimeDB verifies the token's signature, but it accepts any OpenID Connect issuer. Until your module checks the `iss` and `aud` claims in a `clientConnected` reducer, a signature-valid token from another provider connects too. See [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).
+</Aside>
+
 ## Step 4: Add the providers in main.tsx
 
 <Aside type="warning" title="Remove the existing SpacetimeDBProvider">

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -4,6 +4,8 @@ title: Integrate SpacetimeDB with Kinde
 description: Authenticate SpacetimeDB users with a Kinde-issued ID token in a React app, with no server-side configuration.
 sidebar:
   order: 15
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - f3dcba7f-fa4f-4ea1-a470-f03af04ba347
   - 820ec3ab-2b80-4331-937c-644da9f8b339
@@ -31,11 +33,13 @@ Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users 
 - A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/sdks/typescript/react-quickstart).
 - A [Kinde](https://kinde.com) account.
 
-## Step 1: Install the Kinde React SDK
+## Quickstart
+
+### 1. Install the Kinde React SDK
 
 <PackageManagers pkg="@kinde-oss/kinde-auth-react" />
 
-## Step 2: Set up your Kinde application
+### 2. Set up your Kinde application
 
 1. In the [Kinde dashboard](https://app.kinde.com), add a **Front-end and mobile** application and select **React** as the SDK. For the full walkthrough, see [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/).
 2. On the application's **Details** page, copy the **Client ID** and **Domain** from **App keys**. Both are public values that ship to the browser.
@@ -43,7 +47,7 @@ Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users 
 
 These URLs must match exactly what your app sends. If your dev server starts on a different port, Kinde rejects the sign-in with a `redirect_uri` mismatch before authenticating.
 
-## Step 3: Create a KindeTokenProvider component
+### 3. Create a KindeTokenProvider component
 
 This component:
 
@@ -106,7 +110,7 @@ export function KindeTokenProvider({ children }: { children: ReactNode }) {
 
 Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
 
-## Step 4: Add the providers in main.tsx
+### 4. Add the providers in main.tsx
 
 <Aside type="info" title="Remove the existing SpacetimeDBProvider">
 Don't forget to remove any existing `SpacetimeDBProvider` from `main.tsx`. The connection is created in `App.tsx` instead, once the token is available.
@@ -140,7 +144,7 @@ createRoot(document.getElementById('root')!).render(
 
 Kinde returns the user to `redirectUri` with an authorization code in the query string, and the SDK completes the exchange when that page mounts. No dedicated callback route is required. `forceChildrenRender` renders your app while Kinde initializes, so you can drive your UI from `isLoading` instead of showing a blank page.
 
-## Step 5: Use the ID token in App.tsx
+### 5. Use the ID token in App.tsx
 
 1. Read the token with `useKindeToken()`.
 2. Build the connection inside `useMemo`, with the token as a dependency.
@@ -192,7 +196,7 @@ export default function App() {
 
 Check `isLoading` before `token`. Because `forceChildrenRender` renders your app while Kinde initializes, `token` is still `null` on the first render even for a user who is already signed in — without the loading branch they would see the sign-in button flash before their session resolves.
 
-## Step 6: Add user details and sign out (optional)
+### 6. Add user details and sign out (optional)
 
 Your app can now sign users in. `useKindeAuth` also exposes the signed-in user, along with `register` and `logout`, if you want a fuller set of controls:
 
@@ -222,5 +226,7 @@ function AuthControls() {
   );
 }
 ```
+
+## Next steps
 
 Your users are now authenticated with Kinde, and `ctx.sender` in your module is an `Identity` derived from their Kinde `iss` and `sub` claims — stable across devices and sessions. SpacetimeDB verifies the token's signature against Kinde's public keys, but it does not decide *which* issuers or audiences your module accepts. To check those claims, and to authorize what a signed-in user may do, see [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -4,8 +4,6 @@ title: Integrate SpacetimeDB with Kinde
 description: "Authenticate SpacetimeDB users with Kinde in minutes. Pass a Kinde ID token to your React app's connection, with no auth server to run."
 sidebar:
   order: 15
-tableOfContents:
-  maxHeadingLevel: 3
 relatedArticles:
   - f3dcba7f-fa4f-4ea1-a470-f03af04ba347
   - 820ec3ab-2b80-4331-937c-644da9f8b339
@@ -260,6 +258,37 @@ The above code:
 4. Renders a **Sign out** control that ends the Kinde session and returns the user to your `logoutUri`.
 
 The `user` object is populated from the ID token claims, so `givenName`, `familyName`, `email`, and `picture` are available on the client with no extra API call. Which fields are filled in depends on what the user's identity provider returned and what you collect at sign-up, so treat each one as optional.
+
+Then render `AuthControls` in `App.tsx`, in place of the sign-in button from step 5:
+
+```tsx
+import { AuthControls } from './AuthControls';
+// ... other imports
+
+export default function App() {
+  const { isLoading } = useKindeAuth();
+  const token = useKindeToken();
+
+  // ... connectionBuilder
+
+  if (isLoading) {
+    return <p>Loading…</p>;
+  }
+
+  if (!token) {
+    return <AuthControls />;
+  }
+
+  return (
+    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+      <AuthControls />
+      {/* Your app */}
+    </SpacetimeDBProvider>
+  );
+}
+```
+
+`AuthControls` now renders the sign-in control, so `App` no longer needs `login` from `useKindeAuth`. Rendering it in both branches gives signed-out users a way in, and signed-in users their details and a **Sign out** control.
 
 ## Next steps
 

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -29,42 +29,37 @@ keywords:
   - react authentication
   - real-time database
   - JWT verification
-updated: 2026-08-25
+updated: 2026-08-27
 featured: false
 deprecated: false
-ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The quickstart covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes it to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. An optional step adds user details and sign out. Prerequisites are a working SpacetimeDB project and a Kinde account. Intended for developers adding authentication to real-time SpacetimeDB applications."
+ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The guide covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes it to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. The final step displays user information from the ID token and adds sign out. Prerequisites are a Kinde account and a working SpacetimeDB project. Intended for developers adding authentication to real-time SpacetimeDB applications."
 ---
 
 Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users from a Kinde-issued ID token with no server-side configuration. This guide shows you how to obtain that token in a React app and pass it to your SpacetimeDB connection.
 
-### What you need
+## What you need
 
+- A [Kinde](https://kinde.com) account (Sign up for free)
 - A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/quickstarts/react/).
-- A [Kinde](https://kinde.com) account.
 
-## Quickstart
-
-### 1. Install the Kinde React SDK
+## Step 1: Install the Kinde React SDK
 
 <PackageManagers pkg="@kinde-oss/kinde-auth-react" />
 
-### 2. Set up your Kinde application
+## Step 2: Set up your Kinde application
 
-1. In the [Kinde dashboard](https://app.kinde.com), add a **Front-end and mobile** application and select **React** as the SDK. For the full walkthrough, see [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/).
-2. On the application's **Details** page, copy the **Client ID** and **Domain** from **App keys**. Both are public values that ship to the browser.
-3. On the same page, set the callback and logout URLs to your Vite dev server origin, `http://localhost:5173`. Learn more about [callback URLs](/get-started/connect/callback-urls/).
+1. Sign in to your [Kinde dashboard](https://app.kinde.com) and select **Add application**.
+2. Enter a name for the application, for example `My SpacetimeDB React App`.
+3. Select **Front-end and mobile** as the application type, then select **Save**.
+4. On the **Quick start** page, select **React** from the list of Front-end SDKs, then select **Save**.
+5. On the application's **Details** page, copy the **Client ID** and **Domain** from **App keys**. Both are public values that ship to the browser.
+6. On the same page, set the callback and logout URLs to your Vite dev server origin, `http://localhost:5173`. Learn more about [callback URLs](/get-started/connect/callback-urls/).
 
 These URLs must match exactly what your app sends. If your dev server starts on a different port, Kinde rejects the sign-in with a `redirect_uri` mismatch before authenticating.
 
-### 3. Create a KindeTokenProvider component
+## Step 3: Create a KindeTokenProvider component
 
-This component:
-
-- Waits for Kinde to finish initializing.
-- Fetches the ID token once the user is signed in.
-- Exposes the token to the rest of your app through React context.
-
-`KindeTokenProvider.tsx`
+Create a `KindeTokenProvider.tsx` file with the following code:
 
 ```tsx
 import {
@@ -117,15 +112,22 @@ export function KindeTokenProvider({ children }: { children: ReactNode }) {
 }
 ```
 
+The above code:
+
+1. Waits for Kinde to finish initializing, so it doesn't request a token too early.
+2. Fetches the ID token with `getIdToken()` once the user is signed in.
+3. Clears the token when the user signs out.
+4. Exposes the token to the rest of your app through React context, which you read with the `useKindeToken()` hook.
+
 Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
 
-### 4. Add the providers in main.tsx
+## Step 4: Add the providers in main.tsx
 
-<Aside type="info" title="Remove the existing SpacetimeDBProvider">
+<Aside type="warning" title="Remove the existing SpacetimeDBProvider">
 Don't forget to remove any existing `SpacetimeDBProvider` from `main.tsx`. The connection is created in `App.tsx` instead, once the token is available.
 </Aside>
 
-`main.tsx`
+Update `main.tsx` with the following code:
 
 ```tsx
 import { StrictMode } from 'react';
@@ -151,17 +153,17 @@ createRoot(document.getElementById('root')!).render(
 );
 ```
 
+The above code:
+
+1. Wraps your app in `KindeProvider`, using the **Client ID** and **Domain** you copied in step 2.
+2. Sets `redirectUri` and `logoutUri` to your dev server origin, matching the URLs you saved in Kinde.
+3. Wraps `App` in `KindeTokenProvider`, so the ID token is available anywhere in your component tree.
+
 Kinde returns the user to `redirectUri` with an authorization code in the query string, and the SDK completes the exchange when that page mounts. No dedicated callback route is required. `forceChildrenRender` renders your app while Kinde initializes, so you can drive your UI from `isLoading` instead of showing a blank page.
 
-### 5. Use the ID token in App.tsx
+## Step 5: Use the ID token in App.tsx
 
-1. Read the token with `useKindeToken()`.
-2. Build the connection inside `useMemo`, with the token as a dependency.
-3. Render a sign-in control until the token is available.
-
-Mount `SpacetimeDBProvider` only once the token exists. `SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in will not pick the token up afterwards.
-
-`App.tsx`
+Update `App.tsx` with the following code:
 
 ```tsx
 import { useMemo } from 'react';
@@ -203,16 +205,28 @@ export default function App() {
 }
 ```
 
+The above code:
+
+1. Reads the ID token with `useKindeToken()`.
+2. Builds the SpacetimeDB connection inside `useMemo`, with the token as a dependency.
+3. Shows a loading state while Kinde resolves the session.
+4. Renders a sign-in control until a token is available.
+5. Mounts `SpacetimeDBProvider` only once the token exists.
+
+`SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in never picks the token up afterwards. That is why it is mounted only after the token exists.
+
 Check `isLoading` before `token`. Because `forceChildrenRender` renders your app while Kinde initializes, `token` is still `null` on the first render even for a user who is already signed in — without the loading branch they would see the sign-in button flash before their session resolves.
 
-### 6. Add user details and sign out (optional)
+## Step 6: Add user details and sign out
 
-Your app can now sign users in. `useKindeAuth` also exposes the signed-in user, along with `register` and `logout`, if you want a fuller set of controls:
+Your app can now sign users in, but users still need a way to see who they are signed in as and to sign out again. `useKindeAuth` exposes the signed-in `user`, along with `register` and `logout`, for a fuller set of controls.
+
+Create an `AuthControls.tsx` file with the following code:
 
 ```tsx
 import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
 
-function AuthControls() {
+export function AuthControls() {
   const { isLoading, isAuthenticated, user, login, register, logout } =
     useKindeAuth();
 
@@ -229,6 +243,8 @@ function AuthControls() {
 
   return (
     <>
+      {user?.picture && <img src={user.picture} alt="" width={32} height={32} />}
+      <span>{user?.givenName} {user?.familyName}</span>
       <span>{user?.email}</span>
       <button type="button" onClick={() => logout()}>Sign out</button>
     </>
@@ -236,6 +252,23 @@ function AuthControls() {
 }
 ```
 
+The above code:
+
+1. Shows a loading state while Kinde resolves the session.
+2. Renders **Sign in** and **Sign up** controls when nobody is signed in.
+3. Displays the signed-in user's picture, name, and email.
+4. Renders a **Sign out** control that ends the Kinde session and returns the user to your `logoutUri`.
+
+The `user` object is populated from the ID token claims, so `givenName`, `familyName`, `email`, and `picture` are available on the client with no extra API call. Which fields are filled in depends on what the user's identity provider returned and what you collect at sign-up, so treat each one as optional.
+
 ## Next steps
 
 Your users are now authenticated with Kinde, and `ctx.sender` in your module is an `Identity` derived from their Kinde `iss` and `sub` claims — stable across devices and sessions. SpacetimeDB verifies the token's signature against Kinde's public keys, but it does not decide *which* issuers or audiences your module accepts. To check those claims, and to authorize what a signed-in user may do, see [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).
+
+Now that sign-in works, you might want to explore:
+
+- [Manage users](/manage-users/about/) — view, add, and edit the users of your SpacetimeDB app from the Kinde dashboard.
+- [User permissions](/manage-users/roles-and-permissions/user-permissions/) — assign roles and permissions you can check before letting a user call a reducer.
+- [Multi-tenancy using organizations](/build/organizations/multi-tenancy-using-organizations/) — separate your users into organizations, each with its own members and settings.
+- [Multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) — add a second factor to sign-in.
+- [Feature flags](/releases/about/about-feature-flags/) — roll features out to a subset of users without redeploying your module.

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -239,10 +239,3 @@ function AuthControls() {
 ## Next steps
 
 Your users are now authenticated with Kinde, and `ctx.sender` in your module is an `Identity` derived from their Kinde `iss` and `sub` claims — stable across devices and sessions. SpacetimeDB verifies the token's signature against Kinde's public keys, but it does not decide *which* issuers or audiences your module accepts. To check those claims, and to authorize what a signed-in user may do, see [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).
-
-## Resources
-
-- [SpacetimeDB React Quickstart](https://spacetimedb.com/docs/quickstarts/react/)
-- [SpacetimeDB Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/)
-- [Kinde React SDK](/developer-tools/sdks/frontend/react-sdk/)
-- [Callback URLs](/get-started/connect/callback-urls/)

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -144,6 +144,7 @@ Kinde returns the user to `redirectUri` with an authorization code in the query 
 
 1. Read the token with `useKindeToken()`.
 2. Build the connection inside `useMemo`, with the token as a dependency.
+3. Render a sign-in control until the token is available.
 
 Mount `SpacetimeDBProvider` only once the token exists. `SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in will not pick the token up afterwards.
 
@@ -151,11 +152,13 @@ Mount `SpacetimeDBProvider` only once the token exists. `SpacetimeDBProvider` ke
 
 ```tsx
 import { useMemo } from 'react';
+import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
 import { SpacetimeDBProvider } from 'spacetimedb/react';
 import { DbConnection } from './module_bindings';
 import { useKindeToken } from './KindeTokenProvider';
 
 export default function App() {
+  const { isLoading, login } = useKindeAuth();
   const token = useKindeToken();
 
   const connectionBuilder = useMemo(
@@ -171,8 +174,12 @@ export default function App() {
     [token]
   );
 
+  if (isLoading) {
+    return <p>Loading…</p>;
+  }
+
   if (!token) {
-    return <p>Sign in to continue.</p>;
+    return <button onClick={() => login()}>Sign in</button>;
   }
 
   return (
@@ -183,9 +190,11 @@ export default function App() {
 }
 ```
 
-## Step 6: Add signed-in UI and sign out (optional)
+Check `isLoading` before `token`. Because `forceChildrenRender` renders your app while Kinde initializes, `token` is still `null` on the first render even for a user who is already signed in — without the loading branch they would see the sign-in button flash before their session resolves.
 
-`useKindeAuth` exposes the signed-in user along with `login`, `register`, and `logout`:
+## Step 6: Add user details and sign out (optional)
+
+Your app can now sign users in. `useKindeAuth` also exposes the signed-in user, along with `register` and `logout`, if you want a fuller set of controls:
 
 ```tsx
 import { useKindeAuth } from '@kinde-oss/kinde-auth-react';

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -179,7 +179,7 @@ export default function App() {
   }
 
   if (!token) {
-    return <button onClick={() => login()}>Sign in</button>;
+    return <button type="button" onClick={() => login()}>Sign in</button>;
   }
 
   return (
@@ -208,8 +208,8 @@ function AuthControls() {
   if (!isAuthenticated) {
     return (
       <>
-        <button onClick={() => login()}>Sign in</button>
-        <button onClick={() => register()}>Sign up</button>
+        <button type="button" onClick={() => login()}>Sign in</button>
+        <button type="button" onClick={() => register()}>Sign up</button>
       </>
     );
   }
@@ -217,7 +217,7 @@ function AuthControls() {
   return (
     <>
       <span>{user?.email}</span>
-      <button onClick={() => logout()}>Sign out</button>
+      <button type="button" onClick={() => logout()}>Sign out</button>
     </>
   );
 }

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -1,9 +1,10 @@
 ---
 page_id: 7eaa79ab-49be-4e00-be2a-54950de661e5
-title: Integrate SpacetimeDB with Kinde
+title: Authenticate SpacetimeDB users with Kinde
 description: "Authenticate SpacetimeDB users with Kinde in minutes. Pass a Kinde ID token to your React app's connection, with no auth server to run."
 sidebar:
   order: 15
+  label: Kinde and SpacetimeDB
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:
@@ -29,7 +30,7 @@ keywords:
   - react authentication
   - real-time database
   - JWT verification
-updated: 2026-08-27
+updated: 2026-09-08
 featured: false
 deprecated: false
 ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The guide covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes it to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. The final step displays user information from the ID token and adds sign out. Prerequisites are a Kinde account and a working SpacetimeDB project. Intended for developers adding authentication to real-time SpacetimeDB applications."

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -4,6 +4,8 @@ title: Integrate SpacetimeDB with Kinde
 description: "Authenticate SpacetimeDB users with Kinde in minutes. Pass a Kinde ID token to your React app's connection, with no auth server to run."
 sidebar:
   order: 15
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - f3dcba7f-fa4f-4ea1-a470-f03af04ba347
   - 820ec3ab-2b80-4331-937c-644da9f8b339
@@ -40,11 +42,13 @@ Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users 
 - A [Kinde](https://kinde.com) account (Sign up for free)
 - A working SpacetimeDB project. If you don't have one, follow the [React Quickstart Guide](https://spacetimedb.com/docs/quickstarts/react/).
 
-## Step 1: Install the Kinde React SDK
+## Quickstart
+
+### 1. Install the Kinde React SDK
 
 <PackageManagers pkg="@kinde-oss/kinde-auth-react" />
 
-## Step 2: Set up your Kinde application
+### 2. Set up your Kinde application
 
 1. Sign in to your [Kinde dashboard](https://app.kinde.com) and select **Add application**.
 2. Enter a name for the application, for example `My SpacetimeDB React App`.
@@ -55,242 +59,240 @@ Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users 
 
 These URLs must match exactly what your app sends. If your dev server starts on a different port, Kinde rejects the sign-in with a `redirect_uri` mismatch before authenticating.
 
-## Step 3: Create a KindeTokenProvider component
+### 3. Create a KindeTokenProvider component
 
-Create a `KindeTokenProvider.tsx` file with the following code:
+1. Create a `KindeTokenProvider.tsx` file with the following code:
 
-```tsx
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from 'react';
-import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
+    ```tsx
+    import {
+      createContext,
+      useContext,
+      useEffect,
+      useState,
+      type ReactNode,
+    } from 'react';
+    import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
 
-const KindeTokenContext = createContext<string | null>(null);
+    const KindeTokenContext = createContext<string | null>(null);
 
-export function useKindeToken(): string | null {
-  return useContext(KindeTokenContext);
-}
-
-export function KindeTokenProvider({ children }: { children: ReactNode }) {
-  const { isLoading, isAuthenticated, getIdToken } = useKindeAuth();
-  const [token, setToken] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (isLoading) return;
-
-    if (!isAuthenticated) {
-      setToken(null);
-      return;
+    export function useKindeToken(): string | null {
+      return useContext(KindeTokenContext);
     }
 
-    let cancelled = false;
-    getIdToken()
-      .then(idToken => {
-        if (!cancelled) setToken(idToken ?? null);
-      })
-      .catch(err => {
-        console.error('Failed to get Kinde ID token:', err);
-        if (!cancelled) setToken(null);
-      });
+    export function KindeTokenProvider({ children }: { children: ReactNode }) {
+      const { isLoading, isAuthenticated, getIdToken } = useKindeAuth();
+      const [token, setToken] = useState<string | null>(null);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [isLoading, isAuthenticated, getIdToken]);
+      useEffect(() => {
+        if (isLoading) return;
 
-  return (
-    <KindeTokenContext.Provider value={token}>
-      {children}
-    </KindeTokenContext.Provider>
-  );
-}
-```
+        if (!isAuthenticated) {
+          setToken(null);
+          return;
+        }
+
+        let cancelled = false;
+        getIdToken()
+          .then(idToken => {
+            if (!cancelled) setToken(idToken ?? null);
+          })
+          .catch(err => {
+            console.error('Failed to get Kinde ID token:', err);
+            if (!cancelled) setToken(null);
+          });
+
+        return () => {
+          cancelled = true;
+        };
+      }, [isLoading, isAuthenticated, getIdToken]);
+
+      return (
+        <KindeTokenContext.Provider value={token}>
+          {children}
+        </KindeTokenContext.Provider>
+      );
+    }
+    ```
 
 The above code:
 
-1. Waits for Kinde to finish initializing, so it doesn't request a token too early.
-2. Fetches the ID token with `getIdToken()` once the user is signed in.
-3. Clears the token when the user signs out.
-4. Exposes the token to the rest of your app through React context, which you read with the `useKindeToken()` hook.
+- Waits for Kinde to finish initializing, so it doesn't request a token too early.
+- Fetches the ID token with `getIdToken()` once the user is signed in.
+- Clears the token when the user signs out.
+- Exposes the token to the rest of your app through React context, which you read with the `useKindeToken()` hook.
 
 Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
 
 <Aside type="warning" title="The sample doesn't restrict who can connect">
+
 SpacetimeDB verifies the token's signature, but it accepts any OpenID Connect issuer. Until your module checks the `iss` and `aud` claims in a `clientConnected` reducer, a signature-valid token from another provider connects too. See [Using Auth Claims](https://spacetimedb.com/docs/core-concepts/authentication/usage/).
+
 </Aside>
 
-## Step 4: Add the providers in main.tsx
+### 4. Add the providers in main.tsx
 
 <Aside type="warning" title="Remove the existing SpacetimeDBProvider">
+
 Don't forget to remove any existing `SpacetimeDBProvider` from `main.tsx`. The connection is created in `App.tsx` instead, once the token is available.
+
 </Aside>
 
-Update `main.tsx` with the following code:
+1. Update `main.tsx` with the following code:
 
-```tsx
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { KindeProvider } from '@kinde-oss/kinde-auth-react';
-import { KindeTokenProvider } from './KindeTokenProvider';
-import App from './App';
+    ```tsx
+    import { StrictMode } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { KindeProvider } from '@kinde-oss/kinde-auth-react';
+    import { KindeTokenProvider } from './KindeTokenProvider';
+    import App from './App';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <KindeProvider
-      clientId="<YOUR_KINDE_CLIENT_ID>"
-      domain="<YOUR_KINDE_DOMAIN>"
-      redirectUri={window.location.origin}
-      logoutUri={window.location.origin}
-      forceChildrenRender
-    >
-      <KindeTokenProvider>
-        <App />
-      </KindeTokenProvider>
-    </KindeProvider>
-  </StrictMode>
-);
-```
-
-The above code:
-
-1. Wraps your app in `KindeProvider`, using the **Client ID** and **Domain** you copied in step 2.
-2. Sets `redirectUri` and `logoutUri` to your dev server origin, matching the URLs you saved in Kinde.
-3. Wraps `App` in `KindeTokenProvider`, so the ID token is available anywhere in your component tree.
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <KindeProvider
+          clientId="<YOUR_KINDE_CLIENT_ID>"
+          domain="<YOUR_KINDE_DOMAIN>"
+          redirectUri={window.location.origin}
+          logoutUri={window.location.origin}
+          forceChildrenRender
+        >
+          <KindeTokenProvider>
+            <App />
+          </KindeTokenProvider>
+        </KindeProvider>
+      </StrictMode>
+    );
+    ```
 
 Kinde returns the user to `redirectUri` with an authorization code in the query string, and the SDK completes the exchange when that page mounts. No dedicated callback route is required. `forceChildrenRender` renders your app while Kinde initializes, so you can drive your UI from `isLoading` instead of showing a blank page.
 
-## Step 5: Use the ID token in App.tsx
+### 5. Use the ID token in App.tsx
 
-Update `App.tsx` with the following code:
+1. Update `App.tsx` with the following code:
 
-```tsx
-import { useMemo } from 'react';
-import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
-import { SpacetimeDBProvider } from 'spacetimedb/react';
-import { DbConnection } from './module_bindings';
-import { useKindeToken } from './KindeTokenProvider';
+    ```tsx
+    import { useMemo } from 'react';
+    import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
+    import { SpacetimeDBProvider } from 'spacetimedb/react';
+    import { DbConnection } from './module_bindings';
+    import { useKindeToken } from './KindeTokenProvider';
 
-export default function App() {
-  const { isLoading, login } = useKindeAuth();
-  const token = useKindeToken();
+    export default function App() {
+      const { isLoading, login } = useKindeAuth();
+      const token = useKindeToken();
 
-  const connectionBuilder = useMemo(
-    () =>
-      DbConnection.builder()
-        .withUri('<YOUR SPACETIMEDB URL>')
-        .withDatabaseName('<YOUR SPACETIMEDB MODULE NAME>')
-        .withToken(token ?? undefined)
-        .onConnect((_conn, identity) =>
-          console.log('Connected as:', identity.toHexString())
-        )
-        .onConnectError((_ctx, err) => console.log('Connection error:', err)),
-    [token]
-  );
+      const connectionBuilder = useMemo(
+        () =>
+          DbConnection.builder()
+            .withUri('<YOUR SPACETIMEDB URL>')
+            .withDatabaseName('<YOUR SPACETIMEDB MODULE NAME>')
+            .withToken(token ?? undefined)
+            .onConnect((_conn, identity) =>
+              console.log('Connected as:', identity.toHexString())
+            )
+            .onConnectError((_ctx, err) => console.log('Connection error:', err)),
+        [token]
+      );
 
-  if (isLoading) {
-    return <p>Loading…</p>;
-  }
+      if (isLoading) {
+        return <p>Loading…</p>;
+      }
 
-  if (!token) {
-    return <button type="button" onClick={() => login()}>Sign in</button>;
-  }
+      if (!token) {
+        return <button type="button" onClick={() => login()}>Sign in</button>;
+      }
 
-  return (
-    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
-      {/* Your app */}
-    </SpacetimeDBProvider>
-  );
-}
-```
+      return (
+        <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+          {/* Your app */}
+        </SpacetimeDBProvider>
+      );
+    }
+    ```
 
 The above code:
 
-1. Reads the ID token with `useKindeToken()`.
-2. Builds the SpacetimeDB connection inside `useMemo`, with the token as a dependency.
-3. Shows a loading state while Kinde resolves the session.
-4. Renders a sign-in control until a token is available.
-5. Mounts `SpacetimeDBProvider` only once the token exists.
+- Reads the ID token with `useKindeToken()`.
+- Builds the SpacetimeDB connection inside `useMemo`, with the token as a dependency.
+- Shows a loading state while Kinde resolves the session.
+- Renders a sign-in control until a token is available.
+- Mounts `SpacetimeDBProvider` only once the token exists.
 
 `SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in never picks the token up afterwards. That is why it is mounted only after the token exists.
 
 Check `isLoading` before `token`. Because `forceChildrenRender` renders your app while Kinde initializes, `token` is still `null` on the first render even for a user who is already signed in — without the loading branch they would see the sign-in button flash before their session resolves.
 
-## Step 6: Add user details and sign out
+### 6. Add user details and sign out
 
 Your app can now sign users in, but users still need a way to see who they are signed in as and to sign out again. `useKindeAuth` exposes the signed-in `user`, along with `register` and `logout`, for a fuller set of controls.
 
-Create an `AuthControls.tsx` file with the following code:
+1. Create an `AuthControls.tsx` file with the following code:
 
-```tsx
-import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
+    ```tsx
+    import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
 
-export function AuthControls() {
-  const { isLoading, isAuthenticated, user, login, register, logout } =
-    useKindeAuth();
+    export function AuthControls() {
+      const { isLoading, isAuthenticated, user, login, register, logout } =
+        useKindeAuth();
 
-  if (isLoading) return <span>Loading…</span>;
+      if (isLoading) return <span>Loading…</span>;
 
-  if (!isAuthenticated) {
-    return (
-      <>
-        <button type="button" onClick={() => login()}>Sign in</button>
-        <button type="button" onClick={() => register()}>Sign up</button>
-      </>
-    );
-  }
+      if (!isAuthenticated) {
+        return (
+          <>
+            <button type="button" onClick={() => login()}>Sign in</button>
+            <button type="button" onClick={() => register()}>Sign up</button>
+          </>
+        );
+      }
 
-  return (
-    <>
-      {user?.picture && <img src={user.picture} alt="" width={32} height={32} />}
-      <span>{user?.givenName} {user?.familyName}</span>
-      <span>{user?.email}</span>
-      <button type="button" onClick={() => logout()}>Sign out</button>
-    </>
-  );
-}
-```
+      return (
+        <>
+          {user?.picture && <img src={user.picture} alt="" width={32} height={32} />}
+          <span>{user?.givenName} {user?.familyName}</span>
+          <span>{user?.email}</span>
+          <button type="button" onClick={() => logout()}>Sign out</button>
+        </>
+      );
+    }
+    ```
 
 The above code:
 
-1. Shows a loading state while Kinde resolves the session.
-2. Renders **Sign in** and **Sign up** controls when nobody is signed in.
-3. Displays the signed-in user's picture, name, and email.
-4. Renders a **Sign out** control that ends the Kinde session and returns the user to your `logoutUri`.
+- Shows a loading state while Kinde resolves the session.
+- Renders **Sign in** and **Sign up** controls when nobody is signed in.
+- Displays the signed-in user's picture, name, and email.
+- Renders a **Sign out** control that ends the Kinde session and returns the user to your `logoutUri`.
 
 The `user` object is populated from the ID token claims, so `givenName`, `familyName`, `email`, and `picture` are available on the client with no extra API call. Which fields are filled in depends on what the user's identity provider returned and what you collect at sign-up, so treat each one as optional.
 
-Then render `AuthControls` in `App.tsx`, in place of the sign-in button from step 5:
+2. Render `AuthControls` in `App.tsx`, in place of the sign-in button from step 5:
 
-```tsx
-import { AuthControls } from './AuthControls';
-// ... other imports
+    ```tsx
+    import { AuthControls } from './AuthControls';
+    // ... other imports
 
-export default function App() {
-  const { isLoading } = useKindeAuth();
-  const token = useKindeToken();
+    export default function App() {
+      const { isLoading } = useKindeAuth();
+      const token = useKindeToken();
 
-  // ... connectionBuilder
+      // ... connectionBuilder
 
-  if (isLoading) {
-    return <p>Loading…</p>;
-  }
+      if (isLoading) {
+        return <p>Loading…</p>;
+      }
 
-  if (!token) {
-    return <AuthControls />;
-  }
+      if (!token) {
+        return <AuthControls />;
+      }
 
-  return (
-    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
-      <AuthControls />
-      {/* Your app */}
-    </SpacetimeDBProvider>
-  );
-}
-```
+      return (
+        <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+          <AuthControls />
+          {/* Your app */}
+        </SpacetimeDBProvider>
+      );
+    }
+    ```
 
 `AuthControls` now renders the sign-in control, so `App` no longer needs `login` from `useKindeAuth`. Rendering it in both branches gives signed-out users a way in, and signed-in users their details and a **Sign out** control.
 

--- a/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
+++ b/src/content/docs/integrate/third-party-tools/kinde-spacetimedb.mdx
@@ -30,10 +30,10 @@ keywords:
   - react authentication
   - real-time database
   - JWT verification
-updated: 2026-09-08
+updated: 2026-09-09
 featured: false
 deprecated: false
-ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The guide covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes it to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. The final step displays user information from the ID token and adds sign out. Prerequisites are a Kinde account and a working SpacetimeDB project. Intended for developers adding authentication to real-time SpacetimeDB applications."
+ai_summary: "Guide to authenticating SpacetimeDB users with Kinde in a React application. SpacetimeDB accepts any OpenID Connect issuer, so a Kinde-issued ID token authenticates users with no server-side configuration. The guide covers installing the Kinde React SDK, creating a Kinde front-end application and setting callback and logout URLs for a Vite dev server, and building a KindeTokenProvider component that waits for Kinde to initialize, fetches the ID token with getIdToken, and exposes both the token and its own loading flag to the app through React context. It explains why the ID token is used rather than the access token: both carry the iss and sub claims that SpacetimeDB derives a user Identity from, but the access token has an empty aud claim unless an audience is requested. Later steps wrap the app in KindeProvider and KindeTokenProvider in main.tsx, use forceChildrenRender so UI can be driven from isLoading, build the SpacetimeDB connection inside useMemo, and mount SpacetimeDBProvider only once a token exists. The final step displays user information from the ID token and adds sign out. Prerequisites are a Kinde account and a working SpacetimeDB project. Intended for developers adding authentication to real-time SpacetimeDB applications."
 ---
 
 Kinde is an OpenID Connect provider, so SpacetimeDB can authenticate your users from a Kinde-issued ID token with no server-side configuration. This guide shows you how to obtain that token in a React app and pass it to your SpacetimeDB connection.
@@ -74,32 +74,45 @@ These URLs must match exactly what your app sends. If your dev server starts on 
     } from 'react';
     import { useKindeAuth } from '@kinde-oss/kinde-auth-react';
 
-    const KindeTokenContext = createContext<string | null>(null);
+    type KindeTokenState = {
+      token: string | null;
+      isLoading: boolean;
+    };
 
-    export function useKindeToken(): string | null {
+    const KindeTokenContext = createContext<KindeTokenState>({
+      token: null,
+      isLoading: true,
+    });
+
+    export function useKindeToken(): KindeTokenState {
       return useContext(KindeTokenContext);
     }
 
     export function KindeTokenProvider({ children }: { children: ReactNode }) {
       const { isLoading, isAuthenticated, getIdToken } = useKindeAuth();
-      const [token, setToken] = useState<string | null>(null);
+      const [state, setState] = useState<KindeTokenState>({
+        token: null,
+        isLoading: true,
+      });
 
       useEffect(() => {
         if (isLoading) return;
 
         if (!isAuthenticated) {
-          setToken(null);
+          setState({ token: null, isLoading: false });
           return;
         }
 
         let cancelled = false;
+        setState({ token: null, isLoading: true });
+
         getIdToken()
           .then(idToken => {
-            if (!cancelled) setToken(idToken ?? null);
+            if (!cancelled) setState({ token: idToken ?? null, isLoading: false });
           })
           .catch(err => {
             console.error('Failed to get Kinde ID token:', err);
-            if (!cancelled) setToken(null);
+            if (!cancelled) setState({ token: null, isLoading: false });
           });
 
         return () => {
@@ -108,7 +121,7 @@ These URLs must match exactly what your app sends. If your dev server starts on 
       }, [isLoading, isAuthenticated, getIdToken]);
 
       return (
-        <KindeTokenContext.Provider value={token}>
+        <KindeTokenContext.Provider value={state}>
           {children}
         </KindeTokenContext.Provider>
       );
@@ -119,8 +132,9 @@ The above code:
 
 - Waits for Kinde to finish initializing, so it doesn't request a token too early.
 - Fetches the ID token with `getIdToken()` once the user is signed in.
-- Clears the token when the user signs out.
-- Exposes the token to the rest of your app through React context, which you read with the `useKindeToken()` hook.
+- Tracks its own `isLoading` flag, which stays `true` until `getIdToken()` settles.
+- Clears the token when the user signs out, or when the token request fails.
+- Exposes both values through React context, which you read with the `useKindeToken()` hook.
 
 Use `getIdToken()` rather than `getAccessToken()`. SpacetimeDB derives a user's `Identity` from the token's `iss` and `sub` claims, and both tokens carry those — but unless you request an audience, Kinde leaves the access token's `aud` claim empty, while the ID token always carries one. If you want to check the audience in your module, the ID token gives you something to check by default.
 
@@ -178,8 +192,8 @@ Kinde returns the user to `redirectUri` with an authorization code in the query 
     import { useKindeToken } from './KindeTokenProvider';
 
     export default function App() {
-      const { isLoading, login } = useKindeAuth();
-      const token = useKindeToken();
+      const { isLoading, isAuthenticated, login } = useKindeAuth();
+      const { token, isLoading: isTokenLoading } = useKindeToken();
 
       const connectionBuilder = useMemo(
         () =>
@@ -194,12 +208,16 @@ Kinde returns the user to `redirectUri` with an authorization code in the query 
         [token]
       );
 
-      if (isLoading) {
+      if (isLoading || isTokenLoading) {
         return <p>Loading…</p>;
       }
 
-      if (!token) {
+      if (!isAuthenticated) {
         return <button type="button" onClick={() => login()}>Sign in</button>;
+      }
+
+      if (!token) {
+        return <p>Signed in, but no ID token was returned. Try signing in again.</p>;
       }
 
       return (
@@ -212,15 +230,16 @@ Kinde returns the user to `redirectUri` with an authorization code in the query 
 
 The above code:
 
-- Reads the ID token with `useKindeToken()`.
+- Reads the token and its loading flag with `useKindeToken()`.
 - Builds the SpacetimeDB connection inside `useMemo`, with the token as a dependency.
-- Shows a loading state while Kinde resolves the session.
-- Renders a sign-in control until a token is available.
+- Shows a loading state until both Kinde and the token request have settled.
+- Renders a sign-in control when nobody is signed in.
+- Reports an error if the user is signed in but no token came back.
 - Mounts `SpacetimeDBProvider` only once the token exists.
 
 `SpacetimeDBProvider` keys its pooled connection on the URI and module name, and ignores the builder once a connection is live — so a connection opened before sign-in never picks the token up afterwards. That is why it is mounted only after the token exists.
 
-Check `isLoading` before `token`. Because `forceChildrenRender` renders your app while Kinde initializes, `token` is still `null` on the first render even for a user who is already signed in — without the loading branch they would see the sign-in button flash before their session resolves.
+Branch on both loading flags before you look at the token. Kinde's own `isLoading` covers SDK initialization only; `KindeTokenProvider` calls `getIdToken()` after that, so there is a second window in which the user is authenticated but the token has not arrived yet. Checking `!token` first would render the sign-in control during that window, even for someone who is already signed in — so gate sign-in on `isAuthenticated`, and treat a signed-in user with no token as an error rather than a signed-out one.
 
 ### 6. Add user details and sign out
 
@@ -273,17 +292,21 @@ The `user` object is populated from the ID token claims, so `givenName`, `family
     // ... other imports
 
     export default function App() {
-      const { isLoading } = useKindeAuth();
-      const token = useKindeToken();
+      const { isLoading, isAuthenticated } = useKindeAuth();
+      const { token, isLoading: isTokenLoading } = useKindeToken();
 
       // ... connectionBuilder
 
-      if (isLoading) {
+      if (isLoading || isTokenLoading) {
         return <p>Loading…</p>;
       }
 
-      if (!token) {
+      if (!isAuthenticated) {
         return <AuthControls />;
+      }
+
+      if (!token) {
+        return <p>Signed in, but no ID token was returned. Try signing in again.</p>;
       }
 
       return (
@@ -295,7 +318,7 @@ The `user` object is populated from the ID token claims, so `givenName`, `family
     }
     ```
 
-`AuthControls` now renders the sign-in control, so `App` no longer needs `login` from `useKindeAuth`. Rendering it in both branches gives signed-out users a way in, and signed-in users their details and a **Sign out** control.
+`AuthControls` now renders the sign-in control, so `App` no longer needs `login` from `useKindeAuth`. Rendering it in both the signed-out and signed-in branches gives visitors a way in, and signed-in users their details and a **Sign out** control.
 
 ## Next steps
 


### PR DESCRIPTION
#### Description (required)

Adds a new guide — **Integrate SpacetimeDB with Kinde** — under Integrations → Third-party tools.

SpacetimeDB accepts any OpenID Connect issuer, so it can authenticate users from a Kinde-issued ID token with no server-side configuration. Nothing on the site covered how to wire that up. The guide walks through it in a React app: install the Kinde React SDK, expose the ID token via a small context provider, and hand it to the SpacetimeDB connection builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the React integration guide for Kinde authentication with SpacetimeDB.
  * Added clearer setup instructions, application configuration, token handling, provider wiring, and token-gated database connections.
  * Documented authentication controls, user profile details, claim-based identity, authorization guidance, and follow-up resources.
  * Added guidance on issuer and audience claim validation, along with a warning about OpenID Connect issuer handling.
  * Updated the example application flow to show authentication controls for both signed-out and signed-in states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->