### PR TITLE
feat: document what token and session revocation does and doesn't reach

### DIFF
--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -7,14 +7,17 @@ relatedArticles:
   - 6f5b7b0d-3818-4654-a1a1-3247a5e4d52a
   - 5a248c6f-c1ae-480a-95c3-d3c69c81598d
   - 4ed081b0-7853-49be-b5fd-22a84a86bdad
-description: >-
-  Guide to managing Kinde authenticated sessions including session persistence,
-  inactivity timeouts, and browser session behavior.
+tableOfContents:
+  maxHeadingLevel: 3
+description: "Set SSO persistence and inactivity timeouts, then end user sessions from your backend with the Management API"
 featured: false
 deprecated: false
 topics:
   - authenticate
-sdk: []
+  - manage-authentication
+  - sso
+sdk:
+  - kinde-management-api
 languages: []
 audience:
   - developer
@@ -23,10 +26,14 @@ complexity: intermediate
 keywords:
   - session management
   - SSO session
-  - session cookies
   - inactivity timeout
-  - browser session
-updated: 2026-08-28
+  - persistent cookies
+  - delete user sessions
+  - refresh tokens
+  - sign out everywhere
+  - session cookies
+ai_summary: "Guide to managing Kinde authenticated SSO sessions at the application level. Covers persistent versus non-persistent session cookies, SSO session inactivity timeout (default 86400 seconds), and dashboard steps under Settings, Environment, Applications, Sessions. Explains that these settings apply only to Kinde sessions, not sessions your app maintains, and links to organization-level session configuration. Documents cookie limitations such as surviving tab close and browser session restore. Explains how to end all of a user's sessions from a backend using DELETE /api/v1/users/{user_id}/sessions with an M2M application and the delete:user_sessions scope, including that refresh tokens are invalidated immediately while issued access tokens remain valid until expiry. Clarifies that ending sessions does not delete or suspend the user. FAQ covers what counts as inactivity (authenticated calls to Kinde such as token refresh, not local app browsing or M2M) and how switching organizations via login with orgCode updates a shared refresh_token cookie across tabs. Intended for developers and product managers."
+updated: 2026-08-31
 ---
 
 You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.
@@ -34,19 +41,27 @@ You can manage Kinde authenticated sessions via your application settings. An au
 These settings only apply to Kinde sessions and not sessions you maintain through your own application.
 If you want, you can [change session settings for an organization](/authenticate/manage-authentication/session-management-per-organization/), without affecting other organizations. 
 
