### PR TITLE
document IdP-initiated SAML RelayState two-hop login flow

### DIFF
--- a/composer/api-keys-overview.es.md
+++ b/composer/api-keys-overview.es.md
@@ -1,0 +1,122 @@
+# Descripción general de las claves API
+
+Kinde ofrece un sistema integral de gestión de claves API que le permite emitir y administrar claves API para sus propias API.
+
+Este sistema admite la gestión de claves tanto a nivel de organización como de usuario, lo que lo hace adecuado para modelos de negocio B2B, B2C y B2B2C.
+
+> **Nota:** Esta función está disponible en los [planes de pago de Kinde](https://kinde.com/pricing/).
+
+## ¿Qué son las claves API?
+
+Las claves API son credenciales de larga duración que permiten a los usuarios finales autenticarse con sus API.
+
+Ofrecen una forma sencilla de acceder a sus servicios sin pasar por flujos OAuth y permiten realizar solicitudes fuera del navegador, por ejemplo con CLIs, cURL, etc.
+
+### Características principales
+
+- **Con ámbito limitado**: cada clave está restringida a una API específica
+- **Permisos**: a cada clave se le pueden otorgar ámbitos/permisos específicos
+- **Seguras**: las claves se almacenan como hashes seguros y nunca se exponen después de la creación
+- **Administrables**: las claves se pueden crear, rotar y revocar según sea necesario
+- **De larga duración**: las claves API no caducan a menos que establezca una fecha de vencimiento (próximamente)
+
+## Modelos de gestión de claves
+
+### Claves a nivel de organización
+
+- Administradas por administradores de la organización
+- Adecuadas para escenarios B2B en los que los clientes necesitan acceso a sus API
+- Las claves están asociadas a organizaciones específicas
+- Los administradores pueden gestionar claves en nombre de sus usuarios
+
+### Claves a nivel de usuario
+
+- Administradas por usuarios individuales
+- Adecuadas para escenarios B2C en los que los usuarios finales necesitan acceso a la API
+- Los usuarios crean y administran sus propias claves
+- Las claves están asociadas a cuentas de usuario específicas
+
+## Cómo funcionan las claves API
+
+### 1. Registrar una API
+
+Antes de poder emitir claves API, debe registrar sus API en Kinde:
+
+- Proporcionar un nombre y una descripción
+- Definir los ámbitos disponibles
+- Obtener un `api_id` único para cada API
+
+Lea más sobre el [registro de API](/developer-tools/your-apis/register-manage-apis/).
+
+### 2. Crear claves
+
+Al crear una clave API:
+
+- Asóciela a una API registrada
+- Asigne ámbitos específicos para el control de acceso
+- Genere un secreto seguro (se muestra solo una vez)
+- Cree un `key_id` estable para su administración
+
+### 3. Usar claves
+
+Los usuarios finales incluyen la clave API en sus solicitudes a su API:
+
+- Normalmente se envía en un encabezado `Authorization`
+- Su API extrae la clave y la verifica con Kinde
+- Kinde devuelve los resultados de la validación, incluidos ámbitos y metadatos
+
+Lea más sobre la [verificación de claves API](/manage-your-apis/add-manage-api-keys/verify-api-keys-in-your-api/).
+
+### 4. Administrar claves
+
+Las claves se pueden administrar a lo largo de su ciclo de vida:
+
+- **Rotar**: generar nuevos secretos manteniendo el mismo ID de clave
+- **Revocar**: marcar claves como inactivas
+- **Actualizar**: modificar las API o ámbitos asociados (requiere una clave nueva)
+
+## Para qué puede usar las claves API
+
+### IA y automatización
+
+- Permitir que los agentes de IA accedan a sus API
+- Admitir flujos de trabajo e integraciones automatizadas
+- Proporcionar acceso seguro para aplicaciones de aprendizaje automático
+
+### Integraciones con terceros
+
+- Permitir que los clientes se integren con su plataforma
+- Ofrecer distintos niveles de acceso según el plan del cliente
+- Hacer seguimiento del uso y aplicar límites de tasa
+
+### Automatización interna
+
+- Habilitar scripts y herramientas automatizadas
+- Proporcionar acceso seguro para pipelines de CI/CD
+- Admitir el desarrollo y las pruebas internas
+
+### Acceso para socios
+
+- Conceder a los socios acceso a API específicas
+- Controlar a qué datos y funciones pueden acceder los socios
+- Mantener registros de auditoría para cumplimiento normativo
+
+### Herramientas para desarrolladores
+
+- Proporcionar acceso a la API para herramientas de desarrollo y SDK
+- Habilitar la exploración de API en autoservicio
+- Admitir pruebas y desarrollo de API
+
+## Funciones de seguridad de las claves API
+
+### Almacenamiento seguro
+
+- Los secretos de las claves API nunca se almacenan en texto plano
+- Todos los secretos se hashean con algoritmos seguros
+- No hay forma de recuperar el secreto original después de la creación
+
+### Control de acceso
+
+- Las claves están vinculadas a una sola API
+- A las claves se les pueden otorgar ámbitos/permisos específicos
+- El aislamiento a nivel de organización evita el acceso entre inquilinos

--- a/src/content/docs/authenticate/enterprise-connections/advanced-saml-configurations.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/advanced-saml-configurations.mdx
@@ -2,7 +2,7 @@
 page_id: 17559023-5b50-4690-ba7b-fd1df4b78664
 title: Advanced SAML configurations
 sidebar:
-  order: 13
+  order: 9
 relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322

--- a/src/content/docs/authenticate/enterprise-connections/azure.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/azure.mdx
@@ -2,7 +2,8 @@
 page_id: 98f6868a-7871-4ece-ba9c-2a7b21d1b322
 title: 'Microsoft Entra ID enterprise connection (OAuth 2.0, WS-Fed)'
 sidebar:
-  order: 6
+  order: 2
+  label: MS Entra ID (OAuth 2.0, WS-Fed)
 relatedArticles:
   - ed2f7810-6f8c-4dec-bcf1-f49922174daa
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740

--- a/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/cloudflare-saml.mdx
@@ -2,7 +2,8 @@
 page_id: 04e9e501-0320-40d5-a440-845e637ced7b
 title: Cloudflare enterprise connection (SAML)
 sidebar:
-  order: 8
+  order: 4
+  label: Cloudflare (SAML)
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml-google-workspace.mdx
@@ -2,7 +2,8 @@
 page_id: 0dfcab9d-8610-4881-9293-8501bd472041
 title: Google Workspace enterprise connection (SAML)
 sidebar:
-  order: 9
+  order: 5
+  label: Google Workspace (SAML)
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -2,7 +2,8 @@
 page_id: 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
 title: Custom SAML enterprise connection
 sidebar:
-  order: 12
+  order: 8
+  label: Custom SAML
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:

--- a/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/enterprise-connections-b2b.mdx
@@ -2,7 +2,7 @@
 page_id: 4a1dbecf-91b4-4328-8f78-fd66240eecb4
 title: Enterprise connections for B2B
 sidebar:
-  order: 3
+  order: 16
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8

--- a/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/entra-id-saml.mdx
@@ -2,7 +2,8 @@
 page_id: ed2f7810-6f8c-4dec-bcf1-f49922174daa
 title: Microsoft Entra ID enterprise connection (SAML)
 sidebar:
-  order: 7
+  order: 3
+  label: MS Entra ID (SAML)
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - 17559023-5b50-4690-ba7b-fd1df4b78664

--- a/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/home-realm-discovery.mdx
@@ -2,7 +2,7 @@
 page_id: e100d77b-530b-4327-8216-93c955657e0c
 title: Home realm or IdP discovery
 sidebar:
-  order: 4
+  order: 12
 relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -42,7 +42,7 @@ keywords:
   - RelayState
   - connection_id
   - client_id
-updated: 2026-08-25
+updated: 2026-09-01
 ---
 
 In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring RelayState, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.
@@ -212,6 +212,7 @@ The route you point RelayState at is responsible for turning the parameters it r
 1. **Read `connection_id` from the incoming query string** and pass it to your Kinde SDK's login method. Most SDKs accept this as `connectionId`. If you are not using an SDK, see [`connection_id`](/developer-tools/about/using-kinde-without-an-sdk/) in our guide to using Kinde without an SDK.
 2. **Let the SDK build the authorization URL.** The SDK adds the callback URL, `state`, and PKCE parameters where applicable. These are what allow Kinde to complete the login and return the user to your application.
 3. **Pass `org_code` too, if the connection is organization-level.** Most SDKs accept this as `orgCode`. Your route needs to preserve the value from the incoming request and forward it.
+4. **Pass `login_hint` through as well, if it is present.** If **Use IdP email as login hint** is switched on for the connection (Step 2), Kinde appends the user's email to the RelayState redirect as a `login_hint` query parameter. Forward it to your SDK's login method (most SDKs accept this as `loginHint`) so the IdP can skip account selection on the second hop.
 
 <Aside type="warning">
 

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -39,10 +39,13 @@ keywords:
   - metadata URL
   - metadata hosting
   - XML
-updated: 2025-12-19
+  - RelayState
+  - connection_id
+  - client_id
+updated: 2026-08-25
 ---
 
-In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.
+In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring RelayState, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.
 
 ## What is IdP-initiated SSO?
 
@@ -52,18 +55,34 @@ When setting up enterprise authentication, you'll encounter two main ways to sta
 
 ### How it works
 
-1. A user logs into their corporate Identity Provider portal (such as Okta, Azure AD, or Google Workspace)
-2. From the IdP dashboard, the user clicks on your application
-3. The IdP creates a SAML assertion containing the user's identity and attributes
-4. The IdP sends this assertion directly to your Kinde ACS URL
-5. Kinde validates the assertion and creates a user session
-6. The user is redirected to your application
+Kinde completes IdP-initiated SSO in two hops. The IdP hands the user off to Kinde, and your application then starts a normal Kinde login.
+
+**Phase 1 – the IdP hands off to Kinde**
+
+1. The user clicks the tile for your application in their IdP.
+2. The IdP posts an unsolicited SAML assertion to your Kinde ACS endpoint.
+3. Kinde validates the assertion. This first request confirms who the user is, but **it does not sign the user in to Kinde**. No end-user session exists yet.
+4. Kinde redirects the browser to the URL supplied in RelayState.
+
+**Phase 2 – your application starts the Kinde login**
+
+5. The RelayState URL is a route in your application. That route starts a normal Kinde authorization request, preserving `connection_id`.
+6. Because `connection_id` is present, Kinde skips its own login screen and goes straight to the SP-initiated SAML round-trip for that connection.
+7. The user already has an active session at the IdP, so this round-trip normally completes without asking for credentials again.
+8. Kinde creates the authenticated session and returns the user to your application.
+
+<Aside title="Why two hops?">
+
+The second leg is a standard SP-initiated exchange, so the session is created with the full set of checks in place, including `InResponseTo`, state, and PKCE where applicable. The user experience is still a single click in the IdP portal.
+
+</Aside>
 
 ### What you need 
 
 - A [Kinde](https://kinde.com) account with an **enterprise connections** entitlement
 - Admin access to your [enterprise identity provider](/authenticate/enterprise-connections/about-enterprise-connections) (Okta, Azure AD, Google Workspace, etc.)
 - A [verified domain configured in Kinde](/build/domains/organization-custom-domain/) (for organization-level connections)
+- A route in your application that starts Kinde login and can accept query parameters
 
 ## Step 1: Add a SAML enterprise connection in Kinde
 
@@ -104,7 +123,7 @@ After creating the connection, configure these settings:
 
 1. **Connection name**: A name to identify this connection (e.g., "Acme Corp SSO")
 2. **Entity ID**: The unique identifier configured in your IdP (e.g., `https://yourapp.kinde.com`)
-3. **IdP metadata URL**: You will add this after finishing setup in your Identity Provider (see Step 3)
+3. **IdP metadata URL**: You will add this after finishing setup in your Identity Provider (see Step 4)
 
     <Aside title="No metadata URL? Host the XML file yourself">
 
@@ -140,8 +159,17 @@ After creating the connection, configure these settings:
 10. **Always show sign-in button**: 
     - **Off (default):** If home realm domains are set, the SSO button only shows after email domain detection
     - **On:** The SSO button is always visible on the login screen
-11. Copy the **Assertion Consumer Service (ACS) URL**. You will need to add this to your IdP configuration.
-12. **Provisioning**: Control how users are created when authenticating via SAML:
+11. **IdP-initiated SSO behavior**: If your environment shows this section, use it to control whether Kinde accepts sign-in requests that start at the IdP:
+
+    - **Accept requests**: Accepts unsolicited login requests sent to Kinde by your IdP. This is off by default, and IdP-initiated SSO does not work until you switch it on.
+    - **Use IdP email as login hint**: Takes the email address from the SAML response and adds it to the redirect as a `login_hint` query parameter. This lets the IdP skip account selection when the user is signed in to more than one account.
+
+        <Aside>
+        If you don't see an **IdP-initiated SSO behavior** section on your connection, contact Kinde support to have IdP-initiated SSO enabled for your environment.
+        </Aside>
+
+12. Copy the **Assertion Consumer Service (ACS) URL**. You will need to add this to your IdP configuration.
+13. **Provisioning**: Control how users are created when authenticating via SAML:
     - **Create a user record in Kinde**: When enabled, users who don't exist in Kinde are automatically created on first sign-in
     - **Trust email addresses provided by this connection**: Merge accounts when email matches an existing Kinde user
 
@@ -151,21 +179,59 @@ After creating the connection, configure these settings:
 
         ![auto add users in kinde organization](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/adde50b3-de8c-429b-010e-7793a7df6800/socialsharingimage)
 
-13. Select **Save**
+14. Select **Save**
 
-## Step 3: Configure your Identity Provider
+## Step 3: Decide on your RelayState URL
+
+RelayState is how the IdP tells Kinde where to send the browser after the assertion is validated. For this flow, RelayState is required, and it must be a **full, absolute URL**. A bare query string such as `client_id=...&connection_id=...` is not accepted.
+
+The URL should point at the route in your application that starts Kinde login, and it must carry the `client_id` and `connection_id` parameters:
+
+```
+https://app.example.com/login?client_id=YOUR_KINDE_CLIENT_ID&connection_id=conn_0192c16abb53b44277e597d31877ba5b
+```
+
+### RelayState parameters
+
+| Parameter | What it does | Notes |
+| --- | --- | --- |
+| `client_id` | Identifies the Kinde application the user is signing in to | Must use this exact query parameter name |
+| `connection_id` | Identifies the enterprise connection to use | Must use this exact query parameter name |
+| `org_code` | Identifies the organization | For an organization-level connection, your application may also need to preserve this value and pass it on to the authorization request |
+
+<Aside type="warning" title="Kinde uses the exact URL you provide">
+
+Kinde redirects the browser to the exact RelayState URL you supply. It does **not** use `client_id` to look up your application's configured **Application login URI** and invoke that for you. If RelayState is missing, incomplete, or not a full URL, the flow cannot recover and the user won't be signed in.
+
+</Aside>
+
+### What your application's login route must do
+
+The route you point RelayState at is responsible for turning the parameters it receives into a complete Kinde authorization request.
+
+1. **Read `connection_id` from the incoming query string** and pass it to your Kinde SDK's login method. Most SDKs accept this as `connectionId`. If you are not using an SDK, see [`connection_id`](/developer-tools/about/using-kinde-without-an-sdk/) in our guide to using Kinde without an SDK.
+2. **Let the SDK build the authorization URL.** The SDK adds the callback URL, `state`, and PKCE parameters where applicable. These are what allow Kinde to complete the login and return the user to your application.
+3. **Pass `org_code` too, if the connection is organization-level.** Most SDKs accept this as `orgCode`. Your route needs to preserve the value from the incoming request and forward it.
+
+<Aside type="warning">
+
+Don't construct or hardcode a partial `/oauth2/auth` URL that contains only `client_id` and `connection_id`. A URL with just those two parameters is missing the callback, state, and PKCE values needed to finish signing the user in.
+
+</Aside>
+
+## Step 4: Configure your Identity Provider
 
 In your IdP admin console, create a new SAML application with these settings:
 
 1. **ACS URL / Reply URL**: Use the ACS URL you copied from Kinde in Step 2 (e.g., `https://yourdomain.kinde.com/login/saml/callback`)
 2. **Entity ID / Audience**: Use the Entity ID you configured in Kinde
 3. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*Persistent* recommended)
-4. **RelayState** (optional): Configure a default RelayState URL if your IdP supports it. This is where users are redirected after authentication.
+4. **RelayState**: Enter the full URL you decided on in Step 3. This is required for IdP-initiated SSO in Kinde. It is where the browser is sent to *begin* Kinde login, not where the user lands after signing in.
     <Aside> 
     If you are using Google Workspace as your Identity Provider, set your RelayState URL in the Start URL field in the Google SAML application settings. 
     </Aside>
 
-5. **Enable IdP-initiated SSO**: In your IdP's application settings, enable the option to allow IdP-initiated sign-on (the exact setting name varies by provider)
+5. **Enable IdP-initiated SSO**: IdP-initiated SSO has to be enabled on both sides. Switch on **Accept requests** in Kinde (Step 2), and enable the equivalent option in your IdP's application settings (the exact setting name varies by provider)
 
     <Aside>
     IdP-initiated SAML SSO support may vary by Identity Provider. Contact Kinde support if you encounter issues with specific IdP configurations.
@@ -173,17 +239,17 @@ In your IdP admin console, create a new SAML application with these settings:
 
 6. Copy the **Metadata URL** from your IdP. This is typically found in the SAML application settings or can be downloaded as an XML file. You'll need this URL in the next step.
   
-## Step 4: Finish setting up your IdP connection
+## Step 5: Finish setting up your IdP connection
 
 1. Open the connection in Kinde. Go to **Organizations** > **Authentication** or **Settings** > **Authentication**.
-2. Scroll to the **IdP metadata URL** field and paste the Metadata URL you copied from Step 3.
+2. Scroll to the **IdP metadata URL** field and paste the Metadata URL you copied from Step 4.
 3. (Optional) Enter the signed certificate and key information if you have it. You can do this later as well. See [Advanced SAML configurations](/authenticate/enterprise-connections/advanced-saml-configurations/) for more details.
 4. Switch on the connection. This will make it instantly available to users if this is your production environment.
     - For environment-level connections, scroll down and select the apps that will use the auth method.
     - For organization-level connections, scroll down and select if you want to switch this on for the org.
 5. Select **Save**. You can now use the IdP for the selected applications.
 
-## Step 5: Test the configuration
+## Step 6: Test the configuration
 
 ### Test SP-initiated flow (standard)
 
@@ -196,7 +262,9 @@ In your IdP admin console, create a new SAML application with these settings:
 
 1. Log in to your Identity Provider's portal
 2. Click on your application in the IdP dashboard
-3. You should be redirected to your app and logged in automatically
+3. Your browser should be sent to your RelayState URL, which starts Kinde login
+4. Because you already have a session at the IdP, you should not be asked for credentials again
+5. You should land back in your app, signed in
 
 ## Troubleshooting
 
@@ -208,6 +276,11 @@ In your IdP admin console, create a new SAML application with these settings:
 | "Signature verification failed" | Certificate mismatch | Verify your IdP's signing certificate is correctly configured |
 | User not created | Provisioning disabled | Enable "Create a user record in Kinde" |
 | Wrong attributes | Attribute mapping | Check that your IdP attribute names match the mapped keys |
+| Nothing happens after clicking the app tile, or you land on the Kinde login screen | RelayState is only `client_id=...&connection_id=...` | RelayState must be a full URL including the scheme and host, not just a query string |
+| Login does not complete after the redirect | Your login route is sending a Kinde `/oauth2/auth` URL that contains only `client_id` and `connection_id` | Use your SDK's login method so the callback, `state`, and PKCE parameters are included |
+| The ordinary Kinde login screen appears instead of the enterprise connection | Your application's login route is not forwarding `connection_id` | Read `connection_id` from the incoming request and pass it to the SDK as `connectionId` |
+| Users reach the wrong organization, or the connection isn't offered | An organization-level connection without `org_code` | Preserve `org_code` through your login route and pass it to the SDK |
+| "Invalid client", or the connection isn't recognized | The client ID and connection ID are from different Kinde environments | Confirm both values come from the same Kinde environment |
 
 ### Error codes
 

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -2,20 +2,23 @@
 page_id: 8a3f4e2d-9c1b-4a7d-8e2f-1a5b6c7d8e9f
 title: IdP-initiated SAML SSO
 sidebar:
-  order: 14
+  order: 10
 tableOfContents:
   maxHeadingLevel: 3
 relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 17559023-5b50-4690-ba7b-fd1df4b78664
+  - 02d02820-92da-4721-9a91-222c9b095869
+  - e100d77b-530b-4327-8216-93c955657e0c
+  - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
 app_context:
   - m: settings
     s: authentication
-description: "Enable IdP-initiated SAML SSO so enterprise users can open your app from their identity provider portal in one click"
+description: "Let users open your app from their IdP portal with IdP-initiated SAML SSO, RelayState, and a standard Kinde login"
 featured: false
 deprecated: false
-ai_summary: "Guide to configuring IdP-initiated SAML single sign-on in Kinde, where authentication starts at the identity provider rather than the application. Explains the two-hop flow: the IdP posts an unsolicited SAML assertion to the Kinde ACS endpoint, then Kinde redirects to a RelayState URL that starts a standard Kinde authorization request. Covers creating environment-level and organization-level enterprise connections, connection settings including Accept requests and Use IdP email as login hint, home realm domains, provisioning, and ACS URL setup. Details how to build a full RelayState URL with client_id, connection_id, and org_code, and what the application login route must pass to the SDK, including connectionId, orgCode, loginHint, and PKCE. Includes IdP configuration for ACS URL, Entity ID, RelayState, and metadata URL, plus testing SP-initiated and IdP-initiated flows, troubleshooting, and security guidance. Intended for developers, enterprise admins, and security engineers."
+ai_summary: "Guide to configuring IdP-initiated SAML single sign-on in Kinde, where login starts at the identity provider rather than the application. Explains the two-hop flow: the IdP posts an unsolicited SAML assertion to the Kinde ACS endpoint, then Kinde redirects to a RelayState URL that starts a normal Kinde login. Covers creating environment-level and organization-level enterprise connections, completing provider-specific SAML setup for Custom SAML, Google Workspace, Okta, Cloudflare, Microsoft Entra ID, and LastPass, then enabling IdP-initiated settings including Accept requests, Use IdP email as login hint, ACS URL, and optional provisioning. Details how to build a full RelayState URL with client_id, connection_id, and org_code, and how the application login route must forward those values. Includes a Next.js login example and a raw OAuth authorization request without an SDK, plus IdP RelayState field names, testing of SP-initiated and IdP-initiated flows, troubleshooting, and security guidance. Intended for developers, enterprise admins, and security engineers."
 topics:
   - authenticate
   - enterprise-connections
@@ -34,9 +37,9 @@ keywords:
   - connection_id
   - SAML SSO
   - login_hint
-  - home realm discovery
+  - Accept requests
   - unsolicited SAML
-updated: 2026-09-06
+updated: 2026-09-07
 ---
 
 In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring RelayState, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.
@@ -44,9 +47,9 @@ In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, includi
 ## What you need
 
 - A [Kinde](https://kinde.com) account with **Engineer** or **Admin** permissions
-- Admin access to your [enterprise identity provider](/authenticate/enterprise-connections/about-enterprise-connections) (Okta, Azure AD, Google Workspace, etc.)
+- Admin access to your [enterprise identity provider](/authenticate/enterprise-connections/about-enterprise-connections) (Okta, Microsoft Entra ID, Google Workspace, etc.)
 - A route in your application that starts Kinde login and can accept query parameters
-- A [verified domain configured in Kinde](/build/domains/organization-custom-domain/) for organization-level connections ([Kinde Plus plan](https://www.kinde.com/pricing/) or higher is needed)
+- For organization-level connections only: a [verified domain configured in Kinde](/build/domains/organization-custom-domain/). A [Kinde Plus plan](https://www.kinde.com/pricing/) or higher is required.
 
 ## What is IdP-initiated SSO?
 
@@ -87,14 +90,10 @@ This is an environment-level connection shared across all organizations in the e
 1. Sign in to your Kinde admin portal
 2. Go to **Settings > Environment > Authentication**
 3. Select **Add connection** in the **Enterprise connections** section
-4. Select your SAML provider:
-   - **Custom SAML** (for any SAML 2.0 IdP)
-   - **Google Workspace** (pre-configured for Google)
-   - **Okta** (pre-configured for Okta)
-   - **Cloudflare** (pre-configured for Cloudflare Access)
+4. Select your SAML provider from the list of supported providers or select **Custom SAML**
 5. Select **Next**
 
-### 1. Alternative way: Create an organization-specific connection
+### Alternative way: Create an organization-specific connection
 
 <Aside type="upgrade">
 
@@ -110,67 +109,37 @@ Organization-level connections require [verified domains](/build/domains/organiz
 
     ![kinde organization sso connection](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/bee83baa-247d-45db-eb26-d1a7adcf7800/socialsharingimage)
 
-6. Choose your connection type (Custom SAML, Cloudflare, Okta, etc.)
+6. Select your SAML provider from the list of supported providers or select **Custom SAML**
 7. Select **Next**
 
-### 2. Configure connection details in Kinde
+### 2. Configure the SAML connection and IdP-initiated settings
 
-After creating the connection, configure these settings:
+Complete the SAML connection using the setup guide for your provider. Those pages cover Entity ID, IdP metadata URL, bindings, attribute mapping, and related fields.
+
+- [Custom SAML](/authenticate/enterprise-connections/custom-saml/) (any SAML 2.0 IdP)
+- [Google Workspace](/authenticate/enterprise-connections/custom-saml-google-workspace/)
+- [Okta](/authenticate/enterprise-connections/okta-saml-connection/)
+- [Cloudflare](/authenticate/enterprise-connections/cloudflare-saml/)
+- [Microsoft Entra ID (SAML)](/authenticate/enterprise-connections/entra-id-saml/)
+- [LastPass](/authenticate/enterprise-connections/lastpass-sso/)
+
+For extra SAML options, see [Advanced SAML configurations](/authenticate/enterprise-connections/advanced-saml-configurations/). For email-domain routing on the Kinde login screen, see [Home realm discovery](/authenticate/enterprise-connections/home-realm-discovery/).
+
+Then return to the connection in Kinde and complete the settings that IdP-initiated SSO depends on.
 
     ![kinde custom saml connection](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/67daf001-e62e-488a-31ca-0199a8f8db00/socialsharingimage)
 
-1. **Connection ID**: Copy this value. You need it to create the RelayState URL for IdP-initiated SSO.
-2. **Connection name**: A name to identify this connection (e.g., "Acme Corp SSO")
-3. **Entity ID**: The unique identifier configured in your IdP (e.g., `https://yourapp.kinde.com`)
-4. **IdP metadata URL**: Add this after you finish setup in your Identity Provider (see Step 4)
+1. Copy the **Connection ID**. You need it to create the RelayState URL in Step 3.
+2. Under **IdP-initiated SSO behavior**, configure:
 
-    <Aside title="No metadata URL? Host the XML file yourself">
-
-    If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
-
-    </Aside>
-
-5. **Sign in URL** (optional): Override the default SSO endpoint with a URL your IdP recognizes
-6. **Sign request algorithm**: Choose the algorithm used to sign SAML requests (RSA-SHA1 or RSA-SHA256)
-7. **Protocol binding**: Choose the protocol binding used to send SAML requests
-8. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*Persistent* recommended)
-9. Set up the user attribute mapping:
-
-    - **Email key attribute**: The attribute in the SAML token that contains the user's email. Defaults to `email` if not provided.
-    - **User ID key attribute**: The attribute in the SAML token that contains the user ID. Defaults to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` if not provided.
-    - **First name key attribute**: The attribute in the SAML token that contains the user's first name. Defaults to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` if not provided.
-    - **Last name key attribute**: The attribute in the SAML token that contains the user's last name. Defaults to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname` if not provided.
-
-        <Aside>
-
-        If your IdP uses different attribute names, enter the correct attribute keys in the mapping fields.
-        
-        </Aside>
-
-10. **Home realm domains**: A list of domains used for home realm discovery. Add each domain on a new line:
-
-    ```text title="Sample home realm domains"
-    acmecorp.com
-    acme.co
-    ```
-    <Aside>
-
-    When users enter an email matching these domains, they are automatically routed to this SSO connection.
-    
-    </Aside>
-
-11. **Always show sign-in button**:
-    - **Off (default):** If home realm domains are set, the SSO button only shows after email domain detection
-    - **On:** The SSO button is always visible on the login screen
-12. **IdP-initiated SSO behavior**: Controls whether Kinde accepts sign-in requests that start at the IdP:
-
-    - **Accept requests**: Accepts unsolicited login requests sent to Kinde by your IdP. This is off by default, and IdP-initiated SSO does not work until you switch it on.
-    - **Use IdP email as login hint**: Takes the email address from the SAML response and adds it to the redirect as a `login_hint` query parameter. This lets the IdP skip account selection when the user is signed in to more than one account.
+    - **Accept requests**: Switch this **On**. It is off by default. IdP-initiated SSO does not work until you switch it on. This setting accepts unsolicited login requests that your IdP sends to Kinde.
+    - **Use IdP email as login hint** (optional): Takes the email address from the SAML response and adds it to the RelayState redirect as a `login_hint` query parameter. This lets the IdP skip account selection when the user is signed in to more than one account.
 
         ![kinde idp initiated sso behavior](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/b3887c3a-a2d4-4bfb-8c85-a146ad6fb300/socialsharingimage)
 
-13. Copy the **Assertion Consumer Service (ACS) URL**. You need this for your IdP configuration.
-14. **Provisioning**: Control how users are created when authenticating via SAML:
+3. Copy the **Assertion Consumer Service (ACS) URL**. You need this for your IdP configuration in Step 4. If you use a custom domain, copy the ACS URL that matches that domain, not the default `*.kinde.com` URL.
+4. (Optional) Set [provisioning](/authenticate/enterprise-connections/provision-users-enterprise/) so users are created or added to the organization on first sign-in:
+
     - **Create a user record in Kinde**: When enabled, users who don't exist in Kinde are automatically created on first sign-in
     - **Trust email addresses provided by this connection**: Merge accounts when email matches an existing Kinde user
 
@@ -180,7 +149,7 @@ After creating the connection, configure these settings:
 
         ![auto add users in kinde organization](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a4736783-6aaf-4a69-b66a-e380f63a4300/socialsharingimage)
 
-15. Select **Save**
+5. Select **Save**. You will come back in Step 5 to paste the IdP metadata URL.
 
 ### 3. Decide on your RelayState URL
 
@@ -191,22 +160,17 @@ The URL should point at the route in your application that starts Kinde login, a
 ```text title="Sample RelayState URL"
 https://app.example.com/login?
 client_id=YOUR_KINDE_CLIENT_ID
-&connection_id=conn_0192c16abb53b44277e597d31877ba5b
+&connection_id=conn_xxxxxxxx
 ```
 
-#### RelayState parameters
+For an organization-level connection, include `org_code` as well:
 
-| Parameter | What it does | Notes |
-| --- | --- | --- |
-| `client_id` | Identifies the Kinde application the user is signing in to | Must use this exact query parameter name |
-| `connection_id` | Identifies the enterprise connection to use | Must use this exact query parameter name |
-| `org_code` | Identifies the organization | For an organization-level connection, your application may also need to preserve this value and pass it on to the authorization request |
-
-#### Where to find these parameters
-
-- `client_id`: Go to **Settings > Environment > Applications**, select **View details** on the application tile, and copy the **Client ID**.
-- `connection_id`: Copy this from the connection configuration in Step 2.
-- `org_code`: Go to **Organizations** and copy the **Code** value from the organization row.
+```text title="Sample RelayState URL for an organization-level connection"
+https://app.example.com/login?
+client_id=YOUR_KINDE_CLIENT_ID
+&connection_id=conn_xxxxxxxx
+&org_code=org_xxxxxxxx
+```
 
 <Aside type="warning" title="Kinde uses the exact URL you provide">
 
@@ -214,14 +178,80 @@ Kinde redirects the browser to the exact RelayState URL you supply. It does **no
 
 </Aside>
 
+#### RelayState parameters
+
+| Parameter | What it does | Notes |
+| --- | --- | --- |
+| `client_id` | Identifies the Kinde application the user is signing in to | Must use this exact query parameter name |
+| `connection_id` | Identifies the enterprise connection to use | Must use this exact query parameter name |
+| `org_code` | Identifies the organization | Required for an organization-level connection. Your application must preserve this value and pass it on to the authorization request |
+
+#### Where to find these parameters
+
+- `client_id`: Go to **Settings > Environment > Applications**, select **View details** on the application tile, and copy the **Client ID**.
+- `connection_id`: Copy this from the connection configuration in Step 2.
+- `org_code`: Go to **Organizations** and copy the **Code** value from the organization row.
+
 #### What your application's login route must do
 
 The route you point RelayState at is responsible for turning the parameters it receives into a complete Kinde authorization request.
 
-1. **Read `connection_id` from the incoming query string** and pass it to your Kinde SDK's login method. Most SDKs accept this as `connectionId`. If you are not using an SDK, see [`connection_id`](/developer-tools/about/using-kinde-without-an-sdk/#connection_id) in our guide to using Kinde without an SDK.
-2. **Let the SDK build the authorization URL.** The SDK adds the callback URL, `state`, and PKCE parameters where applicable. These allow Kinde to complete the login and return the user to your application.
-3. **Pass `org_code` too, if the connection is organization-level.** Most SDKs accept this as `orgCode`. Your route needs to preserve the value from the incoming request and forward it.
-4. **Pass `login_hint` through as well, if it is present.** If **Use IdP email as login hint** is switched on for the connection (Step 2), Kinde appends the user's email to the RelayState redirect as a `login_hint` query parameter. Forward it to your SDK's login method (most SDKs accept this as `loginHint`) so the IdP can skip account selection on the second hop.
+1. **Read `connection_id` from the incoming query string** and pass it into the login request.
+2. **Include callback, `state`, and PKCE values.** Your SDK adds these. If you are not using an SDK, you must add them yourself.
+3. **Pass `org_code` too, if the connection is organization-level.**
+4. **Pass `login_hint` through as well, if it is present.** If **Use IdP email as login hint** is switched on for the connection (Step 2), Kinde appends the user's email to the RelayState redirect as a `login_hint` query parameter. Forward it so the IdP can skip account selection on the second hop.
+
+<Tabs>
+
+  <TabItem label="Using an SDK">
+
+Most Kinde SDKs accept these as `connectionId`, `orgCode`, and `loginHint`. Parameter names vary slightly by SDK; check your [SDK docs](/developer-tools/about/our-sdks/) if a call fails.
+
+Read the values from the incoming RelayState query string, then start login. Do not hardcode them.
+
+
+```typescript title="Next.js example"
+import { redirect } from "next/navigation";
+
+export default async function LoginPage({ searchParams }) {
+  const { connection_id, org_code, login_hint } = await searchParams;
+  const query = new URLSearchParams();
+
+  if (connection_id) query.set("connection_id", connection_id);
+  if (org_code) query.set("org_code", org_code);
+  if (login_hint) query.set("login_hint", login_hint);
+
+  redirect(`/api/auth/login?${query.toString()}`);
+}
+```
+
+The SDK builds the authorization URL, including the callback URL, `state`, and PKCE parameters where applicable.
+
+  </TabItem>
+
+  <TabItem label="Without an SDK">
+
+Build a full `/oauth2/auth` request. Include `redirect_uri`, `state`, and PKCE (`code_challenge` and `code_challenge_method=S256`) where required. See [Use Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/#connection_id).
+
+Read `connection_id`, `org_code`, and `login_hint` from the incoming RelayState query string and add them to the authorization URL:
+
+```text title="Authorization request"
+https://<your_subdomain>.kinde.com/oauth2/auth
+?response_type=code
+&client_id=<your_kinde_client_id>
+&redirect_uri=<your_app_callback_url>
+&scope=openid%20profile%20email
+&state=<random_state>
+&connection_id=<connection_id_from_query>
+&org_code=<org_code_from_query>
+&login_hint=<login_hint_from_query>
+```
+
+Omit `org_code` or `login_hint` when they are not in the incoming request. Never send this URL with only `client_id` and `connection_id`.
+
+  </TabItem>
+
+</Tabs>
 
 <Aside type="warning">
 
@@ -231,18 +261,19 @@ Don't construct or hardcode a partial `/oauth2/auth` URL that contains only `cli
 
 ### 4. Configure your Identity Provider
 
-In your IdP admin console, create a new SAML application with these settings:
+In your IdP admin console, open the SAML application you created in the provider guide (or create one if you have not already). Add these settings:
 
 1. **ACS URL / Reply URL**: Use the ACS URL you copied from Kinde in Step 2 (e.g., `https://yourdomain.kinde.com/login/saml/callback`)
 2. **Entity ID / Audience**: Use the Entity ID you configured in Kinde
 3. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*Persistent* recommended)
 4. **RelayState**: Enter the full URL you decided on in Step 3. This is required for IdP-initiated SSO in Kinde. It is where the browser is sent to *begin* Kinde login, not where the user lands after signing in.
 
-    <Aside> 
+    Field names vary by provider. Common locations:
 
-    If you are using Google Workspace as your Identity Provider, set your RelayState URL in the **Start URL** field in the Google SAML application settings. 
-
-    </Aside>
+    - **Google Workspace**: **Start URL** in the SAML application settings
+    - **Okta**: **Default Relay State**
+    - **Microsoft Entra ID**: **Relay State** in the SAML single sign-on settings
+    - Other IdPs: look for RelayState, Default RelayState, or Start URL
 
 5. **Enable IdP-initiated SSO**: IdP-initiated SSO must be enabled on both sides. Switch on **Accept requests** in Kinde (Step 2), and enable the equivalent option in your IdP's application settings (the exact setting name varies by provider)
 
@@ -252,7 +283,7 @@ In your IdP admin console, create a new SAML application with these settings:
 
     </Aside>
 
-6. Copy the **Metadata URL** from your IdP. This is typically in the SAML application settings. You can also download it as an XML file. You need this URL in the next step.
+6. Copy the **Metadata URL** from your IdP. This is typically in the SAML application settings. If you only have an XML file, host it in a location you control, such as an [AWS S3](https://aws.amazon.com/s3/) bucket or [Cloudflare R2](https://developers.cloudflare.com/r2/), then use that file's URL. You need this URL in the next step.
 
 ### 5. Finish setting up your IdP connection
 
@@ -268,12 +299,16 @@ In your IdP admin console, create a new SAML application with these settings:
 
 ### SP-initiated flow
 
+This path uses [home realm discovery](/authenticate/enterprise-connections/home-realm-discovery/). If you did not set home realm domains on the connection, enter an email on the Kinde login screen and select the enterprise connection instead.
+
 1. Go to your application's login page
 2. Enter an email address that matches a home realm domain
 
 You should be redirected to your IdP. After authentication, you should be redirected back to your app.
 
 ### IdP-initiated flow
+
+Confirm **Accept requests** is switched on for the connection (Step 2) before you test.
 
 1. Sign in to your Identity Provider's portal
 2. Select your application in the IdP dashboard
@@ -288,12 +323,15 @@ Your browser should be sent to your RelayState URL, which starts Kinde login. Be
 | --- | --- | --- |
 | "Invalid SAML response" | Mismatched Entity ID | Ensure the Entity ID in Kinde matches your IdP configuration exactly |
 | "Signature verification failed" | Certificate mismatch | Verify your IdP's signing certificate is correctly configured |
-| User not created | Provisioning disabled | Enable "Create a user record in Kinde" |
+| User not created | Provisioning disabled | Enable "Create a user record in Kinde". See [Provision users for enterprise](/authenticate/enterprise-connections/provision-users-enterprise/) |
 | Wrong attributes | Attribute mapping | Check that your IdP attribute names match the mapped keys |
-| Nothing happens after clicking the app tile, or you land on the Kinde login screen | RelayState is only `client_id=...&connection_id=...` | RelayState must be a full URL including the scheme and host, not just a query string |
-| Login does not complete after the redirect | Your login route is sending a Kinde `/oauth2/auth` URL that contains only `client_id` and `connection_id` | Use your SDK's login method so the callback, `state`, and PKCE parameters are included |
+| Nothing happens after selecting the app tile, or you land on the Kinde login screen | RelayState is only `client_id=...&connection_id=...`, or RelayState is not set in the IdP | RelayState must be a full URL including the scheme and host. Confirm it is saved in the IdP (Start URL, Default Relay State, or equivalent) |
+| Login does not complete after the redirect | Your login route is sending a Kinde `/oauth2/auth` URL that contains only `client_id` and `connection_id` | Use your SDK's login method, or include callback, `state`, and PKCE parameters |
 | The ordinary Kinde login screen appears instead of the enterprise connection | Your application's login route is not forwarding `connection_id` | Read `connection_id` from the incoming request and pass it to the SDK as `connectionId` |
-| Users reach the wrong organization, or the connection isn't offered | An organization-level connection without `org_code` | Preserve `org_code` through your login route and pass it to the SDK |
+| Nothing happens after selecting the app tile, and **Accept requests** is off | IdP-initiated SSO is disabled on the Kinde connection | Switch **Accept requests** on (Step 2) |
+| Users reach the wrong organization, or the connection isn't offered | An organization-level connection without `org_code` | Include `org_code` in RelayState, preserve it through your login route, and pass it to the SDK |
+| The IdP shows an account picker on the second hop | `login_hint` is not forwarded | Switch on **Use IdP email as login hint** and pass `login_hint` / `loginHint` through to the authorization request |
+| ACS or audience errors | The ACS URL or Entity ID in the IdP does not match Kinde, or you mixed a custom domain ACS with the default `*.kinde.com` ACS | Copy the ACS URL shown on the connection you are using, including custom domain if configured |
 | "Invalid client", or the connection isn't recognized | The client ID and connection ID are from different Kinde environments | Confirm both values come from the same Kinde environment |
 
 ### Error codes
@@ -307,8 +345,3 @@ For a full list of error codes, see [Common errors and codes](/get-started/guide
 - **Use signed requests**: Configure SAML request signing for enhanced security
 - **Enforce MFA at the IdP**: Since authentication happens at the IdP, ensure MFA is required there
 - **Keep certificates current**: Monitor certificate expiration and rotate before they expire
-
-## Conclusion
-
-You have configured IdP-initiated SAML SSO in Kinde. Enterprise users can now open your application from their Identity Provider portal. Use IdP-initiated SSO only when customers require portal-based access, and test both authentication flows before enabling in production.
-

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -3,6 +3,8 @@ page_id: 8a3f4e2d-9c1b-4a7d-8e2f-1a5b6c7d8e9f
 title: IdP-initiated SAML SSO
 sidebar:
   order: 14
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - fcf28a71-c3a8-4474-9564-ad089d3f2105
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
@@ -10,17 +12,14 @@ relatedArticles:
 app_context:
   - m: settings
     s: authentication
-description: >-
-  Guide to configuring IdP-initiated SAML single sign-on flows where
-  authentication starts at the Identity Provider rather than your application.
+description: "Enable IdP-initiated SAML SSO so enterprise users can open your app from their identity provider portal in one click"
 featured: false
 deprecated: false
-ai_summary: >-
-  Guide to configuring IdP-initiated SAML single sign-on flows where
-  authentication starts at the Identity Provider rather than your application,
-  including setup steps, IdP configuration, and security best practices.
+ai_summary: "Guide to configuring IdP-initiated SAML single sign-on in Kinde, where authentication starts at the identity provider rather than the application. Explains the two-hop flow: the IdP posts an unsolicited SAML assertion to the Kinde ACS endpoint, then Kinde redirects to a RelayState URL that starts a standard Kinde authorization request. Covers creating environment-level and organization-level enterprise connections, connection settings including Accept requests and Use IdP email as login hint, home realm domains, provisioning, and ACS URL setup. Details how to build a full RelayState URL with client_id, connection_id, and org_code, and what the application login route must pass to the SDK, including connectionId, orgCode, loginHint, and PKCE. Includes IdP configuration for ACS URL, Entity ID, RelayState, and metadata URL, plus testing SP-initiated and IdP-initiated flows, troubleshooting, and security guidance. Intended for developers, enterprise admins, and security engineers."
 topics:
   - authenticate
+  - enterprise-connections
+  - saml
 sdk: []
 languages: []
 audience:
@@ -30,66 +29,63 @@ audience:
 complexity: advanced
 keywords:
   - IdP-initiated
-  - SAML
-  - SSO
-  - identity provider
-  - service provider
-  - SP-initiated
-  - enterprise authentication
-  - metadata URL
-  - metadata hosting
-  - XML
   - RelayState
+  - ACS URL
   - connection_id
-  - client_id
-updated: 2026-09-01
+  - SAML SSO
+  - login_hint
+  - home realm discovery
+  - unsolicited SAML
+updated: 2026-09-06
 ---
 
 In this guide, you'll learn how to configure IdP-initiated SSO in Kinde, including setting up the SAML connection, configuring RelayState, configuring your Identity Provider, and testing both SP-initiated and IdP-initiated authentication flows.
 
+## What you need
+
+- A [Kinde](https://kinde.com) account with **Engineer** or **Admin** permissions
+- Admin access to your [enterprise identity provider](/authenticate/enterprise-connections/about-enterprise-connections) (Okta, Azure AD, Google Workspace, etc.)
+- A route in your application that starts Kinde login and can accept query parameters
+- A [verified domain configured in Kinde](/build/domains/organization-custom-domain/) for organization-level connections ([Kinde Plus plan](https://www.kinde.com/pricing/) or higher is needed)
+
 ## What is IdP-initiated SSO?
 
-IdP-initiated SSO is an authentication flow where the login process **starts at the Identity Provider** rather than at your application (the Service Provider).
-
-When setting up enterprise authentication, you'll encounter two main ways to start a SAML single sign-on flow: Service Provider (SP) initiated and Identity Provider (IdP) initiated. IdP-initiated SSO differs from SP-initiated SSO, where the user first visits your application and is then redirected to the IdP to authenticate.
-
-### How it works
+IdP-initiated SSO is an authentication flow where login **starts at the Identity Provider** rather than at your application (the Service Provider). In Service Provider (SP) initiated SSO, the user visits your application first and is then redirected to the IdP to authenticate.
 
 Kinde completes IdP-initiated SSO in two hops. The IdP hands the user off to Kinde, and your application then starts a normal Kinde login.
 
-**Phase 1 – the IdP hands off to Kinde**
+### Phase 1 – the IdP hands off to Kinde
 
-1. The user clicks the tile for your application in their IdP.
-2. The IdP posts an unsolicited SAML assertion to your Kinde ACS endpoint.
+1. The user selects the tile for your application in their IdP.
+2. The IdP posts an unsolicited SAML assertion to your Kinde Assertion Consumer Service (ACS) endpoint.
 3. Kinde validates the assertion. This first request confirms who the user is, but **it does not sign the user in to Kinde**. No end-user session exists yet.
 4. Kinde redirects the browser to the URL supplied in RelayState.
 
-**Phase 2 – your application starts the Kinde login**
+### Phase 2 – your application starts the Kinde login
 
-5. The RelayState URL is a route in your application. That route starts a normal Kinde authorization request, preserving `connection_id`.
-6. Because `connection_id` is present, Kinde skips its own login screen and goes straight to the SP-initiated SAML round-trip for that connection.
-7. The user already has an active session at the IdP, so this round-trip normally completes without asking for credentials again.
-8. Kinde creates the authenticated session and returns the user to your application.
+1. The RelayState URL is a route in your application. That route starts a normal Kinde authorization request, preserving `connection_id`.
+2. Because `connection_id` is present, Kinde skips its own login screen and goes straight to the SP-initiated SAML round-trip for that connection.
+3. The user already has an active session at the IdP, so this round-trip normally completes without asking for credentials again.
+4. Kinde creates the authenticated session and returns the user to your application.
 
 <Aside title="Why two hops?">
 
-The second leg is a standard SP-initiated exchange, so the session is created with the full set of checks in place, including `InResponseTo`, state, and PKCE where applicable. The user experience is still a single click in the IdP portal.
+The second leg is a standard SP-initiated exchange, so the session is created with the full set of checks in place, including `InResponseTo`, state, and Proof Key for Code Exchange (PKCE) where applicable. The user experience is still a single click in the IdP portal.
 
 </Aside>
 
-### What you need 
+## Configuration
 
-- A [Kinde](https://kinde.com) account with an **enterprise connections** entitlement
-- Admin access to your [enterprise identity provider](/authenticate/enterprise-connections/about-enterprise-connections) (Okta, Azure AD, Google Workspace, etc.)
-- A [verified domain configured in Kinde](/build/domains/organization-custom-domain/) (for organization-level connections)
-- A route in your application that starts Kinde login and can accept query parameters
+### 1. Create an enterprise connection
 
-## Step 1: Add a SAML enterprise connection in Kinde
+<Aside>
 
-### Option A: Environment-level connection (shared across organizations)
+This is an environment-level connection shared across all organizations in the environment. For organization-specific connections, see [Alternative way](#alternative-way-create-an-organization-specific-connection).
+
+</Aside>
 
 1. Sign in to your Kinde admin portal
-2. Navigate to **Settings** > **Authentication**
+2. Go to **Settings > Environment > Authentication**
 3. Select **Add connection** in the **Enterprise connections** section
 4. Select your SAML provider:
    - **Custom SAML** (for any SAML 2.0 IdP)
@@ -98,44 +94,47 @@ The second leg is a standard SP-initiated exchange, so the session is created wi
    - **Cloudflare** (pre-configured for Cloudflare Access)
 5. Select **Next**
 
-### Option B: Organization-level connection (specific to one organization)
+### 1. Alternative way: Create an organization-specific connection
 
-1. Sign in to your Kinde admin portal
-2. Navigate to **Organizations** > select your organization
-3. Go to the **Authentication** tab
-4. Select **Add connection**. A pop-up appears
-5. Select **Organization SSO connection**, then select **Next**
-6. Choose your connection type (Custom SAML, Cloudflare, Okta, etc.)
-7. Select **Next**
+<Aside type="upgrade">
 
-<Aside type="warning">
-
-Organization-level connections require verified domains to be configured for the organization first. Contact your system administrator if no domains are available.
+Organization-level connections require [verified domains](/build/domains/organization-custom-domain/) to be configured for the organization first. A [Kinde Plus plan](https://www.kinde.com/pricing/) or higher is required to use this feature.
 
 </Aside>
 
+1. Sign in to your Kinde admin portal
+2. Go to **Organizations** and select your organization
+3. Go to the **Authentication** tab
+4. Select **Add connection**. A dialog appears
+5. Select **Organization SSO connection**, then select **Next**
 
-## Step 2: Configure the SAML connection details in Kinde
+    ![kinde organization sso connection](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/bee83baa-247d-45db-eb26-d1a7adcf7800/socialsharingimage)
+
+6. Choose your connection type (Custom SAML, Cloudflare, Okta, etc.)
+7. Select **Next**
+
+### 2. Configure connection details in Kinde
 
 After creating the connection, configure these settings:
 
-    ![kinde custom saml connection](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/5f39d363-c8b2-4de8-2890-e1886edd7700/socialsharingimage)
+    ![kinde custom saml connection](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/67daf001-e62e-488a-31ca-0199a8f8db00/socialsharingimage)
 
-1. **Connection name**: A name to identify this connection (e.g., "Acme Corp SSO")
-2. **Entity ID**: The unique identifier configured in your IdP (e.g., `https://yourapp.kinde.com`)
-3. **IdP metadata URL**: You will add this after finishing setup in your Identity Provider (see Step 4)
+1. **Connection ID**: Copy this value. You need it to create the RelayState URL for IdP-initiated SSO.
+2. **Connection name**: A name to identify this connection (e.g., "Acme Corp SSO")
+3. **Entity ID**: The unique identifier configured in your IdP (e.g., `https://yourapp.kinde.com`)
+4. **IdP metadata URL**: Add this after you finish setup in your Identity Provider (see Step 4)
 
     <Aside title="No metadata URL? Host the XML file yourself">
 
-   If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
+    If your identity provider gives you the SAML metadata as an XML file but does not provide a hosted metadata URL, upload the file to a publicly accessible location such as an [AWS S3](https://aws.amazon.com/s3/) bucket, [Cloudflare R2](https://developers.cloudflare.com/r2/), a [GitHub Gist](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists/), or any public website. Then enter that file's URL in the **IdP metadata URL** field. Kinde reads the file from this URL so your signing certificates stay up to date.
 
     </Aside>
 
-4. **Sign in URL** (optional): Override the default SSO endpoint with a URL your IdP recognizes
-5. **Sign request algorithm**: Choose the algorithm used to sign SAML requests (RSA-SHA1 or RSA-SHA256)
-6. **Protocol binding**: Choose the protocol binding used to send SAML requests
-7. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*persistent* recommended)
-8. Set up the attribute mapping for user:
+5. **Sign in URL** (optional): Override the default SSO endpoint with a URL your IdP recognizes
+6. **Sign request algorithm**: Choose the algorithm used to sign SAML requests (RSA-SHA1 or RSA-SHA256)
+7. **Protocol binding**: Choose the protocol binding used to send SAML requests
+8. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*Persistent* recommended)
+9. Set up the user attribute mapping:
 
     - **Email key attribute**: The attribute in the SAML token that contains the user's email. Defaults to `email` if not provided.
     - **User ID key attribute**: The attribute in the SAML token that contains the user ID. Defaults to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` if not provided.
@@ -143,55 +142,59 @@ After creating the connection, configure these settings:
     - **Last name key attribute**: The attribute in the SAML token that contains the user's last name. Defaults to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname` if not provided.
 
         <Aside>
+
         If your IdP uses different attribute names, enter the correct attribute keys in the mapping fields.
+        
         </Aside>
 
-9. **Home realm domains**: A list of domains used for home realm discovery. Add each URL on a new line:
+10. **Home realm domains**: A list of domains used for home realm discovery. Add each domain on a new line:
 
-    ```
+    ```text title="Sample home realm domains"
     acmecorp.com
     acme.co
     ```
-    <Aside> 
-      When users enter an email matching these domains, they'll be automatically routed to this SSO connection.
+    <Aside>
+
+    When users enter an email matching these domains, they are automatically routed to this SSO connection.
+    
     </Aside>
 
-10. **Always show sign-in button**: 
+11. **Always show sign-in button**:
     - **Off (default):** If home realm domains are set, the SSO button only shows after email domain detection
     - **On:** The SSO button is always visible on the login screen
-11. **IdP-initiated SSO behavior**: If your environment shows this section, use it to control whether Kinde accepts sign-in requests that start at the IdP:
+12. **IdP-initiated SSO behavior**: Controls whether Kinde accepts sign-in requests that start at the IdP:
 
     - **Accept requests**: Accepts unsolicited login requests sent to Kinde by your IdP. This is off by default, and IdP-initiated SSO does not work until you switch it on.
     - **Use IdP email as login hint**: Takes the email address from the SAML response and adds it to the redirect as a `login_hint` query parameter. This lets the IdP skip account selection when the user is signed in to more than one account.
 
-        <Aside>
-        If you don't see an **IdP-initiated SSO behavior** section on your connection, contact Kinde support to have IdP-initiated SSO enabled for your environment.
-        </Aside>
+        ![kinde idp initiated sso behavior](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/b3887c3a-a2d4-4bfb-8c85-a146ad6fb300/socialsharingimage)
 
-12. Copy the **Assertion Consumer Service (ACS) URL**. You will need to add this to your IdP configuration.
-13. **Provisioning**: Control how users are created when authenticating via SAML:
+13. Copy the **Assertion Consumer Service (ACS) URL**. You need this for your IdP configuration.
+14. **Provisioning**: Control how users are created when authenticating via SAML:
     - **Create a user record in Kinde**: When enabled, users who don't exist in Kinde are automatically created on first sign-in
     - **Trust email addresses provided by this connection**: Merge accounts when email matches an existing Kinde user
 
-        ![provisioning create user record](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/6e7fd08b-b5b9-43a9-b171-4a43f1c97d00/socialsharingimage)
+        ![sso provisioning create a user record switch](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/31860fbb-b57e-49f5-ea89-71e0446a3000/socialsharingimage)
 
     - **Auto-add users** (org-level only): Users are automatically added as members of the organization
 
-        ![auto add users in kinde organization](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/adde50b3-de8c-429b-010e-7793a7df6800/socialsharingimage)
+        ![auto add users in kinde organization](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a4736783-6aaf-4a69-b66a-e380f63a4300/socialsharingimage)
 
-14. Select **Save**
+15. Select **Save**
 
-## Step 3: Decide on your RelayState URL
+### 3. Decide on your RelayState URL
 
 RelayState is how the IdP tells Kinde where to send the browser after the assertion is validated. For this flow, RelayState is required, and it must be a **full, absolute URL**. A bare query string such as `client_id=...&connection_id=...` is not accepted.
 
 The URL should point at the route in your application that starts Kinde login, and it must carry the `client_id` and `connection_id` parameters:
 
-```
-https://app.example.com/login?client_id=YOUR_KINDE_CLIENT_ID&connection_id=conn_0192c16abb53b44277e597d31877ba5b
+```text title="Sample RelayState URL"
+https://app.example.com/login?
+client_id=YOUR_KINDE_CLIENT_ID
+&connection_id=conn_0192c16abb53b44277e597d31877ba5b
 ```
 
-### RelayState parameters
+#### RelayState parameters
 
 | Parameter | What it does | Notes |
 | --- | --- | --- |
@@ -199,18 +202,24 @@ https://app.example.com/login?client_id=YOUR_KINDE_CLIENT_ID&connection_id=conn_
 | `connection_id` | Identifies the enterprise connection to use | Must use this exact query parameter name |
 | `org_code` | Identifies the organization | For an organization-level connection, your application may also need to preserve this value and pass it on to the authorization request |
 
+#### Where to find these parameters
+
+- `client_id`: Go to **Settings > Environment > Applications**, select **View details** on the application tile, and copy the **Client ID**.
+- `connection_id`: Copy this from the connection configuration in Step 2.
+- `org_code`: Go to **Organizations** and copy the **Code** value from the organization row.
+
 <Aside type="warning" title="Kinde uses the exact URL you provide">
 
 Kinde redirects the browser to the exact RelayState URL you supply. It does **not** use `client_id` to look up your application's configured **Application login URI** and invoke that for you. If RelayState is missing, incomplete, or not a full URL, the flow cannot recover and the user won't be signed in.
 
 </Aside>
 
-### What your application's login route must do
+#### What your application's login route must do
 
 The route you point RelayState at is responsible for turning the parameters it receives into a complete Kinde authorization request.
 
-1. **Read `connection_id` from the incoming query string** and pass it to your Kinde SDK's login method. Most SDKs accept this as `connectionId`. If you are not using an SDK, see [`connection_id`](/developer-tools/about/using-kinde-without-an-sdk/) in our guide to using Kinde without an SDK.
-2. **Let the SDK build the authorization URL.** The SDK adds the callback URL, `state`, and PKCE parameters where applicable. These are what allow Kinde to complete the login and return the user to your application.
+1. **Read `connection_id` from the incoming query string** and pass it to your Kinde SDK's login method. Most SDKs accept this as `connectionId`. If you are not using an SDK, see [`connection_id`](/developer-tools/about/using-kinde-without-an-sdk/#connection_id) in our guide to using Kinde without an SDK.
+2. **Let the SDK build the authorization URL.** The SDK adds the callback URL, `state`, and PKCE parameters where applicable. These allow Kinde to complete the login and return the user to your application.
 3. **Pass `org_code` too, if the connection is organization-level.** Most SDKs accept this as `orgCode`. Your route needs to preserve the value from the incoming request and forward it.
 4. **Pass `login_hint` through as well, if it is present.** If **Use IdP email as login hint** is switched on for the connection (Step 2), Kinde appends the user's email to the RelayState redirect as a `login_hint` query parameter. Forward it to your SDK's login method (most SDKs accept this as `loginHint`) so the IdP can skip account selection on the second hop.
 
@@ -220,7 +229,7 @@ Don't construct or hardcode a partial `/oauth2/auth` URL that contains only `cli
 
 </Aside>
 
-## Step 4: Configure your Identity Provider
+### 4. Configure your Identity Provider
 
 In your IdP admin console, create a new SAML application with these settings:
 
@@ -228,44 +237,48 @@ In your IdP admin console, create a new SAML application with these settings:
 2. **Entity ID / Audience**: Use the Entity ID you configured in Kinde
 3. **Name ID format**: Select the format for the Name ID used to identify users in SAML responses (*Persistent* recommended)
 4. **RelayState**: Enter the full URL you decided on in Step 3. This is required for IdP-initiated SSO in Kinde. It is where the browser is sent to *begin* Kinde login, not where the user lands after signing in.
+
     <Aside> 
-    If you are using Google Workspace as your Identity Provider, set your RelayState URL in the Start URL field in the Google SAML application settings. 
+
+    If you are using Google Workspace as your Identity Provider, set your RelayState URL in the **Start URL** field in the Google SAML application settings. 
+
     </Aside>
 
-5. **Enable IdP-initiated SSO**: IdP-initiated SSO has to be enabled on both sides. Switch on **Accept requests** in Kinde (Step 2), and enable the equivalent option in your IdP's application settings (the exact setting name varies by provider)
+5. **Enable IdP-initiated SSO**: IdP-initiated SSO must be enabled on both sides. Switch on **Accept requests** in Kinde (Step 2), and enable the equivalent option in your IdP's application settings (the exact setting name varies by provider)
 
     <Aside>
+
     IdP-initiated SAML SSO support may vary by Identity Provider. Contact Kinde support if you encounter issues with specific IdP configurations.
+
     </Aside>
 
-6. Copy the **Metadata URL** from your IdP. This is typically found in the SAML application settings or can be downloaded as an XML file. You'll need this URL in the next step.
-  
-## Step 5: Finish setting up your IdP connection
+6. Copy the **Metadata URL** from your IdP. This is typically in the SAML application settings. You can also download it as an XML file. You need this URL in the next step.
 
-1. Open the connection in Kinde. Go to **Organizations** > **Authentication** or **Settings** > **Authentication**.
+### 5. Finish setting up your IdP connection
+
+1. Open the connection in Kinde. Go to **Settings > Environment > Authentication** or **Organizations > Authentication**.
 2. Scroll to the **IdP metadata URL** field and paste the Metadata URL you copied from Step 4.
 3. (Optional) Enter the signed certificate and key information if you have it. You can do this later as well. See [Advanced SAML configurations](/authenticate/enterprise-connections/advanced-saml-configurations/) for more details.
-4. Switch on the connection. This will make it instantly available to users if this is your production environment.
-    - For environment-level connections, scroll down and select the apps that will use the auth method.
-    - For organization-level connections, scroll down and select if you want to switch this on for the org.
+4. Switch on the connection. This makes it available to users immediately if this is your production environment.
+    - For environment-level connections, scroll down and select the applications that will use this authentication method.
+    - For organization-level connections, scroll down and choose whether to switch this on for the organization.
 5. Select **Save**. You can now use the IdP for the selected applications.
 
-## Step 6: Test the configuration
+## Test the configuration
 
-### Test SP-initiated flow (standard)
+### SP-initiated flow
 
-1. Navigate to your application's login page
-2. Enter an email address matching a home realm domain
-3. You should be redirected to your IdP
-4. After authentication, you should be redirected back to your app
+1. Go to your application's login page
+2. Enter an email address that matches a home realm domain
 
-### Test IdP-initiated flow
+You should be redirected to your IdP. After authentication, you should be redirected back to your app.
 
-1. Log in to your Identity Provider's portal
-2. Click on your application in the IdP dashboard
-3. Your browser should be sent to your RelayState URL, which starts Kinde login
-4. Because you already have a session at the IdP, you should not be asked for credentials again
-5. You should land back in your app, signed in
+### IdP-initiated flow
+
+1. Sign in to your Identity Provider's portal
+2. Select your application in the IdP dashboard
+
+Your browser should be sent to your RelayState URL, which starts Kinde login. Because you already have a session at the IdP, you should not be asked for credentials again. You should land back in your app, signed in.
 
 ## Troubleshooting
 
@@ -285,7 +298,7 @@ In your IdP admin console, create a new SAML application with these settings:
 
 ### Error codes
 
-For a comprehensive list of error codes, see [Common errors and codes](/get-started/guides/error-codes/).
+For a full list of error codes, see [Common errors and codes](/get-started/guides/error-codes/).
 
 ## Security best practices
 
@@ -295,7 +308,7 @@ For a comprehensive list of error codes, see [Common errors and codes](/get-star
 - **Enforce MFA at the IdP**: Since authentication happens at the IdP, ensure MFA is required there
 - **Keep certificates current**: Monitor certificate expiration and rotate before they expire
 
-### Conclusion
+## Conclusion
 
-You've successfully configured IdP-initiated SAML SSO in Kinde. Your enterprise users can now access your application directly from their Identity Provider portal. Remember that while IdP-initiated SSO offers convenience, SP-initiated flows provide additional security validations. Use IdP-initiated SSO only when your enterprise customers specifically require portal-based access. Test both authentication flows thoroughly before enabling in production.
+You have configured IdP-initiated SAML SSO in Kinde. Enterprise users can now open your application from their Identity Provider portal. Use IdP-initiated SSO only when customers require portal-based access, and test both authentication flows before enabling in production.
 

--- a/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/idp-initiated-saml-sso.mdx
@@ -283,7 +283,7 @@ In your IdP admin console, open the SAML application you created in the provider
 
     </Aside>
 
-6. Copy the **Metadata URL** from your IdP. This is typically in the SAML application settings. If you only have an XML file, host it in a location you control, such as an [AWS S3](https://aws.amazon.com/s3/) bucket or [Cloudflare R2](https://developers.cloudflare.com/r2/), then use that file's URL. You need this URL in the next step.
+6. Copy the **Metadata URL** from your IdP. This is typically in the SAML application settings. If you only have an XML file, host it at a **publicly accessible HTTPS URL**, such as a public [AWS S3](https://aws.amazon.com/s3/) object or [Cloudflare R2](https://developers.cloudflare.com/r2/) object. Private objects cannot be used. You need this URL in the next step.
 
 ### 5. Finish setting up your IdP connection
 

--- a/src/content/docs/authenticate/enterprise-connections/lastpass-sso.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/lastpass-sso.mdx
@@ -2,7 +2,8 @@
 page_id: 00aa9631-5633-4b25-a75d-9263092a233f
 title: LastPass enterprise connection (SAML)
 sidebar:
-  order: 10
+  order: 6
+  label: LastPass (SAML)
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105

--- a/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/mapping-users-enterprise.mdx
@@ -2,7 +2,7 @@
 page_id: fbe51780-8c30-4e7d-b294-cfb6660466c6
 title: Mapping and syncing users for enterprise auth
 sidebar:
-  order: 5
+  order: 14
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c

--- a/src/content/docs/authenticate/enterprise-connections/migrate-users-to-enterprise-identity.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/migrate-users-to-enterprise-identity.mdx
@@ -3,7 +3,7 @@ page_id: 8c71cef6-4e34-4417-afcd-cbc3fdf13ab3
 title: Migrating users from email identity to enterprise identity
 description: Step-by-step guide to migrating existing email/password users to Enterprise SSO connections (SAML/Entra ID) using JIT provisioning, including testing, pilot rollout, and post-migration security best practices.
 sidebar:
-  order: 5
+  order: 15
 relatedArticles:
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
 topics:

--- a/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/okta-saml-connection.mdx
@@ -2,7 +2,8 @@
 page_id: 9456239e-0d53-4597-83d2-56ab0c1468d3
 title: Okta enterprise connection (SAML)
 sidebar:
-  order: 11
+  order: 7
+  label: Okta (SAML)
 relatedArticles:
   - 17559023-5b50-4690-ba7b-fd1df4b78664
   - fcf28a71-c3a8-4474-9564-ad089d3f2105

--- a/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/provision-users-enterprise.mdx
@@ -2,7 +2,7 @@
 page_id: 2c58dabc-fe5c-4919-ade7-4caab8da47e8
 title: Provisioning users for enterprise connections
 sidebar:
-  order: 2
+  order: 13
 relatedArticles:
   - 98f6868a-7871-4ece-ba9c-2a7b21d1b322
   - e100d77b-530b-4327-8216-93c955657e0c

--- a/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/refresh-saml-certificate.mdx
@@ -2,7 +2,7 @@
 page_id: d894dd3c-356f-41b0-b510-c35066a2277d
 title: Refresh SAML certificate
 sidebar:
-  order: 15
+  order: 11
 relatedArticles:
   - 66b2a627-b24a-4ccf-a792-80a6a9fe35ef
   - 0dfcab9d-8610-4881-9293-8501bd472041


### PR DESCRIPTION
#### Description (required)

Updates the IdP-initiated SAML SSO guide to describe Kinde’s two-hop login: the IdP posts an unsolicited assertion to Kinde, Kinde validates it without creating a session, then redirects to a RelayState URL in the customer’s app so that app can start a normal Kinde authorization request.

The guide now makes RelayState required as a full absolute URL (with `client_id` and `connection_id`, plus `org_code` when needed), explains that Kinde does not derive the Application login URI from `client_id`, and documents what the app login route must pass through to the SDK (including callback, state, and PKCE). Also adds Google Workspace Start URL notes, IdP-initiated test steps, and troubleshooting for incomplete RelayState or auth URLs.

#### Related issues & labels (optional)

- Suggested label: documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded IdP-initiated SAML SSO guidance, including RelayState requirements, connection settings, login configuration, metadata hosting, limitations, and troubleshooting.
  * Added troubleshooting details for error 9055, including required RelayState parameters and connection settings.
  * Reorganized enterprise connection documentation in the sidebar and added clearer labels for supported providers and protocols.
  * Updated related page metadata, navigation order, descriptions, keywords, and revision information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->