### PR TITLE
update: invalid callback URL page customization and error note

### DIFF
--- a/src/content/docs/get-started/guides/error-codes.mdx
+++ b/src/content/docs/get-started/guides/error-codes.mdx
@@ -3,30 +3,35 @@ page_id: 46149cb3-fa96-46a2-bd94-0ba4aacae527
 title: Common errors and codes
 sidebar:
   order: 4
-description: Comprehensive troubleshooting guide for common Kinde error codes including authentication, SAML, OAuth, and verification issues.
+description: "Fix common Kinde authentication errors with codes, causes, and steps for callbacks, SAML, OAuth, JWKS, and more."
 relatedArticles:
   - 9b9ce8a8-dffb-47e5-82a9-e612b1947963
+tableOfContents:
+  maxHeadingLevel: 3
 topics:
   - get-started
   - guides
+  - authentication
 sdk: []
-languages: []
+languages:
+  - typescript
 audience:
   - developers
   - admins
 complexity: intermediate
 keywords:
   - error codes
-  - troubleshooting
-  - authentication errors
-  - saml errors
-  - oauth errors
+  - invalid callback URL
+  - JWKS
+  - SAML errors
+  - OAuth errors
   - verification codes
-  - token errors
-updated: 2026-05-29
+  - state not found
+  - social sign-in
+updated: 2026-08-25
 featured: false
 deprecated: false
-ai_summary: Comprehensive troubleshooting guide for common Kinde error codes including authentication, SAML, OAuth, and verification issues.
+ai_summary: "Troubleshooting reference for common Kinde authentication errors and numeric error codes. Covers user-facing messages such as invalid callback URL, state not found, and authentication configuration failures, plus JWKS endpoint 403 responses, missing email and SMS verification codes, and a time-limited email verification link error. Lists SAML, OAuth 2.0, social sign-in, connected app, and post-authentication workflow codes with descriptions and troubleshooting steps, including callback URL setup in the Kinde dashboard, custom invalid_redirect_url error pages, identity provider ACS and metadata checks, and workflow failure policies. Intended for developers and admins diagnosing login, SSO, and token issues."
 ---
 
 Depending on the complexity of your authentication setup, you or your users may occasionally encounter errors.
@@ -40,6 +45,34 @@ This error message typically appears when there's an issue with your authenticat
 - Misconfigured authentication settings
 - Session management issues
 - Incorrect callback URLs
+
+## Invalid callback URL
+
+Looks like the allowed callback URLs in your Kinde application don't include the one below.
+
+<img src="https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/b50d897d-febf-4238-7cef-88021fa48400/socialsharingimage" alt="Invalid callback URL page" width="300" />
+
+This error appears when the callback URL is not in the list of allowed callback URLs in your Kinde application.
+
+<Aside>
+
+If you are signed in to your Kinde account, you will see an **Add callback to application now** button on the error page. Selecting this button takes you to the **Callback URLs** page, where you can add the callback URL.
+
+</Aside>
+
+### Fix the error
+
+Update the allowed callback URLs in your Kinde application to include the URL that is causing the error. You can find the callback URL in the relevant [Kinde SDK](/developer-tools/about/our-sdks/) docs. If you are using [Kinde without an SDK](/developer-tools/about/using-kinde-without-an-sdk/), create a route to handle the callback. Learn more about [callback URLs](/get-started/connect/callback-urls/).
+
+After you find the callback URL, add it in Kinde:
+
+1. Sign in to your Kinde dashboard and select **View details** for the relevant application.
+2. Go to the **Details** page and enter the callback URL in the **Allowed callback URLs** field.
+3. Select **Save**.
+
+### Change the default error page
+
+If you do not want the default error page to show, replace it with your own custom UI in Kinde. Add a custom `(invalid_redirect_url)` error page to replace this content. Learn more about [Kinde page customization](/design/customize-with-code/understand-page-design/#error-pages).
 
 ## State not found
 


### PR DESCRIPTION
This PR documents how to deal with the invalid callback URL error status in Kinde. So far this PR documents the error in the common errors page and how to change with a custom page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the error codes guide metadata and table of contents.
  - Added TypeScript to the listed supported languages.
  - Added guidance for resolving invalid callback URL errors.
  - Documented how to update allowed callback URLs and configure a custom error page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->