+## Manage SSO session behaviors and policies
+
+Session settings are managed on per-application basis. Do the following to manage them:
+
+1. Sign in to your Kinde dashboard.
+2. Go to **Settings > Environment > Applications.**
+3. Select **View details** on the application tile you want to manage.
+4. Select **Sessions** in the side menu.
+
+    ![session management in kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/2253664a-70b9-4cc7-c22f-2a07fab63000/socialsharingimage)
+
+5. In the **SSO sessions** section, decide on the policy for session cookies:
+    - Persistent: Keep the session active even if the user closes their browser.
+    - Non-persistent: End the session when the user closes their browser (some [limitations](#limitations) apply). 
+6. In the **SSO session inactivity timeout** section, set how long a session can be inactive before prompting re-authentication. This setting is applied in seconds. Default is `86400` seconds (one day).
+7. When you're finished, select **Save**.
+
 ## Limitations
 
 - Session cookies are not destroyed when a tab is closed, the full browser window must be closed.
 - Modern browsers usually allow session restoration. Restoring a browser session can also restore a session cookie.
-
-## Manage SSO session behaviors and policies
-
-1. Go to **Settings > Environment > Applications.**
-2. Select **View details** on the application tile.
-3. Select **Sessions** in the side menu.
-4. In the **SSO sessions** section, decide on the policy for session cookies. A persistent session leaves the cookie active when the browser is closed. A non-persistent session is terminated when the browser window closes (unless the limitations listed above apply). 
-5. In the **Session inactivity timeout** section, set how long a session can be inactive before prompting re-authentication. This setting is applied in seconds - where 3,600 seconds is one hour; 86,400 seconds is one day.
-6. When you're finished, select **Save**.
 
 ## End a user's sessions from your backend
 
@@ -62,7 +77,9 @@ Ending sessions does not delete or suspend the user. They can sign in again stra
 
 </Aside>
 
-## What counts as activity for SSO session inactivity?
+## FAQ
+
+### What counts as activity for SSO session inactivity?
 
 Kinde measures inactivity **on the server**. Browsing your own app—switching pages or using the UI—does not reset the timer **unless** that work leads to **authenticated calls to Kinde** for the signed-in user. **Token refresh** is a familiar example: when your app or SDK exchanges a refresh token at Kinde, that interaction can count as activity for this timeout.
 
@@ -70,7 +87,7 @@ There is **no public list of every action** that resets inactivity. In practice,
 
 **Machine-to-machine (M2M)** integrations and the **Management API** use separate credentials and contexts. They are **not** equivalent to activity on a specific person’s browser SSO session when you interpret this setting.
 
-## Does switching organizations affect other browser tabs?
+### Does switching organizations affect other browser tabs?
 
 Yes. When a user switches to a different organization (by calling `login({ orgCode })` from your app), a new refresh token for that organization is issued and stored in the `refresh_token` cookie. Because this cookie is shared across all tabs on the same domain, other tabs that were authenticated to a different organization will use the new cookie on their next token refresh — and will then be operating in the context of the most recently signed-in organization.
 

--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -26,7 +26,7 @@ keywords:
   - session cookies
   - inactivity timeout
   - browser session
-updated: 2026-04-13
+updated: 2026-08-28
 ---
 
 You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.
@@ -47,6 +47,20 @@ If you want, you can [change session settings for an organization](/authenticate
 4. In the **SSO sessions** section, decide on the policy for session cookies. A persistent session leaves the cookie active when the browser is closed. A non-persistent session is terminated when the browser window closes (unless the limitations listed above apply). 
 5. In the **Session inactivity timeout** section, set how long a session can be inactive before prompting re-authentication. This setting is applied in seconds - where 3,600 seconds is one hour; 86,400 seconds is one day.
 6. When you're finished, select **Save**.
+
+## End a user's sessions from your backend
+
+The session settings above control how long a session lasts on its own. You can also end a user's sessions on demand from your own backend, using the Management API. This is useful when an admin deactivates an account, when you detect suspicious activity, or when you want a "sign out everywhere" control in your app.
+
+Call `DELETE /api/v1/users/{user_id}/sessions` using an M2M application with the `delete:user_sessions` scope. See the [Management API reference](/kinde-apis/management#tag/users) for request and response details.
+
+This ends the user's SSO sessions and invalidates their refresh tokens immediately. Access tokens their app already holds remain valid until they expire, because those are validated locally by your API rather than checked against Kinde on each request. For how to narrow that window, see [What revocation does and doesn't do](/build/tokens/configure-tokens/#what-revocation-does-and-doesnt-do).
+
+<Aside>
+
+Ending sessions does not delete or suspend the user. They can sign in again straight away. To prevent sign-in entirely, [suspend or delete the user](/manage-users/access-control/delete-or-suspend-users/).
+
+</Aside>
 
 ## What counts as activity for SSO session inactivity?
 

--- a/src/content/docs/authenticate/manage-authentication/session-management.mdx
+++ b/src/content/docs/authenticate/manage-authentication/session-management.mdx
@@ -36,14 +36,14 @@ ai_summary: "Guide to managing Kinde authenticated SSO sessions at the applicati
 updated: 2026-08-31
 ---
 
-You can manage Kinde authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.
+You can manage Kinde-authenticated sessions via your application settings. An authenticated session (or SSO session) is the period during which Kinde treats the user as signed in. You can define whether a session persists after the browser is closed, and how much time can elapse before prompting a user to re-authenticate.
 
 These settings only apply to Kinde sessions and not sessions you maintain through your own application.
 If you want, you can [change session settings for an organization](/authenticate/manage-authentication/session-management-per-organization/), without affecting other organizations. 
 
 ## Manage SSO session behaviors and policies
 
-Session settings are managed on per-application basis. Do the following to manage them:
+Session settings are managed on a per-application basis. Do the following to manage them:
 
 1. Sign in to your Kinde dashboard.
 2. Go to **Settings > Environment > Applications.**

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -1,18 +1,20 @@
 ---
 page_id: d8069575-dfef-421d-8f3a-8f3efe9ad2f3
 title: Access tokens
-description: Comprehensive guide to Kinde access tokens including standard JWT claims, Kinde-specific claims like organization codes and feature flags, and token behavior during refresh operations.
+description: "Inspect Kinde access token claims, lifetimes, and refresh behavior so you can authorize APIs with confidence"
 sidebar:
   order: 2
 relatedArticles:
   - 5a248c6f-c1ae-480a-95c3-d3c69c81598d
   - cf687bce-9732-4b67-9da5-580953c8549f
+tableOfContents:
+  maxHeadingLevel: 3
 app_context:
   - m: application_details
     s: tokens
 topics:
+  - build
   - tokens
-  - authentication
   - oauth
 sdk: []
 languages:
@@ -22,17 +24,17 @@ audience: developers
 complexity: intermediate
 keywords:
   - access tokens
-  - JWT
+  - JWT claims
   - OAuth 2.0
-  - token claims
   - feature flags
   - permissions
-  - organization claims
+  - token refresh
+  - token expiry
   - billing trial
-updated: 2026-08-28
+updated: 2026-08-31
 featured: false
 deprecated: false
-ai_summary: Comprehensive guide to Kinde access tokens including standard JWT claims, Kinde-specific claims like organization codes and feature flags, and token behavior during refresh operations.
+ai_summary: "Reference for Kinde access tokens as JWTs used to authenticate users and pass authorization data to APIs. Documents an example token and standard claims including aud, azp, exp, iat, iss, jti, scp, and sub, plus custom claims via Properties. Covers Kinde-specific claims: org_code, feature_flags with type and value short codes, permissions, billing trial fields has_trial_period and trial_expires_on, external provider ID, and Microsoft Entra ID ext_ claims. Explains refresh_token grant behavior: Kinde may return an unexpired access token unless it was revoked, the user signed out via logout, or the token expired. FAQ covers removing claims with the user token generation workflow, the default 24-hour access token lifetime, and that revocation, session end, or user deletion does not shorten already-issued access tokens. Intended for developers implementing authorization."
 ---
 
 Access tokens are a secure way of authenticating users and passing information about a user to a system.
@@ -145,18 +147,6 @@ Access tokens are a secure way of authenticating users and passing information a
 
   ```
 
-## Can I remove claims to reduce token size?
-
-Yes. Kinde automatically populates the access token with claims like `permissions`, `feature_flags`, and `org_code`. If your app handles this data another way — or you want to keep JWTs small and free of client-readable claims — you can strip any of these from the token at generation time using the [user token generation workflow](/workflows/example-workflows/user-token-generation/#reduce-token-size).
-
-The workflow fires whenever a token is issued and gives you full control over what goes into the final token. You can also use it to retrieve data from the [Kinde Management API](/kinde-apis/management/) server-side instead of embedding it in the JWT.
-
-## How long does an access token last?
-
-Access tokens have a default lifetime of **24 hours (86,400 seconds)**. You can change this in **Settings > Environment > Applications > [your app] > Tokens**. Kinde does not recommend extending the access token lifetime beyond 1 day, as access tokens are the most exposed token type and a longer lifetime increases the window of risk if one is compromised.
-
-For a comparison of all token default lifetimes, see [Configure token and session expiry](/build/tokens/configure-tokens/). Note that revoking a token, ending a session, or deleting a user does not shorten the lifetime of an access token that has already been issued — see [What revocation does and doesn't do](/build/tokens/configure-tokens/#what-revocation-does-and-doesnt-do).
-
 ## Behaviour of Access Tokens on refresh
 
 When you use the `refresh_token` grant to refresh an access token, Kinde will return an existing access token if that existing access token is not expired. You will get a completely new access token if one (or more) of the following conditions are met:
@@ -164,3 +154,18 @@ When you use the `refresh_token` grant to refresh an access token, Kinde will re
 - You revoke your existing access token
 - Your user has signed out of their session, and your application has called the logout function in Kinde
 - Your existing access token has expired.
+
+
+## FAQ
+
+### Can I remove claims to reduce token size?
+
+Yes. Kinde automatically populates the access token with claims like `permissions`, `feature_flags`, and `org_code`. If your app handles this data another way — or you want to keep JWTs small and free of client-readable claims — you can strip any of these from the token at generation time using the **user token generation workflow** - see [Remove claims](/workflows/workflow-tutorials/customize-token-with-workflow/#remove-claims).
+
+The workflow fires whenever a token is issued and gives you full control over what goes into the final token. You can also use it to retrieve data from the [Kinde Management API](/kinde-apis/management/) server-side instead of embedding it in the JWT.
+
+### How long does an access token last?
+
+Access tokens have a default lifetime of **24 hours (86,400 seconds)**. You can change this in **Settings > Environment > Applications > [your app] > Tokens**. Kinde does not recommend extending the access token lifetime beyond 1 day, as access tokens are the most exposed token type and a longer lifetime increases the window of risk if one is compromised.
+
+For a comparison of all token default lifetimes, see [Configure token and session expiry](/build/tokens/configure-tokens/). Note that revoking a token, ending a session, or deleting a user does not shorten the lifetime of an access token that has already been issued — see [What revocation does and doesn't do](/build/tokens/configure-tokens/#what-revocation-does-and-doesnt-do).

--- a/src/content/docs/build/tokens/about-access-tokens.mdx
+++ b/src/content/docs/build/tokens/about-access-tokens.mdx
@@ -29,7 +29,7 @@ keywords:
   - permissions
   - organization claims
   - billing trial
-updated: 2026-04-13
+updated: 2026-08-28
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide to Kinde access tokens including standard JWT claims, Kinde-specific claims like organization codes and feature flags, and token behavior during refresh operations.
@@ -155,7 +155,7 @@ The workflow fires whenever a token is issued and gives you full control over wh
 
 Access tokens have a default lifetime of **24 hours (86,400 seconds)**. You can change this in **Settings > Environment > Applications > [your app] > Tokens**. Kinde does not recommend extending the access token lifetime beyond 1 day, as access tokens are the most exposed token type and a longer lifetime increases the window of risk if one is compromised.
 
-For a comparison of all token default lifetimes, see [Configure token and session expiry](/build/tokens/configure-tokens/).
+For a comparison of all token default lifetimes, see [Configure token and session expiry](/build/tokens/configure-tokens/). Note that revoking a token, ending a session, or deleting a user does not shorten the lifetime of an access token that has already been issued — see [What revocation does and doesn't do](/build/tokens/configure-tokens/#what-revocation-does-and-doesnt-do).
 
 ## Behaviour of Access Tokens on refresh
 

--- a/src/content/docs/build/tokens/configure-tokens.mdx
+++ b/src/content/docs/build/tokens/configure-tokens.mdx
@@ -119,7 +119,7 @@ Suspension or deletion also stops the user from signing in and from obtaining ne
 
 ### Close the window
 
-**Shorten the access token lifetime.** This is the control to reach for. The remaining validity window is at most the configured access token lifetime, so lowering it is the most direct fix. A 5 to 15 minute access token paired with refresh tokens means access ends within minutes after revocation, because the next refresh fails. See [Set token lifetimes](/build/tokens/configure-tokens/#set-token-lifetimes) above.
+**Shorten the access token lifetime.** This is the control to reach for. The remaining validity window for the revoked session is at most the configured access token lifetime, so lowering it is the most direct fix. A 5 to 15 minute access token paired with refresh tokens means remaining access for that session ends within minutes after revocation, because subsequent refreshes for the revoked session fail. Shortening the lifetime does not prevent the user from signing in again. See [Set token lifetimes](/build/tokens/configure-tokens/#set-token-lifetimes) above.
 
 <Aside>
 

--- a/src/content/docs/build/tokens/configure-tokens.mdx
+++ b/src/content/docs/build/tokens/configure-tokens.mdx
@@ -1,7 +1,7 @@
 ---
 page_id: b5f45f88-93ff-4323-a57f-bfdc0b52878a
 title: Configure token and session expiry
-description: Comprehensive guide for configuring token and session expiry times including security best practices, token lifetime management, and risk mitigation strategies for different token types.
+description: "Configure Kinde token lifetimes, revoke sessions, and close the JWT access window after logout or user deletion"
 sidebar:
   order: 1
 relatedArticles:
@@ -15,9 +15,9 @@ app_context:
   - m: application_details
     s: tokens
 topics:
+  - build
   - tokens
   - security
-  - configuration
 sdk: []
 languages: []
 audience: developers
@@ -26,16 +26,15 @@ keywords:
   - token expiry
   - session timeout
   - token lifetime
-  - security
   - refresh tokens
   - access tokens
-  - ID tokens
-  - revocation
-  - session revocation
-updated: 2026-08-28
+  - token revocation
+  - JWT validation
+  - token introspection
+updated: 2026-08-31
 featured: false
 deprecated: false
-ai_summary: Comprehensive guide for configuring token and session expiry times including security best practices, token lifetime management, and risk mitigation strategies for different token types.
+ai_summary: "Guide to configuring Kinde token and SSO session lifetimes per application. Lists default lifetimes: refresh token 15 days, access token 24 hours, and ID token 1 hour. Explains the role of ID, access, and refresh tokens and session inactivity timeout, plus security risks such as token theft and session hijacking. Includes dashboard steps to set expiry in seconds, optional client-specific refresh token cookies on a custom domain, and revoking tokens via POST /oauth2/revoke. Details what revocation does immediately (SSO session and refresh tokens) versus what it does not (already-issued access tokens remain valid until exp because APIs validate JWTs locally). Recommends shortening access token lifetime and using introspect only for high-value actions. Covers reuse detection, refresh token rotation, and revoking tokens after logout. Intended for developers configuring token security."
 ---
 
 Tokens are an essential part of keeping your application secure. They enable the continued verification of users and applications (including APIs), and are a mechanism for detecting unauthorized intruders.
@@ -114,11 +113,13 @@ Revoking a token or ending a user's sessions takes effect immediately for everyt
 
 This is a property of JWTs, not a Kinde limitation. Access tokens are self-contained and signed, so your API validates them locally against Kinde's public keys, checking the signature, issuer, audience, and expiry. That check never calls Kinde, which is what makes it fast and keeps Kinde out of your request path. The trade-off is that no identity provider can reach into a token that has already been handed out.
 
-In practice, a revoked user can no longer obtain new tokens, but an access token they already hold keeps working until `exp`. With the default 24 hour access token lifetime, that window can be up to 24 hours.
+In practice, an access token already held by an app keeps working until `exp`, even after you revoke sessions or refresh tokens, or suspend or delete the user. That remaining window is at most the access token lifetime you configured — up to 24 hours with the default.
+
+Suspension or deletion also stops the user from signing in and from obtaining new tokens. Revoking a session or refresh token does not: the user must reauthenticate, but they can sign in again immediately.
 
 ### Close the window
 
-**Shorten the access token lifetime.** This is the control to reach for. The window is exactly the access token lifetime, so lowering it is the most direct fix. A 5 to 15 minute access token paired with refresh tokens means a revoked user loses access within minutes, because their next refresh fails. See [Set token lifetimes](/build/tokens/configure-tokens/#set-token-lifetimes) above.
+**Shorten the access token lifetime.** This is the control to reach for. The remaining validity window is at most the configured access token lifetime, so lowering it is the most direct fix. A 5 to 15 minute access token paired with refresh tokens means access ends within minutes after revocation, because the next refresh fails. See [Set token lifetimes](/build/tokens/configure-tokens/#set-token-lifetimes) above.
 
 <Aside>
 

--- a/src/content/docs/build/tokens/configure-tokens.mdx
+++ b/src/content/docs/build/tokens/configure-tokens.mdx
@@ -30,7 +30,9 @@ keywords:
   - refresh tokens
   - access tokens
   - ID tokens
-updated: 2026-04-03
+  - revocation
+  - session revocation
+updated: 2026-08-28
 featured: false
 deprecated: false
 ai_summary: Comprehensive guide for configuring token and session expiry times including security best practices, token lifetime management, and risk mitigation strategies for different token types.
@@ -97,6 +99,34 @@ To revoke a previously issued token, you need to make a POST request to the `/oa
 Ensure to set the Content-Type header to `application/x-www-form-urlencoded`. 
 
 Upon successful revocation, you will receive a 200 status code indicating that the token was successfully revoked. For more information and example code snippets, see [revoke tokens](https://docs.kinde.com/kinde-apis/frontend/#tag/oauth/post/oauth2/revoke).
+
+To end all of a specific user's sessions from your backend rather than revoking one token at a time, see [End a user's sessions from your backend](/authenticate/manage-authentication/session-management/#end-a-users-sessions-from-your-backend).
+
+## What revocation does and doesn't do
+
+Revoking a token or ending a user's sessions takes effect immediately for everything Kinde holds server-side. It does not reach access tokens that have already been issued.
+
+| What you revoke | Effect |
+| --- | --- |
+| SSO (authenticated) session | Ends immediately. The user must sign in again to start a new session. |
+| Refresh token | Invalidated immediately. The next refresh attempt fails with `invalid_grant`. |
+| Access token already held by an app | **Remains valid until it expires.** |
+
+This is a property of JWTs, not a Kinde limitation. Access tokens are self-contained and signed, so your API validates them locally against Kinde's public keys, checking the signature, issuer, audience, and expiry. That check never calls Kinde, which is what makes it fast and keeps Kinde out of your request path. The trade-off is that no identity provider can reach into a token that has already been handed out.
+
+In practice, a revoked user can no longer obtain new tokens, but an access token they already hold keeps working until `exp`. With the default 24 hour access token lifetime, that window can be up to 24 hours.
+
+### Close the window
+
+**Shorten the access token lifetime.** This is the control to reach for. The window is exactly the access token lifetime, so lowering it is the most direct fix. A 5 to 15 minute access token paired with refresh tokens means a revoked user loses access within minutes, because their next refresh fails. See [Set token lifetimes](/build/tokens/configure-tokens/#set-token-lifetimes) above.
+
+<Aside>
+
+Shortening the access token lifetime increases the number of refresh calls your app makes. Test the value you choose against your traffic before rolling it out broadly.
+
+</Aside>
+
+**Check live state, very sparingly.** The `/oauth2/introspect` endpoint validates a token against current session state, so it reflects revocation immediately. It also puts Kinde back in your request path, which is the thing local JWT validation exists to avoid. Reserve it for a small number of genuinely high-value actions where a short token lifetime is not enough on its own. Do not use it for routine request authorization.
 
 ## Token security
 

--- a/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
+++ b/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
@@ -109,7 +109,7 @@ To block access for accounts created with a specific identifier (after sign-up),
 - **Webhooks** — Subscribe to the `user.created` event via [webhooks](/integrate/webhooks/about-webhooks/). When a new user signs up with a blocked identifier, call the [Management API](/kinde-apis/management#tag/users/patch/api/v1/user) to suspend or delete them as soon as the event is processed.
 - **Management API** — React to sign-up events and use the [`PATCH /api/v1/user`](/kinde-apis/management#tag/users/patch/api/v1/user) endpoint to suspend users whose identifiers match your blocklist.
 
-The same expiry window applies to these workarounds. Suspending or deleting a user in response to a webhook stops them getting new tokens, but an access token already issued during sign-up stays valid until it expires — see [What happens to sessions and tokens](#what-happens-to-sessions-and-tokens) above.
+The same expiry window applies to these workarounds. Suspending or deleting a user in response to a webhook stops them getting new tokens, but an access token already issued during sign-up stays valid until it expires — see [What happens to sessions and tokens](#what-happens-to-sessions-and-tokens) above. Deleting an account does not prevent the same identifier from signing up again if self-sign-up is enabled. If you need to block future sign-ups, keep a persistent identifier check (for example in a post-authentication workflow) or suspend the user instead of deleting them.
 
 <Aside type="warning">
 

--- a/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
+++ b/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
@@ -6,6 +6,7 @@ sidebar:
 relatedArticles:
   - cb91d7a1-7306-4c58-9635-b0fe1b913b38
   - 556c9ce6-477b-4a31-9ce1-75f612eb3740
+  - b5f45f88-93ff-4323-a57f-bfdc0b52878a
 app_context:
   - m: user
     s: details
@@ -29,7 +30,8 @@ keywords:
   - admin permissions
   - user management
   - self sign up
-updated: 2026-03-26
+  - session revocation
+updated: 2026-08-28
 featured: false
 deprecated: false
 ai_summary: Guide to deleting or suspending users in Kinde including suspension, restoration, and permanent deletion options for access control.
@@ -69,6 +71,20 @@ For details on suspending an organization, see [Add and manage organizations](/b
    2. Select the second option to completely remove the user record from Kinde, including access and all subscriber lists.
 5. Select **Delete user**. When the user tries to sign in, they will be prompted to sign up (if self-sign-up is allowed in your business).
 
+## What happens to sessions and tokens
+
+When you suspend or delete a user, Kinde immediately ends their authenticated sessions and invalidates their refresh tokens. The user cannot sign in again, and any attempt to refresh their tokens fails with `invalid_grant`.
+
+Access tokens the user's app already holds are not affected, and remain valid until they expire. Access tokens are self-contained JWTs that your API validates locally, so there is nothing for Kinde to withdraw once one has been issued.
+
+This matters if you rely on deletion to cut off access instantly. Until the user's access token expires, your API will still accept it. To narrow that window, shorten your access token lifetime. See [What revocation does and doesn't do](/build/tokens/configure-tokens/#what-revocation-does-and-doesnt-do).
+
+<Aside>
+
+This applies whether you delete or suspend the user in the Kinde admin area or through the Management API.
+
+</Aside>
+
 ## Can I block users by email, username, or phone number?
 
 Kinde does not have a built-in blocklist for specific email addresses, usernames, or phone numbers. Suspending or deleting a user removes their existing account, but does not prevent someone from signing up again with the same identifier if self-sign-up is enabled.
@@ -78,6 +94,8 @@ To block access for accounts created with a specific identifier (after sign-up),
 - **Workflows** — Use a [post-authentication workflow](/workflows/example-workflows/workflow-user-post-auth/) to check the authenticating user's email, username, or phone number against a blocklist stored in an environment variable or external data source. If matched, the workflow can deny access using the `deny` action.
 - **Webhooks** — Subscribe to the `user.created` event via [webhooks](/integrate/webhooks/about-webhooks/). When a new user signs up with a blocked identifier, call the [Management API](/kinde-apis/management#tag/users/patch/api/v1/user) to suspend or delete them as soon as the event is processed.
 - **Management API** — React to sign-up events and use the [`PATCH /api/v1/user`](/kinde-apis/management#tag/users/patch/api/v1/user) endpoint to suspend users whose identifiers match your blocklist.
+
+The same expiry window applies to these workarounds. Suspending or deleting a user in response to a webhook stops them getting new tokens, but an access token already issued during sign-up stays valid until it expires — see [What happens to sessions and tokens](#what-happens-to-sessions-and-tokens) above.
 
 <Aside type="warning">
 

--- a/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
+++ b/src/content/docs/manage-users/access-control/delete-or-suspend-users.mdx
@@ -10,7 +10,7 @@ relatedArticles:
 app_context:
   - m: user
     s: details
-description: Guide to deleting or suspending users in Kinde including user deactivation, permanent deletion, and access control management.
+description: "Suspend or delete Kinde users, restore access, and see how sessions and tokens behave after deactivation"
 topics:
   - manage-users
   - access-control
@@ -19,57 +19,71 @@ languages: []
 audience:
   - admins
   - developers
-complexity: beginner
+complexity: intermediate
 keywords:
   - delete users
   - suspend users
-  - user suspension
-  - user deletion
+  - restore users
   - access control
-  - user restoration
-  - admin permissions
-  - user management
-  - self sign up
   - session revocation
-updated: 2026-08-28
+  - self sign-up
+  - user blocklist
+  - Management API
+updated: 2026-08-31
 featured: false
 deprecated: false
-ai_summary: Guide to deleting or suspending users in Kinde including suspension, restoration, and permanent deletion options for access control.
+ai_summary: "Guide for Kinde Owners and Admins to delete or suspend users from the Users list. Covers permanent deletion with confirmation, suspending a user (Suspended badge and sign-in error), and restoring a suspended user. Notes that deleted users may sign up again if self-sign-up is allowed. Links to suspending an organization. Explains that suspend or delete immediately ends SSO sessions and invalidates refresh tokens, but issued access tokens remain valid until expiry whether the action is taken in the dashboard or Management API. FAQ states there is no built-in identifier blocklist; workarounds include post-authentication workflows, user.created webhooks, and PATCH /api/v1/user. Intended for admins and developers managing user access."
 ---
 
-If you want to prevent access by a user, you can suspend or delete them. You need to be a Kinde Owner or Admin to do this.
+If you want to prevent access by a user, you can delete or suspend them. 
 
-<Aside title="Suspending a user vs suspending an organization">
+<Aside>
 
-**Suspending a user** prevents that specific user from signing in to any organization.
-
-**Suspending an organization** prevents all users from signing in to that specific organization, but does not affect their access to other organizations.
-
-For details on suspending an organization, see [Add and manage organizations](/build/organizations/add-and-manage-organizations/#suspend-an-organization).
+You need to be a Kinde **Owner** or **Admin** to perform these actions. See [Team member roles](/get-started/team-and-account/team-member-roles/) for more information.
 
 </Aside>
 
+## Delete a user
+
+<Aside type="danger">
+
+Deleting a user is a permanent action and cannot be undone.
+
+</Aside>
+
+1. Sign in to your Kinde dashboard and select **Users**.
+2. Find the user you want to delete.
+3. Select the **three dots menu** in the user's row, then select **Delete user**. A confirmation window opens.
+
+    ![delete user popup in kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/240dc0d5-9797-44a5-45ca-9248bcc00700/socialsharingimage)
+
+4. Check the **Yes, I definitely want to delete** checkbox and select **Delete user**. The user will be deleted.
+
+When the user tries to sign in, they will be prompted to sign up (if self-sign-up is allowed in your business).
+
 ## Suspend a user
 
-1. On the Kinde home page, select **Users**.
+When you don't want to permanently delete a user, but restrict their access, you can suspend them:
+
+1. Sign in to your Kinde dashboard and select **Users**.
 2. Find the user you want to suspend.
-3. Select the three dots menu, then select **Suspend user.** A ‘suspended’ badge appears next to their name on the user list. When the user tries to sign in, they will receive an error and will not be able to sign in.
+3. Select the **three dots menu**, then select **Suspend user.** 
+
+A `Suspended` badge appears next to their name on the user list. When the user tries to sign in, they will receive an error and will not be able to sign in.
+
+![suspend badge next to user name in kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/7cdb4b68-ea92-469c-f65d-cf7989e1e800/socialsharingimage)
 
 ## Restore a suspended user
 
-1. On the Kinde home page, select **Users**.
+1. Go to the **Users** section in Kinde.
 2. Find the suspended user you want to restore.
-3. Select the three dots menu, then select **Restore user**. This reinstates their access. When the user tries to sign in, their access will be restored.
+3. Select the **three dots menu**, then select **Restore user**. 
 
-## Delete a user
+This reinstates their access. When the user tries to sign in, their access will be restored.
 
-1. On the Kinde home page, select **Users**.
-2. Find the user you want to delete.
-3. Select the three dots menu, then select **Delete user**. A confirmation window opens.
-4. Select the extent to which you want to delete the user:
-   1. Select the first option to remove the user’s access and ability to sign in to all organizations, but leave their profile in Kinde.
-   2. Select the second option to completely remove the user record from Kinde, including access and all subscriber lists.
-5. Select **Delete user**. When the user tries to sign in, they will be prompted to sign up (if self-sign-up is allowed in your business).
+## Suspending an organization
+
+The above sections explain how to suspend a user. You can also suspend an organization to prevent all users from signing in to that specific organization. For details on suspending an organization, see [Suspend an organization](/build/organizations/add-and-manage-organizations/#suspend-an-organization).
 
 ## What happens to sessions and tokens
 


### PR DESCRIPTION
#### Description (required)

Kinde access tokens are stateless JWTs. Revoking a token or ending a user's sessions ends the SSO session and invalidates refresh tokens immediately, but an access token that has already been issued keeps verifying until it expires. The same applies when an admin deletes or suspends a user. This is inherent to stateless validation and is working as designed.

The docs did not say so anywhere. **Configure token and session expiry** documented `/oauth2/revoke` without stating what revocation *cannot* reach; **Delete or suspend users** said nothing about sessions or tokens at all; and **Session management** never mentioned server-side revocation. That left a gap for anyone who assumes revoking a session or deleting a user takes effect on tokens that have already been handed out.

**Who this helps:** developers choosing an access token lifetime and reasoning about when revocation takes effect, and admins who expect suspension or deletion to apply immediately.

Three new sections plus three one-sentence cross-references. No new pages, no sidebar changes (these directories autogenerate), no code samples.

| Page | Change |
| --- | --- |
| Configure token and session expiry | New section **What revocation does and doesn't do** — a table of what revocation reaches, why it works that way, and how to close the window. Plus a pointer from *Revoke a token to end a user session* to the new session-invalidation content. |
| Delete or suspend users | New section **What happens to sessions and tokens**, placed after *Delete a user* so it covers both verbs. Plus a note in the blocklist FAQ that the same expiry window applies to those workarounds. |
| Session management | New section **End a user's sessions from your backend**, covering the Management API endpoint — the page previously offered no way to terminate a session. |
| Access tokens | One sentence in *How long does an access token last?* noting that revocation does not shorten an already-issued token's lifetime. |

**On the introspection guidance:** `/oauth2/introspect` is deliberately framed as a rarely-appropriate escape hatch for a small number of high-value actions, with an explicit "do not use it for routine request authorization". Shortening the access token lifetime is presented as the control to reach for. The endpoint isn't currently documented anywhere on the docs site, so it's named without a link or request example — adding a reference page for it is separate work.

**Verification**

- `npm run build` — clean.
- `node ./scripts/validate-links.js` (the CI gate) — "All internal links are valid."
- Checked in `dist/` that every new anchor exists and every inbound link resolves to one: `#what-revocation-does-and-doesnt-do`, `#close-the-window`, `#set-token-lifetimes`, `#end-a-users-sessions-from-your-backend`, `#what-happens-to-sessions-and-tokens`.
- All three new `<Aside>` blocks render as real `<aside>` elements; the new table renders inside `.table-wrapper`; the new H2s and H3 appear in their pages' tables of contents; `` `DELETE /api/v1/users/{user_id}/sessions` `` renders literally (braces not evaluated as JSX).
- No new Prettier deltas versus `main` — the warnings on these files are all pre-existing.
- No `page_id` values changed.

**One thing to check in review:** `delete:user_sessions` is not documented anywhere on the site, so I couldn't verify it from the repo. Please confirm it matches the scope name customers actually see when configuring M2M app scopes. The Management API link uses the tag-level `#tag/users` rather than the operation anchor, since that reference is rendered client-side by Scalar from a remotely-fetched spec and an anchor containing `{user_id}` is the least stable thing to link — happy to upgrade it if someone verifies the operation anchor resolves.

**Out of scope:** the `DELETE /api/v1/users/{user_id}/sessions` operation description ("Invalidate user sessions") would benefit from mentioning stateless validation too, but the Management API specs are fetched at build time from `api-spec.kinde.com` and don't live in this repo. That needs routing through the spec repo separately.

#### Related issues & labels (optional)

- Suggested label: `Update doc`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded session management guidance, including SSO policies and ending user sessions through the Management API.
  * Clarified how session revocation, user suspension, and deletion affect refresh tokens and access tokens.
  * Added guidance on token lifetimes, revocation behavior, introspection, and reducing access-token validity windows.
  * Reorganized FAQs, added step-by-step dashboard instructions, screenshots, related links, and updated metadata.
  * Clarified deletion, suspension, restoration, and organization suspension workflows, including permissions and confirmation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->