### PR TITLE
feat: Billing, one-time charges, first slice

### DIFF
--- a/src/content/docs/billing/about-billing/about-billing.mdx
+++ b/src/content/docs/billing/about-billing/about-billing.mdx
@@ -37,8 +37,9 @@ keywords:
   - free trial
   - pricing table
   - self-serve portal
-updated: 2026-08-30
-ai_summary: "Overview of the Kinde billing feature for charging customers and collecting revenue. Covers creating and versioning plans and pricing tables in the dashboard, billing fixed charges on daily weekly monthly or yearly intervals, mixed-interval charges on one plan, annual pricing with a Pay annually choice at sign-up and in the self-serve portal, usage-based entitlements, free plans, and free trials that can convert to paid subscriptions. Also covers Stripe for payments invoicing and tax, linking B2B organizations and B2C users to plans, and upgrades downgrades and cancellations from the dashboard or portal. Explains how Collect tax automatically in Settings Environment Billing enables Stripe Tax on new subscriptions, with per-plan Use account setting Collect or Do not collect overrides, and that Stripe still calculates tax from billing country or the Stripe registered address until a country is known. Lists known limitations including no custom intervals such as quarterly, no custom billing anniversaries, and no per-subscription add-ons or discounts. Intended for developers, product managers, and business owners evaluating or adopting Kinde billing."
+  - one-time charges
+updated: 2026-09-07
+ai_summary: "Overview of the Kinde billing feature for charging customers and collecting revenue. Covers creating and versioning plans and pricing tables in the dashboard, billing fixed charges on daily weekly monthly or yearly intervals, mixed-interval charges on one plan, annual pricing with a Pay annually choice at sign-up and in the self-serve portal, usage-based entitlements, one-time charges on plans, free plans, and free trials that can convert to paid subscriptions. Also covers Stripe for payments invoicing and tax, linking B2B organizations and B2C users to plans, and upgrades downgrades and cancellations from the dashboard or portal. Explains how Collect tax automatically in Settings Environment Billing enables Stripe Tax on new subscriptions, with per-plan Use account setting Collect or Do not collect overrides, and that Stripe still calculates tax from billing country or the Stripe registered address until a country is known. Lists known limitations including no custom intervals such as quarterly, no custom billing anniversaries, no per-subscription add-ons or discounts, and that one-time charge purchase and applying charges to existing subscriptions are not available yet. Intended for developers, product managers, and business owners evaluating or adopting Kinde billing."
 ---
 
 Kinde billing gives you the ability to charge customers for your services and collect revenue.
@@ -52,6 +53,7 @@ With billing, you can:
 - Offer non-annual subscriptions with custom annual pricing (for example, $10/month, or $100/year if paid annually)
 - Let customers choose annual pricing during sign-up or in the self-serve portal
 - Add entitlements that control access to features, and metered features whose usage may generate customer charges
