### PR TITLE
`add:` plan availability banner to MFA/OTP code expiration duration

### DIFF
--- a/src/content/docs/build/set-up-options/access-policies.mdx
+++ b/src/content/docs/build/set-up-options/access-policies.mdx
@@ -106,6 +106,10 @@ Some enterprise connections also have their own profile sync setting—both the 
 
 ### MFA/OTP Code expiration duration
 
+<Aside type="upgrade">
+This feature is only available on the [Kinde Scale plan](https://kinde.com/pricing/)
+</Aside>
+
 When users receive a one-time code by email or SMS—for multi-factor authentication, passwordless sign-in, or password reset—this setting controls how long the code stays valid.
 
 - The default expiry duration is 120 minutes (2 hours).


### PR DESCRIPTION
## Add plan availability banner to MFA/OTP code expiration duration

Adds an `Aside type="upgrade"` banner to the **MFA/OTP Code expiration duration** section of *Set global access policies*, noting the setting is only available on the Kinde Scale plan.

### Why

A client flagged that this information was hard to find. The section documents the setting, the default (120 minutes), and guidance on tuning it — but nothing on the page indicated the setting is plan-gated. Readers on a lower plan could follow the whole section before discovering the option wasn't available to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a notice explaining that MFA/OTP code expiration duration settings are available only on the Kinde Scale plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->