+- Configure **one-time charges** on plans for single purchases such as [credit top-ups or add-on unlocks](/billing/manage-plans/create-plans/#add-one-time-charges-to-a-plan) (subscriber purchase rolling out)
 - Create a free plan alongside your paid offerings
 - Offer free trial periods and choose whether a credit card is required to start the trial
 - If you collect a credit card during a free trial, Kinde can notify customers when the trial is about to expire and automatically convert them to paid subscriptions. You can configure this in the Kinde dashboard.
@@ -99,6 +101,7 @@ These are known limitations we are actively working to address.
 - Custom billing intervals (e.g., quarterly) are not supported. Fixed charges are limited to daily, weekly, monthly, or yearly intervals.
 - Changes to the billing cycle (e.g., custom billing anniversaries) are not supported
 - Add-ons and discounts applied to individual subscriptions are not supported
+- One-time charge purchase by subscribers, and applying one-time charges to existing subscriptions, are not supported yet. You can create one-time charges and add them to plans in the Kinde dashboard now.
 
 ## This is our first billing release
 

--- a/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
+++ b/src/content/docs/billing/about-billing/billing-concepts-terms.mdx
@@ -7,7 +7,7 @@ sidebar:
 relatedArticles:
   - 100f75f1-a0a4-459f-874f-da127f2d0615
   - bd6757e3-81d5-48d6-89c8-dd4c222ac647
-description: "Learn Kinde billing terms — fixed charges, mixed-interval pricing, annual payments, next invoice details, trials, and token claims"
+description: "Learn Kinde billing terms — fixed charges, one-time charges, mixed-interval pricing, annual payments, next invoice details, trials, and token claims"
 featured: false
 deprecated: false
 topics:
@@ -31,8 +31,9 @@ keywords:
   - trial period
   - customer agreement
   - access token claims
-updated: 2026-08-22
-ai_summary: "Reference guide to commonly used billing concepts and terms in Kinde. Defines billing identifiers such as customer_id and customer_agreement_id and how they differ from user_id and org_id. Covers key concepts including plan groups, plans, plan settings, trial periods, chargeable and non-chargeable features, fixed charges with billing intervals and optional annual pricing, mixed-interval pricing on one plan, pricing models, payment processing via Stripe, pricing tables, and the self-serve account portal. Includes a glossary of common terms such as agreement, base price, metered and unmetered features, mixed-interval pricing, annual payments, next invoice details, multi-currency, tiered pricing, unit price, and usage-based pricing. Documents trial-related access token claims has_trial_period and trial_expires_on. Intended for developers, product managers, and business owners learning Kinde billing vocabulary."
+  - one-time charges
+updated: 2026-09-07
+ai_summary: "Reference guide to commonly used billing concepts and terms in Kinde. Defines billing identifiers such as customer_id and customer_agreement_id and how they differ from user_id and org_id. Covers key concepts including plan groups, plans, plan settings, trial periods, chargeable and non-chargeable features, fixed charges with billing intervals and optional annual pricing, one-time charges, mixed-interval pricing on one plan, pricing models, payment processing via Stripe, pricing tables, and the self-serve account portal. Includes a glossary of common terms such as agreement, base price, metered and unmetered features, mixed-interval pricing, annual payments, next invoice details, one-time charge, package pricing, expiry, multi-currency, tiered pricing, unit price, and usage-based pricing. Documents trial-related access token claims has_trial_period and trial_expires_on. Intended for developers, product managers, and business owners learning Kinde billing vocabulary."
 ---
 
 'Billing' refers to the broad function of creating plans, setting pricing, collecting payments, etc. Here are some of the common concepts and terms you will come across.
@@ -50,6 +51,7 @@ ai_summary: "Reference guide to commonly used billing concepts and terms in Kind
 - **Trial period** - An optional setting on paid plans that lets customers try the plan for a set number of days before being charged. During the trial, the customer has full access to the plan's features. Kinde creates the trial using Stripe's subscription trial. Plans with a trial enabled show a badge on the pricing table.
 - **Features** - Plan features are the specific capabilities or entitlements included in a plan. They can be chargeable (incurring additional fees) or non-chargeable (included at no extra cost). Features can be metered (usage-based) or unmetered (fixed access).
 - **Fixed charges** – A recurring amount that does not change with usage and is billed in advance.
+- **One-time charges** – Single-purchase items attached to a plan (for example credit top-ups or add-on unlocks). Separate from fixed recurring charges and from subscription entitlements. You can [configure them on plans](/billing/manage-plans/create-plans/#add-one-time-charges-to-a-plan) now; subscriber purchase is rolling out.
 - **Pricing models** - Pricing models are the different methods of charging customers, such as flat-rate, usage-based, tiered, or per-seat pricing. Your pricing model is determined by your product and customer needs. Consider scalability and longevity when choosing one.
 - **Payment processor** - A payment processor is a third-party service that securely processes customer payments via credit cards, ACH, or other methods—such as Stripe Billing.
 - **Pricing table** - A pricing table is a visual representation of your different subscription plans, showcasing features and prices to help users compare options. You can build one in Kinde and then show it to your customers in the auth flow or self-service portal.
@@ -63,12 +65,15 @@ ai_summary: "Reference guide to commonly used billing concepts and terms in Kind
   - **Chargeable feature**: Incurs an additional fee when used. Might be metered or per unit price.
   - **Non-chargeable feature**: Included in the plan at no extra cost. Use for features that aren't independently chargeable but need to be gated in your product.
 - **Credit card prompt (trial)** – The number of days before a trial ends when the customer is prompted to add payment details. This helps ensure payment information is collected before the trial expires and the subscription converts to a paid subscription.
+- **Expiry (one-time charge)** – When access from a one-time purchase ends. **Never expires** keeps access across billing cycles; **Expires with the billing cycle** ends access at the end of the current billing cycle. Access starts when the subscriber pays (once purchase is live).
 - **Feature** – A specific function or capability of your SaaS product that you provision for app users. In the context of a plan, these are chargeable or non-chargeable features provisioned to customers.
 - **Fixed charge** – A recurring amount that does not change with usage and is billed in advance.
 - **Metered and unmetered feature** – Metered features are provisioned in units, often with pricing per unit, e.g., MAU. An unmetered feature behaves like a boolean toggle—a basic entitlement with no pricing attached.
 - **Mixed-interval pricing** – A plan where fixed charges renew on different schedule. For example: `$100 / year + $3 / month`.
 - **Multi-currency** – The ability to set plan prices in different currencies to support global customers. Kinde supports nearly all currencies, but you can currently only pick one as the default for all plans.
 - **Next invoice** – In the self-serve portal and admin billing views, the upcoming charge preview: licensed amounts due on the next charge date plus metered usage recorded so far. May include a caption that the total can still change with usage before the invoice is issued.
+- **One-time charge** – A plan item billed as a single purchase rather than as part of the recurring subscription. Configured under **One-time charges** on the plan editor.
+- **Package pricing (one-time)** – A one-time pricing model where customers pay an **Amount** for a set **Number of units** (for example $20 per 100 credits). Contrast with **Flat**, which is a single amount per purchase.
 - **Pay annually** – Paying for a non-yearly interval charge at a predefined yearly price, often offered at a discount.
 - **Plan** – A packaged offering of features, prices, and terms available for subscription, typically tiered across a group (e.g., Basic, Pro, Enterprise).
 - **Plan group** – A collection of related plans, often grouped by customer type or usage level, allowing easier management and comparison.

--- a/src/content/docs/billing/about-billing/billing-faq.mdx
+++ b/src/content/docs/billing/about-billing/billing-faq.mdx
@@ -34,8 +34,9 @@ keywords:
   - plan upgrades
   - pricing table
   - billing webhooks
-ai_summary: "FAQ covering Kinde billing setup and day-to-day operations. Explains core concepts such as subscription plans, monthly billing cycles, multi-currency defaults, and Stripe-backed payment processing. Covers getting started steps including connecting Stripe, configuring billing roles for B2B organizations, and creating plans with features, limits, and pricing. Answers questions on free plans without card collection, free trial periods that convert to paid subscriptions, automatic tax and VAT via Stripe Tax, payment methods, failed payments, upgrades and downgrades, metered usage, cancellations and refunds, pricing tables, customized billing pages, and signup-flow integration. Also covers self-serve portals, troubleshooting billing errors, webhooks for subscription lifecycle events, and pricing best practices. Intended for developers, product managers, business owners, and support teams working with Kinde billing."
-updated: 2026-08-10
+  - one-time charges
+ai_summary: "FAQ covering Kinde billing setup and day-to-day operations. Explains core concepts such as subscription plans, monthly billing cycles, multi-currency defaults, and Stripe-backed payment processing. Covers getting started steps including connecting Stripe, configuring billing roles for B2B organizations, and creating plans with features, limits, and pricing. Answers questions on free plans without card collection, one-time charges on plans, free trial periods that convert to paid subscriptions, automatic tax and VAT via Stripe Tax, payment methods, failed payments, upgrades and downgrades, metered usage, cancellations and refunds, pricing tables, customized billing pages, and signup-flow integration. Also covers self-serve portals, troubleshooting billing errors, webhooks for subscription lifecycle events, and pricing best practices. Intended for developers, product managers, business owners, and support teams working with Kinde billing."
+updated: 2026-09-07
 ---
 
 Find quick answers to common questions about Kinde billing. Each section covers specific aspects of billing setup, management, and customer support.
@@ -123,9 +124,25 @@ Kinde provides methods for users to upgrade or downgrade their plans, either thr
 <details>
 <summary>Can I let users subscribe to a free plan without entering payment details?</summary>
 
-Yes, Kinde allows you to configure whether credit card collection is required for each plan. When creating or editing a plan, look for the **Ask for credit card** toggle in the Plan settings section. You can disable this for plans with no charges, allowing users to subscribe without providing payment information. This is useful for reducing signup friction on free tiers. Note that plans with any pricing (fixed or usage-based) always require payment details.
+Yes, Kinde allows you to configure whether credit card collection is required for each plan. When creating or editing a plan, look for the **Ask for credit card** toggle in the Plan settings section. You can disable this for plans with no charges, allowing users to subscribe without providing payment information. This is useful for reducing signup friction on free tiers. Note that plans with any positive-price fixed charge or chargeable metered (usage-based) billing always require payment details. Priced one-time charges alone do not require a credit card at signup.
 
 **Learn more:** [Create plans](/billing/manage-plans/create-plans/)
+</details>
+
+<details>
+<summary>Can I add one-time charges (top-ups or add-ons) to a plan?</summary>
+
+Yes. In the plan editor, use the **One-time charges** section to add single-purchase items such as credit top-ups or add-on unlocks. You can create a new charge or reuse an existing one across plans.
+
+Each one-time charge can be:
+
+- **Unmetered** or **Metered**
+- Priced with a **Flat** amount or a **Package** (amount per a set number of units)
+- Set to **Never expire** or **Expire with the billing cycle**
+
+You can configure one-time charges on plans now. Subscribers can’t buy them yet, and they can’t be applied to existing subscriptions.
+
+**Learn more:** [Create plans — Add one-time charges](/billing/manage-plans/create-plans/#add-one-time-charges-to-a-plan) | [About plans](/billing/manage-plans/about-plans/#one-time-charges)
 </details>
 
 <details>

--- a/src/content/docs/billing/manage-plans/about-plans.mdx
+++ b/src/content/docs/billing/manage-plans/about-plans.mdx
@@ -11,7 +11,7 @@ tableOfContents:
 app_context:
   - m: billing
   - s: plans
-description: "Design Kinde billing plans, plan groups, mixed-interval charges, trials, tax, and draft vs published"
+description: "Design Kinde billing plans, plan groups, mixed-interval charges, one-time charges, trials, tax, and draft vs published"
 featured: false
 deprecated: false
 topics:
@@ -35,8 +35,9 @@ keywords:
   - free trial
   - collect tax automatically
   - draft plans
-ai_summary: "Conceptual overview of billing plans in Kinde for structuring product features and charging customers. Explains plan groups for users or organizations, pricing table constraints, and the parts of a plan including profile details and settings such as Ask for credit card, Collect tax automatically with account or plan-level Stripe Tax options, and configurable free trial periods. Covers pricing building blocks: fixed charges with daily weekly monthly or yearly intervals, optional annual pricing on one charge per plan, and mixed-interval totals such as yearly plus monthly; metered features for usage-based entitlements including unit tiered and included allowances such as MAU; and unmetered features for feature gating. Describes reusing a shared pool of features and charges across plans with plan-specific prices and limits. Explains draft versus published states, Stripe price sync status, current limitations including no custom billing cycle changes and no per-subscription add-ons or discount. Intended for developers, product managers, and business owners designing SaaS pricing."
-updated: 2026-08-30
+  - one-time charges
+ai_summary: "Conceptual overview of billing plans in Kinde for structuring product features and charging customers. Explains plan groups for users or organizations, pricing table constraints, and the parts of a plan including profile details and settings such as Ask for credit card, Collect tax automatically with account or plan-level Stripe Tax options, and configurable free trial periods. Covers pricing building blocks: fixed charges with daily weekly monthly or yearly intervals, optional annual pricing on one charge per plan, mixed-interval totals such as yearly plus monthly; metered and unmetered features; and one-time charges with flat or package pricing and expiry. Describes reusing a shared pool of features, fixed charges, and one-time charges across plans with plan-specific prices and limits. Explains draft versus published states, Stripe price sync status, current limitations including no custom billing cycle changes, no per-subscription add-ons or discounts, and that subscribers cannot purchase one-time charges yet. Intended for developers, product managers, and business owners designing SaaS pricing."
+updated: 2026-09-07
 ---
 
 Plans enable you to structure your app features and charge your customers for using your services. Kinde supports both basic and more advanced plans for SaaS services. Here’s some examples:
@@ -52,6 +53,7 @@ These are known limitations that we are actively working on to add.
 
 - No alterations to billing cycle or invoice methods.
 - Add-ons and discounts that can be applied to individual subscriptions.
+- One-time charge purchase by subscribers, and applying one-time charges to existing subscriptions, are not available yet (plan configuration is available now).
 
 ## About plan groups
 
@@ -78,7 +80,7 @@ The plan name appears on the pricing table that you can generate to share with c
 
 Plan settings control additional subscription behavior beyond pricing.
 
-- **Ask for credit card:** Determines whether users must provide payment details when subscribing. This can be disabled for free plans with no charges, allowing frictionless signups. For plans with any charges (fixed or metered), credit card collection is always required.
+- **Ask for credit card:** Determines whether users must provide payment details when subscribing. This can be disabled for free plans with no charges, allowing frictionless signups. For plans with any positive-price fixed charge or chargeable metered billing, credit card collection is always required. Priced one-time charges alone do not require a card at signup.
 - **Collect tax automatically:** Controls whether Stripe Tax is applied for subscriptions to this plan. Choose **Use account setting** (default), **Collect**, or **Don’t collect**. The account default lives under **Settings > Environment > Billing**. See [Create plans — Collect tax automatically](/billing/manage-plans/create-plans/#collect-tax-automatically) for details.
 - **Trial period:** When enabled, lets customers try the plan for a set number of days before being charged. You can configure the trial length and how many days before the trial ends to prompt for payment details. Plans with a trial enabled show a “Free trial for N day(s)” badge on the pricing table. See [Create plans — Configure trial period](/billing/manage-plans/create-plans/#configure-trial-period) for configuration details.
 
@@ -102,6 +104,22 @@ Bill customers for additional features they can access. Features can be:
 - **Metered:** Users pay based on the usage limits you set. Pricing can be per unit, per tier, or non-chargeable. For example, $10 per 1 million API calls, then $25 for up to the next 5 million API calls, and so on.
 - **Unmetered:** The user either has access to the feature or not. There is no usage limit. Unmetered features are typically used to gate feature access. For example, custom domain support or custom themes.
 
+#### One-time charges
+
+Single-purchase items subscribers can buy in addition to their subscription—for example credit top-ups or add-on unlocks. You configure them on the plan under **One-time charges**, with:
+
+- **Flat** or **Package** pricing
+- Optional metering and unit limits
+- An expiry policy (**Never expires** or **Expires with the billing cycle**)
+
+<Aside>
+
+You can create one-time charges and add them to plans now. Subscribers can’t buy them yet, and they can’t be applied to existing subscriptions.
+
+</Aside>
+
+See [Create billing plans — Add one-time charges to a plan](/billing/manage-plans/create-plans/#add-one-time-charges-to-a-plan).
+
 ## Example plan features
 
 | Feature             | Price                        | Pricing model             |
@@ -112,16 +130,19 @@ Bill customers for additional features they can access. Features can be:
 | Storage/Usage       | $x per GB                    | Metered / units or tiered |
 | MAU                 | x included                   | Metered / non-chargeable  |
 | MAU                 | Additional $x per MAU over n | Metered / tiered          |
+| Credit top-up       | $x one-time (for example per package of credits) | One-time / flat or package |
 
 A plan is complete when it includes all the features needed to provide the access and charge the right price.
 
 ## How to use and re-use features and charges
 
-Kinde structures plans so that they can share a pool of features and charges that you define at a high level. When you add the feature in a plan, you add the price, limits, and other differences uniquely in each plan. This makes building and managing plan features easier, because the feature shares the same key (e.g. `base_price`), making it easier to manage in your code and for gating.
+Kinde structures plans so that they can share a pool of features, fixed charges, and one-time charges that you define at a high level. When you add the item to a plan, you set the price, limits, and other differences uniquely in each plan. This makes building and managing plan items easier, because the item shares the same key (e.g. `base_price` or `credit_top_up`), making it easier to manage in your code and for gating.
 
 For example, you only need to define the item ‘Base price’ once, and then you define the price when you add it to each individual plan.
 
 Similarly, features that are inclusions, such as support hours included, just create one metered feature. Then set the limits of the feature differently for each plan level. E.g. Free plan one hour, Pro plan gets 2 hours, etc.
+
+The same reuse pattern applies to one-time charges: define a top-up once, then attach it to each plan with the amount, package size, and expiry you want for that plan.
 
 ![Model of how you can use the same feature or charge across plans](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/190e7ba8-ba26-4fb6-57b4-a4d6b9fec700/public)
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -105,7 +105,7 @@ This toggle controls whether users must enter credit card details when subscribi
 
     <Aside type="warning">
 
-    This option can only be disabled for plans with no paid charges. A fixed charge priced at `0` does not count as a paid charge, so you can disable the toggle on a free plan that uses a $0 price. Credit card collection is always required if the plan has any positive-price fixed charge or chargeable metered (usage-based) billing. Priced one-time charges alone do not require payment details at signup.
+    Disabling this option is blocked by a positive-price fixed charge, chargeable metered (usage-based) billing, or an enabled trial period. A fixed charge priced at `0` does not require payment details, so you can disable the toggle on a free plan that uses a $0 price. Priced one-time charges alone do not require payment details at signup.
 
     </Aside>
 

--- a/src/content/docs/billing/manage-plans/create-plans.mdx
+++ b/src/content/docs/billing/manage-plans/create-plans.mdx
@@ -13,7 +13,7 @@ relatedArticles:
 app_context:
   - m: billing
   - s: plans
-description: "Set up Kinde plans — fixed charges, mixed intervals, annual pricing, trials, tax, and usage-based features"
+description: "Set up Kinde plans — fixed charges, mixed intervals, annual pricing, trials, tax, usage-based features, and one-time charges"
 featured: false
 deprecated: false
 topics:
@@ -37,15 +37,16 @@ keywords:
   - tiered pricing
   - free trial
   - Stripe Tax
-updated: 2026-08-29
-ai_summary: "Step-by-step guide to creating billing plans in the Kinde dashboard. Explains that all plans belong to a plan group scoped to users or organizations, and that charges and features can be reused across plans. Covers adding a plan with name, description, key, and default currency; configuring plan settings including the Ask for credit card toggle, Collect tax automatically (use account setting, collect, or do not collect), and trial period with trial length and credit card prompt timing; adding fixed charges with daily, weekly, monthly, or yearly billing intervals; offering one charge per plan as annual at a custom yearly price while other charges keep their own intervals (mixed-interval pricing); previewing annual versus standard totals in the Pricing sidebar without changing the draft; creating free plans with a zero price; adding metered and unmetered features with flat or tiered graduated pricing; and verifying Stripe price sync status. Notes constraints such as credit card collection requirements for paid plans and trials, Offer as annual only on non-yearly base intervals, one annual charge per plan, and that feature name, key, and type cannot be changed after creation. Intended for developers, product managers, and business owners setting up SaaS subscription plans."
+  - one-time charges
+updated: 2026-09-07
+ai_summary: "Step-by-step guide to creating billing plans in the Kinde dashboard. Explains that all plans belong to a plan group scoped to users or organizations, and that charges, features, and one-time charges can be reused across plans. Covers adding a plan with name, description, key, and default currency; configuring plan settings including the Ask for credit card toggle, Collect tax automatically (use account setting, collect, or do not collect), and trial period with trial length and credit card prompt timing; adding fixed charges with daily, weekly, monthly, or yearly billing intervals; offering one charge per plan as annual at a custom yearly price while other charges keep their own intervals (mixed-interval pricing); previewing annual versus standard totals in the Pricing sidebar without changing the draft; creating free plans with a zero price; adding metered and unmetered features with flat or tiered graduated pricing; adding one-time charges with flat or package pricing, optional metering, and expiry; and verifying Stripe price sync status. Notes constraints such as credit card collection requirements for paid plans and trials, that priced one-time charges alone do not require a card at signup, Offer as annual only on non-yearly base intervals, one annual charge per plan, that subscribers cannot purchase one-time charges yet, and that feature name, key, and type cannot be changed after creation. Intended for developers, product managers, and business owners setting up SaaS subscription plans."
 ---
 
 Once you’ve got a plan strategy along with a plan feature list, prices, and details, you’re ready to create plans in Kinde.
 
 All plans must belong to a plan group. A plan group can contain only user plans or only organization plans—not both. When you create your first plan, Kinde automatically creates a default group based on the plan type you select and adds the plan to it.
 
-You can define a charge or feature once and reuse it across plans. For example, a **Base price** charge can be set to `0.00` in a **free plan**, `10.00` in a **Plus plan**, and `25.00` in a **Pro plan**.
+You can define a charge, feature, or one-time charge once and reuse it across plans. For example, a **Base price** charge can be set to `0.00` in a **free plan**, `10.00` in a **Plus plan**, and `25.00` in a **Pro plan**.
 
 
 ## Add a plan
@@ -104,7 +105,7 @@ This toggle controls whether users must enter credit card details when subscribi
 
     <Aside type="warning">
 
-    This option can only be disabled for plans with no paid charges. A fixed charge priced at `0` does not count as a paid charge, so you can disable the toggle on a free plan that uses a $0 price. Credit card collection is always required if the plan has any positive-price fixed charge or chargeable metered (usage-based) billing.
+    This option can only be disabled for plans with no paid charges. A fixed charge priced at `0` does not count as a paid charge, so you can disable the toggle on a free plan that uses a $0 price. Credit card collection is always required if the plan has any positive-price fixed charge or chargeable metered (usage-based) billing. Priced one-time charges alone do not require payment details at signup.
 
     </Aside>
 
@@ -243,6 +244,8 @@ To create a free plan, add a fixed charge with a **Price** of `0`. Do not add an
 
 The `0` price ensures the plan is added to Stripe and included on the pricing table as a free plan. It does not require card collection: disable **Ask for credit card** if you want users to subscribe without payment details. See [Ask for credit card](#ask-for-credit-card).
 
+Priced one-time charges on a plan do not by themselves require customers to enter payment details when they subscribe. Payment collection for signup still follows your fixed charges and chargeable recurring metered features, plus the **Ask for credit card** setting in **Plan settings**.
+
 ## Add features (entitlements) to a plan
 
 Features describe the individual functions or entitlements that users get with their plan. These can be of the type metered (chargeable) or unmetered (included).
@@ -282,6 +285,95 @@ You cannot change the Name, the Key or the Type of feature once you have created
 15. Select **Save.**
 16. In the **Plan** window, select **Save** to commit your changes.
 17. Repeat for each feature you want to add to the plan. Then repeat this procedure for each plan.
+
+## Add one-time charges to a plan
+
+<Aside title="One-time charges are rolling out">
+
+You can create one-time charges and add them to plans now but subscribers can’t buy them yet and they can’t be applied to existing subscriptions.
+
+</Aside>
+
+One-time charges are single-purchase items on a plan—for example credit top-ups or add-on unlocks. They appear in their own **One-time charges** section on the plan, separate from **Fixed charges** and **Features**. See [One-time (flat or package) pricing](/billing/pricing/pricing-models/#one-time-flat-or-package-pricing) for pricing-model examples.
+
+### Add a one-time charge
+
+1. Open the plan you want to edit.
+2. In **One-time charges**, select **Add one-time charge**.
+
+    ![one-time charge section](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/328451d2-f279-46f5-3991-fe8555594b00/socialsharingimage)
+
+3. If you have previously created a one-time charge, you will see an extra option: **Use an existing one-time charge**:
+
+    ![use an existing one-time charge switch](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/eba4d1d0-2ff9-440c-1082-37fea5488400/socialsharingimage)
+
+    1. Turn this option **on** to reuse a charge already defined for another plan.
+
+        <Aside>
+        
+        Catalog details (name, description, key, line item, metering, unit of measurement) cannot be changed when using this option; you can still set plan-specific limits, pricing, and expiry.
+        
+        </Aside>
+
+    2. Leave this option **off** to create a new charge.
+4. For a new charge, complete **Details**:
+    - **Name** — use a reusable name if you’ll share the charge across plans.
+    - **Description** (optional) — what’s included and when to use it.
+    - **Key** — for referencing in your application’s code.
+    - **Line item description** — appears on the customer invoice.
+
+    ![add a one-time charge details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/84fc605e-018e-4e69-6d81-e37e3381f200/socialsharingimage)
+
+5. Under **Usage** select one of the following:
+    - **Unmetered** — When you don't track usage for this charge
+    - **Metered** — Track the usage for this charge
+6. Set **Unit of measurement** (optional): for example `credits` and **Maximum units**. 
+
+    <Aside>
+
+    You can leave the **Maximum units** field blank if there is no limit.
+
+    </Aside>
+
+7. Under **Pricing**, select a **Pricing model**:
+    - **Flat** — set the **Amount** for each purchase.
+    - **Package** — set the **Amount** and **Number of units**
+8. Under **Expiry**, select:
+    - **Never expires** (default) — Remains available across billing cycles
+    - **Expires with the billing cycle** — Ends with the current billing cycle
+
+    <Aside>
+
+    Access starts as soon as the subscriber pays. Choose when it ends.
+
+    </Aside>
+
+9. Select **Save**.
+
+The charge appears on the plan under **One-time charges**. Cards show metering, pricing model, limits, expiry, and price sync status when connected to Stripe.
+
+### Edit or remove a one-time charge
+
+Use the actions on the one-time charge card to edit or remove it from the plan.
+
+- **Edit** updates the charge for this plan (and shared catalog fields when they are still editable). If the charge is used on other plans, Kinde shows which plans share it—same pattern as shared features.
+- **Remove** detaches the charge from this plan. It does not delete a shared catalog charge that other plans still use.
+
+You need permission to update plans to add or edit one-time charges, and permission to delete plans to remove them.
+
+### One-time charges vs features and fixed charges
+
+| Plan item | Purpose |
+| --- | --- |
+| Fixed charges | Recurring subscription fees billed in advance |
+| Features | Entitlements included with the subscription (metered or unmetered) |
+| One-time charges | Optional single purchases subscribers can buy (when purchase is live) |
+
+<Aside type="warning">
+
+Do not add one-time items through **Add feature** or **Add charge** under Fixed charges. Use **One-time charges** only.
+
+</Aside>
 
 ## Price sync status
 

--- a/src/content/docs/billing/pricing/pricing-models.mdx
+++ b/src/content/docs/billing/pricing/pricing-models.mdx
@@ -7,7 +7,7 @@ relatedArticles:
   - fe9fea0c-274c-4d6b-9cc5-eccdbaad85b7
   - d980a089-d9c1-447b-930a-de0f2c00d3bf
   - 7060212e-5e8c-4188-acd3-e055e3474988
-description: "Choose Kinde pricing models — flat rate with annual or mixed intervals, usage-based, tiered, and per-feature strategies"
+description: "Choose Kinde pricing models — flat rate with annual or mixed intervals, usage-based, one-time flat or package, tiered, and per-feature strategies"
 featured: false
 deprecated: false
 topics:
@@ -29,8 +29,10 @@ keywords:
   - usage-based pricing
   - tiered pricing
   - per-feature pricing
-updated: 2026-08-22
-ai_summary: "Guide to pricing models you can apply to features in Kinde billing plans. Covers research and strategy before first setup. Explains flat rate subscription pricing using a reusable Fixed charge with daily weekly monthly or yearly intervals, optional Offer as annual on one charge per plan, and mixed-interval examples such as an annual base fee plus a monthly add-on that customers see when they turn on Pay annually. Covers usage-based metered pricing per unit and volume or graduated tiers with plan-specific limits, including recording metered amounts for individual customers via API. Describes per-feature pricing by including or excluding unmetered capabilities across plan levels, or offering limited metered tastes of higher features. Invites feedback if a needed model is not listed. Intended for developers, product managers, and business owners designing SaaS pricing."
+  - one-time charges
+  - package pricing
+updated: 2026-09-07
+ai_summary: "Guide to pricing models you can apply to features in Kinde billing plans. Covers research and strategy before first setup. Explains flat rate subscription pricing using a reusable Fixed charge with daily weekly monthly or yearly intervals, optional Offer as annual on one charge per plan, and mixed-interval examples such as an annual base fee plus a monthly add-on that customers see when they turn on Pay annually. Covers usage-based metered pricing per unit and volume or graduated tiers with plan-specific limits, including recording metered amounts for individual customers via API. Describes one-time flat and package pricing for single purchases such as credit packs, with expiry options and a note that subscriber purchase is rolling out. Describes per-feature pricing by including or excluding unmetered capabilities across plan levels, or offering limited metered tastes of higher features. Invites feedback if a needed model is not listed. Intended for developers, product managers, and business owners designing SaaS pricing."
 ---
 
 A pricing model refers to the structured approach businesses use to charge customers for products and services, often based on factors like usage, feature access, or licensing. In Kinde, each feature you include in a plan has a pricing model attached. This topic describes some examples of pricing models you can apply in Kinde, when you might want to use them, and how to [set them up in your Kinde plans](/billing/manage-plans/create-plans/).
@@ -72,6 +74,29 @@ In Kinde, add a **New metered feature**, e.g. `Token generation`. Leave **Maximu
 - Basic plan (100 unit limit) 0-10 tokens / 0.50 per token, 11-20 tokens / 0.35 per token, 21-100 tokens / 0.20 per token.
 - Team plan (250 unit limit) 0-10 tokens / 0.40 per token, 11-20 tokens / 0.30 per token, 21-100 tokens / 0.15 per token.
 - Business plan (No unit limit) 0-100 tokens / 0.15 per token, 101-250 tokens / 0.10 per token, 251-1,000,000,000 tokens / 0.05 per token. (Note you need to include an upper tier limit even if you offer limitless, just use a really high number.)
+
+## One-time (flat or package) pricing
+
+Where you want customers to buy a single purchase on top of (or alongside) a subscription—for example a credit pack or a one-off unlock.
+
+In Kinde, open a plan and use **One-time charges** (not **Fixed charges** and not **New metered** under Features).
+
+1. Select **Add one-time charge**.
+2. Choose **Flat** or **Package** as the pricing model.
+3. For **Flat**, set the **Amount**.
+4. For **Package**, set the **Amount** and **Number of units** (for example `20.00` per `100` credits).
+5. Optionally mark the charge as metered, set a unit of measurement and maximum units, and choose whether access **Never expires** or **Expires with the billing cycle**.
+
+- Example (flat) — Pro plan offers a `$49` one-time “Priority onboarding” unlock that never expires.
+- Example (package) — All plans offer `$20` per `100` AI credits; credits expire with the billing cycle.
+
+<Aside>
+
+You can add one-time charges to plans now. Subscribers can’t purchase them yet.
+
+</Aside>
+
+For field-by-field setup, see [Create billing plans — Add one-time charges to a plan](/billing/manage-plans/create-plans/#add-one-time-charges-to-a-plan).
 
 ## Per feature pricing
 


### PR DESCRIPTION
This PR adds the details, steps and screenshots for the upcoming one-time charges feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for one-time charges, including flat and package pricing, expiry policies, metering, reuse across plans, and configuration.
  * Added glossary definitions, FAQs, examples, pricing-model details, and plan creation instructions.
  * Clarified that subscribers cannot yet purchase one-time charges or apply them to existing subscriptions.
  * Updated payment-details guidance: priced one-time charges alone do not require a card at signup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->