### PR TITLE
feat: add workforce identity (SAML identity provider) documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -158,6 +158,10 @@ export default defineConfig({
     // Build section subfolder redirects
     "/build/applications/":
       "/build/applications/about-applications/",
+    "/build/self-service-portal/":
+      "/build/self-service-portal/about-self-service-portal/",
+    "/build/set-up-options/self-serve-portal-for-users/":
+      "/build/self-service-portal/self-serve-portal-for-users/",
     "/build/domains/":
       "/build/domains/pointing-your-domain/",
     "/build/env-variables/":

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -61,6 +61,7 @@ ai_summary: "Index of LLM training files for Kinde documentation including abrid
 - [Manage Your APIs](https://docs.kinde.com/_llms-txt/manage-your-apis.txt): complete documentation for API management
 - [Properties](https://docs.kinde.com/_llms-txt/properties.txt): complete documentation for custom properties
 - [Workflows](https://docs.kinde.com/_llms-txt/workflows.txt): complete documentation for workflow automation
+- [Workforce Identity](https://docs.kinde.com/_llms-txt/workforce-identity.txt): complete documentation for using Kinde as a SAML identity provider
 
 ## Notes
 

--- a/scripts/generate-llms-txt-sections.js
+++ b/scripts/generate-llms-txt-sections.js
@@ -124,7 +124,8 @@ function generateSectionFrontmatter(sectionName) {
     'properties': '1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e',
     'releases': '2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f',
     'trust-center': '3d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a',
-    'workflows': '4e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b'
+    'workflows': '4e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b',
+    'workforce-identity': '03a725f4-4412-4ac5-9c1f-effebb5101e9'
   };
   
   const pageId = sectionUUIDs[sectionName] || `llms-${sectionName}-fallback`;

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,24 +1,45 @@
 ---
 const sidebar = Astro.props.sidebar;
 
-function getCurrentArticleTaxonomy() {
-  for (const mainTopic of sidebar) {
-    for (const subtopic of mainTopic.entries) {
-      if (subtopic.entries) {
-        for (const article of subtopic.entries) {
-          if (article.isCurrent) {
-            return `<ul class="flex list-none items-center p-0 text-sm text-zinc-500 dark:text-zinc-400">
-              <li>${mainTopic.label}</li>
-              <li class="before:px-2 before:content-['/']">${subtopic.label}</li>
-            </ul><span hidden id="docsearch-lvl0">${mainTopic.label} / ${subtopic.label}</span>`;
-          }
-        }
-      }
+// Sidebar entries are either links or groups, and groups nest to different depths.
+// Most sections go section > group > article ("Build on Kinde / Applications"), but
+// flat sections such as Workforce identity, MCP Servers and Testing autogenerate
+// their articles directly under the section ("Workforce identity").
+// Walk to whichever depth the current article sits at and use the labels above it.
+function getCurrentArticleTaxonomy(entries, ancestors = []) {
+  for (const entry of entries ?? []) {
+    if (entry.type === "group") {
+      const trail = getCurrentArticleTaxonomy(entry.entries, [...ancestors, entry.label]);
+      if (trail) return trail;
+    } else if (entry.isCurrent) {
+      return ancestors;
     }
   }
 }
 
-const breadcrumb = getCurrentArticleTaxonomy();
+const escapeHtml = (value) =>
+  String(value).replace(
+    /[&<>"']/g,
+    (char) =>
+      ({"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"})[char]
+  );
+
+// Pages left out of the sidebar (`hidden: true`, or a section with no sidebar entry)
+// have no trail to show.
+const trail = getCurrentArticleTaxonomy(sidebar) ?? [];
+
+const crumbs = trail
+  .map(
+    (label, index) =>
+      `<li${index > 0 ? ` class="before:px-2 before:content-['/']"` : ""}>${escapeHtml(label)}</li>`
+  )
+  .join("\n              ");
+
+const breadcrumb = trail.length
+  ? `<ul class="flex list-none items-center p-0 text-sm text-zinc-500 dark:text-zinc-400">
+              ${crumbs}
+            </ul><span hidden id="docsearch-lvl0">${escapeHtml(trail.join(" / "))}</span>`
+  : undefined;
 ---
 
 <div class="c-breadcrumb" set:html={breadcrumb} />

--- a/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/about-enterprise-connections.mdx
@@ -8,6 +8,7 @@ relatedArticles:
   - e100d77b-530b-4327-8216-93c955657e0c
   - cc242fb3-4b06-4842-97c8-dd58e87308df
   - 2c58dabc-fe5c-4919-ade7-4caab8da47e8
+  - 9b92bbc7-f738-48e2-ab36-571cc3b4a57f
 app_context:
   - m: settings
     s: authentication
@@ -39,6 +40,8 @@ updated: 2026-03-26
 ---
 
 Enterprise authentication is a common method for managing user access to systems in large organizations.
+
+In enterprise connections, Kinde acts as the service provider (SP) and your customer brings their own identity provider. Looking to let your own team sign in to third-party tools using Kinde as the identity provider? See [Workforce identity in Kinde](/workforce-identity/).
 
 Kinde supports a number of enterprise connection types, including:
 

--- a/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
+++ b/src/content/docs/authenticate/enterprise-connections/custom-saml.mdx
@@ -48,6 +48,8 @@ ai_summary: "Kinde acts as a SAML service provider (SP), requiring an external i
 
 In Kinde, you can use SAML as your authentication protocol. Kinde acts as a service provider (SP), so you still need to bring your own identity provider (IdP) to set it up. Identity providers can include Google, Microsoft, Cloudflare, and others.
 
+Looking to let your own team sign in to third-party tools using Kinde as the identity provider? See [Workforce identity in Kinde](/workforce-identity/).
+
 ![custom saml enterprise connection in Kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/f7998522-cbd7-4ce4-68ab-9131be4b0c00/socialsharingimage)
 
 Note: Since there are differences between set ups for each IdP, we are unable to provide full details on how to configure them all to connect with Kinde. However, the fields we mention below, should have similar names in your IdP. Some concepts are explained in the [advanced SAML configurations](/authenticate/enterprise-connections/advanced-saml-configurations/) topic.

--- a/src/content/docs/build/applications/about-applications.mdx
+++ b/src/content/docs/build/applications/about-applications.mdx
@@ -8,6 +8,7 @@ relatedArticles:
   - 6c70b7ae-1b1b-43bb-bea1-9b3ec88dd082
   - 38d2394f-f064-47a1-89d0-078597b78412
   - 6bf993fc-a195-4836-8eaf-133812be8876
+  - 9b92bbc7-f738-48e2-ab36-571cc3b4a57f
 topics:
   - applications
   - oauth
@@ -35,6 +36,16 @@ Applications in Kinde facilitate the receipt of access tokens in your applicatio
 See [Section 4 of the OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749#section-4) for details on Authorization flows.
 
 We support the following applications and flows.
+
+## Customer identity and workforce identity
+
+**Settings > Environment > Applications** is split into two sub-pages.
+
+**Customer identity** holds the OAuth applications that make up your own product, which are the front-end, back-end and machine to machine apps described on this page. These use OAuth 2.0 to issue tokens to your code.
+
+**Workforce identity** holds SAML applications, which are the third-party tools your own team signs in to, such as Google Workspace, Microsoft 365 or Slack. For these, Kinde acts as a SAML identity provider rather than issuing tokens to your product. See [Workforce identity in Kinde](/workforce-identity/).
+
+The rest of this page describes customer identity applications.
 
 ## Back-end / server-side apps
 

--- a/src/content/docs/build/applications/add-and-manage-applications.mdx
+++ b/src/content/docs/build/applications/add-and-manage-applications.mdx
@@ -8,6 +8,7 @@ relatedArticles:
   - 4a46eba1-598a-4804-b669-dc96f31d2205
   - 6bf993fc-a195-4836-8eaf-133812be8876
   - 7e861737-04c6-4f69-bf83-84b5f40f1962
+  - c00a7687-2d59-427d-b8a4-f2f05d29a7f2
 app_context:
   - m: settings
     s: applications
@@ -37,9 +38,11 @@ If you plan to manage authentication for each of your applications using Kinde, 
 
 [Kinde provides several application types](/build/applications/about-applications/), including a regular web app (for execution on a server), single page web app (for browsers and mobile), and machine to machine applications (for backend services that require access to an API, including the [Kinde management API](/developer-tools/kinde-api/connect-to-kinde-api/)).
 
+Applications are organized into two sub-pages. **Customer identity** holds the OAuth applications that make up your product, which is what this page covers. **Workforce identity** holds SAML applications that let your own team sign in to third-party tools, with Kinde acting as the identity provider. To add one of those, see [Add and configure a SAML application](/workforce-identity/add-saml-application/).
+
 ## Add an application
 
-1. Go to **Settings > Environment >** **Applications**.
+1. Go to **Settings > Environment > Applications** and select the **Customer identity** tab.
 2. Select **Add application**.
 3. Enter a name and select the type of application.
 4. Select **Save**. A tile appears for the application.

--- a/src/content/docs/build/self-service-portal/self-serve-portal-for-users.mdx
+++ b/src/content/docs/build/self-service-portal/self-serve-portal-for-users.mdx
@@ -9,6 +9,7 @@ tableOfContents:
 relatedArticles:
   - beebe908-27f8-4be6-b74c-05fc8ff5dfb5
   - a2668524-5842-4c68-ab50-30b7e8c3e842
+  - c00a7687-2d59-427d-b8a4-f2f05d29a7f2
 topics:
   - self-serve-portal
   - user-management
@@ -66,6 +67,21 @@ Allows users to manage their billing subscription, change or cancel their plan, 
 ### API Keys
 
 Allows users to create and manage their API keys.
+
+### Applications
+
+Allows organization members to open your connected workforce applications directly from the portal. Each application you have made available appears as a tile, and selecting one signs the person in to that tool using Kinde as the identity provider.
+
+This module is off by default. Turn it on in **Settings > Environment > Self-serve portal**.
+
+A tile appears only when all of the following are true for that application:
+
+- The application is **Enabled**.
+- **Show on self-serve portal** is turned on for it.
+- The person's organization is allowed, if you have restricted the application under **Limit to organizations**.
+- The person holds an allowed role, if role-based access control is turned on for it.
+
+To set these up, see [Add and configure a SAML application](/workforce-identity/add-saml-application/).
 
 ## Generate the self-serve portal link
 

--- a/src/content/docs/workforce-identity/add-saml-application.mdx
+++ b/src/content/docs/workforce-identity/add-saml-application.mdx
@@ -1,0 +1,214 @@
+---
+page_id: c00a7687-2d59-427d-b8a4-f2f05d29a7f2
+title: Add and configure a SAML application
+description: "Connect a third-party tool so your team can sign in to it with Kinde as the SAML identity provider."
+sidebar:
+  order: 2
+  label: Add a SAML application
+tableOfContents:
+  maxHeadingLevel: 3
+relatedArticles:
+  - 9b92bbc7-f738-48e2-ab36-571cc3b4a57f
+  - f36bce4a-52bb-4785-865b-6b33356f9838
+  - 6c70b7ae-1b1b-43bb-bea1-9b3ec88dd082
+app_context:
+  - m: settings
+    s: applications
+topics:
+  - workforce-identity
+  - applications
+  - configuration
+sdk: []
+languages: []
+audience:
+  - developers
+  - admins
+complexity: intermediate
+keywords:
+  - SAML application
+  - service provider
+  - ACS URL
+  - SP entity ID
+  - IdP metadata
+  - attribute mapping
+  - single logout
+  - Test SSO
+updated: 2026-09-09
+featured: false
+deprecated: false
+ai_summary: "Step-by-step guide to connecting a third-party tool as a SAML application in Kinde, with Kinde acting as the identity provider. Covers adding an application from the catalog or as Generic SAML, entering service provider details (SP entity ID, ACS URL, Name ID format and source) or importing SP metadata, copying Kinde's IdP metadata into the third-party tool, mapping user attributes to SAML attribute names, choosing authentication methods, restricting access by role, setting session lifetime (default 86400 seconds, max 30 days) and SAML assertion validity (default 3600 seconds, max 24 hours), signing and encryption settings, configuring single logout via the SP logout callback URL, testing with Test SSO, making the application visible in the self-serve portal, and deleting an application. Includes troubleshooting for access denied errors, empty signing certificates, rejected assertions, and missing portal tiles."
+---
+
+Add a SAML application to let your team sign in to a third-party tool using Kinde as the identity provider. For background, see [Workforce identity in Kinde](/workforce-identity/).
+
+<Aside type="upgrade">
+
+Workforce identity is available on the [Kinde Scale plan](https://kinde.com/pricing/). Separate plans for workforce identity are coming soon.
+
+</Aside>
+
+Connecting an application involves an exchange of details in both directions. You tell Kinde where to send assertions, and you tell the third-party tool to trust Kinde.
+
+## Add an application
+
+1. Go to **Settings > Environment > Applications** and select the **Workforce identity** tab.
+2. Select **Add application**.
+3. Choose your application from the catalog. If your tool is not listed, choose **Generic SAML**.
+4. Kinde creates the application and opens its **Details** page.
+
+## Configure the service provider details
+
+On the **Details** tab, fill in the values the third-party tool expects. If the catalog entry includes a setup guide, you will see example values and a link to the vendor's own documentation. Use the examples as a guide only, because your real values usually include your own account or tenant identifier.
+
+1. In **Service provider (SP) configuration**, enter the **SP entity ID**. This is the entity ID configured in the third-party application.
+2. Enter the **Assertion Consumer Service (ACS) URL**. This is where Kinde posts the SAML response.
+3. Check the **Name ID format**. Kinde defaults to the email address format, which suits most applications.
+4. Choose the **Name ID source**, which is the Kinde user field sent as the SAML NameID. Choose **Email** or **User ID**. Email is the default.
+5. Select **Save**.
+
+If your tool publishes a metadata file, you can save time by selecting **Import SP metadata** and supplying the metadata URL or XML. Kinde fills in the entity ID, ACS URL and certificates for you.
+
+<Aside>
+
+Use **User ID** as the Name ID source when people's email addresses may change. Email addresses are easier to read in the third-party tool, but if someone's address changes, the tool may treat them as a new person.
+
+</Aside>
+
+### Optional display name
+
+Under **Application**, set a **Display name** to override the catalog name in your application list. This is useful when you connect more than one instance of the same tool.
+
+## Give the third-party tool Kinde's details
+
+Open the **IdP metadata** tab. It holds the values the third-party tool needs so that it trusts Kinde.
+
+| Value               | What it is                                                          |
+| ------------------- | ------------------------------------------------------------------- |
+| IdP metadata URL    | A single URL many tools can import to configure everything at once  |
+| IdP entity ID       | Kinde's unique identifier for this connection                       |
+| Single sign-on URL  | Where the tool sends its authentication requests                    |
+| Single logout URL   | Where the tool sends logout requests, if you have configured logout |
+| Signing certificate | Used by the tool to verify assertions signed by Kinde               |
+
+Copy these into the third-party tool's SAML settings, or paste the metadata URL if the tool supports importing.
+
+<Aside>
+
+Kinde generates the signing certificate for an application the first time it is actually used. If the certificate field is empty, select **Test SSO** on this tab, or complete a real sign-in through the application, and the certificate will be created.
+
+</Aside>
+
+## Map user attributes
+
+Most applications need more than a NameID. On the **Attribute mapping** tab, map Kinde user fields to the SAML attribute names your tool expects.
+
+1. Go to the **Attribute mapping** tab.
+2. Select a Kinde source field. You can map standard profile fields and any user properties you have defined.
+3. Enter the **SAML attribute name** exactly as the service provider expects it.
+4. Select **Add mapping** to add more.
+5. Select **Save**.
+
+Check the service provider's SAML documentation for the attribute names it requires. Names are usually case sensitive and must match exactly.
+
+<Aside>
+
+User property values are the same across organizations. Organization-specific role claims are not supported yet.
+
+</Aside>
+
+## Choose authentication methods
+
+On the **Authentication** tab, choose which of your authentication connections can be used to sign in to this application. This lets you require a stronger method for sensitive tools than you allow elsewhere.
+
+You need connections permissions to change this tab.
+
+## Restrict access by role
+
+By default, anyone who can sign in to Kinde can sign in to an enabled application. To narrow that:
+
+1. Go to the **Access control** tab.
+2. Turn on **Enable role-based access control**.
+3. Select the **Allowed roles**. Only organization members holding one of these roles can sign in.
+4. Select **Save**.
+
+You need at least one role defined for your business before you can turn this on.
+
+<Aside type="warning">
+
+Role-based access control is evaluated within an organization. If Kinde cannot determine which organization someone is signing in from, access is denied. Test the sign-in path you expect people to use after turning this on.
+
+</Aside>
+
+## Set session and assertion lifetimes
+
+The **Sessions** tab controls two separate timers.
+
+**Session lifetime** is how long since the person last actually authenticated before this application requires a fresh sign-in, even if their browser session is still active. The default is 86400 seconds, which is 24 hours. The maximum is 30 days.
+
+**SAML authentication validity period** is the expiry window written into each issued assertion, which the service provider checks when it receives one. The default is 3600 seconds, which is one hour. The maximum is 24 hours.
+
+These are different things. Session lifetime governs how often people must sign in again. Assertion validity governs how long a single assertion stays acceptable to the service provider, and generally should be left short.
+
+To require a fresh sign-in on every launch regardless of session lifetime, turn on **Force re-authentication** in the **Security** section of the **Details** tab.
+
+## Secure the connection
+
+The **Security** section of the **Details** tab holds the signing and encryption settings.
+
+- **Sign assertion** is on by default and should stay on. It lets the service provider verify the assertion came from Kinde.
+- **Encrypt assertion** is off by default. Turn it on if the service provider requires encrypted assertions, and paste its **SP encryption certificate**. The certificate is required when encryption is enabled.
+- **SP signing certificate** verifies signed requests coming from the application, such as logout requests. Provide it when the tool publishes a signing certificate separate from its encryption certificate.
+
+## Configure single logout
+
+To support single logout, set the **SP logout callback URL** in the **Security** section. This is the third-party application's endpoint where Kinde sends the logout response. Leave it blank to use the RelayState from each logout request.
+
+<Aside type="warning">
+
+The SP logout callback URL is the third-party application's endpoint, not Kinde's single logout URL. Kinde's own single logout URL is on the **IdP metadata** tab and belongs in the third-party tool's configuration.
+
+</Aside>
+
+Set the **Single logout binding** to match what the service provider expects.
+
+## Test the connection
+
+1. Go to the **IdP metadata** tab.
+2. Select **Test SSO**.
+
+Kinde signs you in and runs a real SAML sign-in to the application, so you can confirm the connection before rolling it out. **Test SSO** appears once both the SP entity ID and the ACS URL are set.
+
+## Make the application available to your team
+
+Once the connection works, decide who sees it.
+
+1. On the **Details** tab, under **Settings**, confirm **Enabled** is on.
+2. Turn on **Show on self-serve portal** to give organization members a tile that opens the application.
+3. Optionally use **Limit to organizations** to restrict the tile to chosen organizations. Leave every box unchecked to allow all organizations.
+4. Select **Save**.
+
+For the tile to appear, the **Applications** module must also be enabled for your self-serve portal. See [Enable self-service portal for users](/build/self-service-portal/self-serve-portal-for-users/).
+
+People can also sign in by going to the third-party tool directly, which does not depend on the portal setting.
+
+## Delete an application
+
+1. Go to **Settings > Environment > Applications** and select the **Workforce identity** tab.
+2. Open the application and select **Delete**.
+3. Confirm the deletion.
+
+<Aside type="danger">
+
+Deleting a SAML application is a destructive action which cannot be reversed. Its configuration, attribute mappings, access rules and session records are removed, and anyone using it loses access.
+
+</Aside>
+
+## Troubleshooting
+
+**People cannot sign in and see an access denied message.** Check the **Access control** tab. If role-based access control is on, confirm the person holds one of the allowed roles in the organization they are signing in from.
+
+**The signing certificate field is empty.** The certificate is generated on first use. Select **Test SSO**, or complete a real sign-in.
+
+**The service provider rejects the assertion.** Confirm the SP entity ID and ACS URL match the tool exactly, and that the attribute names on the **Attribute mapping** tab match what the tool expects, including case.
+
+**The tile does not appear in the self-serve portal.** Confirm **Show on self-serve portal** is on, that the person's organization is allowed under **Limit to organizations**, and that the **Applications** portal module is enabled.

--- a/src/content/docs/workforce-identity/add-saml-application.mdx
+++ b/src/content/docs/workforce-identity/add-saml-application.mdx
@@ -49,48 +49,49 @@ Workforce identity is available on the [Kinde Scale plan](https://kinde.com/pric
 
 Connecting an application involves an exchange of details in both directions. You tell Kinde where to send assertions, and you tell the third-party tool to trust Kinde.
 
-## Add an application
+## Quickstart
 
-1. Go to **Settings > Environment > Applications** and select the **Workforce identity** tab.
+### 1. Create an application
+
+1. Sign in to your Kinde dashboard, and go to **Settings > Environment > Applications** and select the **Workforce identity** tab.
 2. Select **Add application**.
-3. Choose your application from the catalog. If your tool is not listed, choose **Generic SAML**.
+3. Choose your application from the catalog. If your tool is not listed, choose **SAML application**.
 4. Kinde creates the application and opens its **Details** page.
 
-## Configure the service provider details
+### 2. Configure app details
 
-On the **Details** tab, fill in the values the third-party tool expects. If the catalog entry includes a setup guide, you will see example values and a link to the vendor's own documentation. Use the examples as a guide only, because your real values usually include your own account or tenant identifier.
+1. Set a **Display name** to override the catalog name in your application list. This is useful when you connect more than one instance of the same tool.
 
-1. In **Service provider (SP) configuration**, enter the **SP entity ID**. This is the entity ID configured in the third-party application.
-2. Enter the **Assertion Consumer Service (ACS) URL**. This is where Kinde posts the SAML response.
-3. Check the **Name ID format**. Kinde defaults to the email address format, which suits most applications.
-4. Choose the **Name ID source**, which is the Kinde user field sent as the SAML NameID. Choose **Email** or **User ID**. Email is the default.
-5. Select **Save**.
+<Aside title="Import metadata to auto configure settings">
 
-If your tool publishes a metadata file, you can save time by selecting **Import SP metadata** and supplying the metadata URL or XML. Kinde fills in the entity ID, ACS URL and certificates for you.
-
-<Aside>
-
-Use **User ID** as the Name ID source when people's email addresses may change. Email addresses are easier to read in the third-party tool, but if someone's address changes, the tool may treat them as a new person.
+If your tool publishes a metadata file, you can save time by selecting **Import SP metadata** and supplying the metadata URL or XML. Kinde fills in the entity ID, ACS URL and certificates for you. Select **Save** to apply the settings.
 
 </Aside>
 
-### Optional display name
+2. In **Service provider (SP) configuration**, enter the **SP entity ID**. This is the entity ID configured in the third-party application.
+3. Enter the **Assertion Consumer Service (ACS) URL**. This is where Kinde posts the SAML response.
+4. Check the **Name ID format**. Kinde defaults to the email address format, which suits most applications.
+5. Choose the **Name ID source**, which is the Kinde user field sent as the SAML NameID. Choose **Email** or **User ID**. Email is the default.
 
-Under **Application**, set a **Display name** to override the catalog name in your application list. This is useful when you connect more than one instance of the same tool.
+    <Aside>
 
-## Give the third-party tool Kinde's details
+    Use **User ID** as the Name ID source when people's email addresses may change. Email addresses are easier to read in the third-party tool, but if someone's address changes, the tool may treat them as a new person.
 
-Open the **IdP metadata** tab. It holds the values the third-party tool needs so that it trusts Kinde.
+    </Aside>
 
-| Value               | What it is                                                          |
-| ------------------- | ------------------------------------------------------------------- |
-| IdP metadata URL    | A single URL many tools can import to configure everything at once  |
-| IdP entity ID       | Kinde's unique identifier for this connection                       |
-| Single sign-on URL  | Where the tool sends its authentication requests                    |
-| Single logout URL   | Where the tool sends logout requests, if you have configured logout |
-| Signing certificate | Used by the tool to verify assertions signed by Kinde               |
+6. Select **Save**.
 
-Copy these into the third-party tool's SAML settings, or paste the metadata URL if the tool supports importing.
+
+### 3. Get Kinde IDP metadata
+
+1. Go to the **Kinde IdP metadata** tab. And copy the **IdP metadata URL**. If your tool supports auto-configuration, use this URL to import all of Kinde's details at once.
+
+2. For manual configuration, copy the following values into the third-party tool's SAML settings:
+
+    - **IdP entity ID**: Kinde's unique identifier for this connection
+    - **Single sign-on URL**: Where the tool sends its authentication requests
+    - **Single logout URL**: Where the tool sends logout requests, if you have configured logout
+    - **Signing certificate**: Used by the tool to verify assertions signed by Kinde
 
 <Aside>
 
@@ -98,7 +99,7 @@ Kinde generates the signing certificate for an application the first time it is 
 
 </Aside>
 
-## Map user attributes
+### 4. Map user attributes
 
 Most applications need more than a NameID. On the **Attribute mapping** tab, map Kinde user fields to the SAML attribute names your tool expects.
 
@@ -116,13 +117,31 @@ User property values are the same across organizations. Organization-specific ro
 
 </Aside>
 
-## Choose authentication methods
+### 5. Choose authentication methods
 
-On the **Authentication** tab, choose which of your authentication connections can be used to sign in to this application. This lets you require a stronger method for sensitive tools than you allow elsewhere.
+1. Go to the **Authentication** tab.
+2. Choose which of your authentication connections can be used to sign in to this application. This lets you require a stronger method for sensitive tools than you allow elsewhere.
 
 You need connections permissions to change this tab.
 
-## Restrict access by role
+### 6. Test the connection
+
+<Aside>
+
+**Test SSO** button appears once both the **SP entity ID** and the **ACS URL** are set.
+
+</Aside>
+
+1. Go to the **Kinde IdP metadata** tab.
+2. Scroll down to the end of the page and under **Test this connection**, select **Test SSO**.
+
+    ![sample application test sso](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/33eb4c6b-de81-4024-dd76-38e3c5a59800/socialsharingimage)
+
+Kinde signs you in and runs a real SAML sign-in to the application, so you can confirm the connection before rolling it out. 
+
+## Advanced configuration
+
+### Restrict access by role
 
 By default, anyone who can sign in to Kinde can sign in to an enabled application. To narrow that:
 
@@ -139,7 +158,7 @@ Role-based access control is evaluated within an organization. If Kinde cannot d
 
 </Aside>
 
-## Set session and assertion lifetimes
+### Set session and assertion lifetimes
 
 The **Sessions** tab controls two separate timers.
 
@@ -151,7 +170,7 @@ These are different things. Session lifetime governs how often people must sign 
 
 To require a fresh sign-in on every launch regardless of session lifetime, turn on **Force re-authentication** in the **Security** section of the **Details** tab.
 
-## Secure the connection
+### Secure the connection
 
 The **Security** section of the **Details** tab holds the signing and encryption settings.
 
@@ -159,7 +178,7 @@ The **Security** section of the **Details** tab holds the signing and encryption
 - **Encrypt assertion** is off by default. Turn it on if the service provider requires encrypted assertions, and paste its **SP encryption certificate**. The certificate is required when encryption is enabled.
 - **SP signing certificate** verifies signed requests coming from the application, such as logout requests. Provide it when the tool publishes a signing certificate separate from its encryption certificate.
 
-## Configure single logout
+### Configure single logout
 
 To support single logout, set the **SP logout callback URL** in the **Security** section. This is the third-party application's endpoint where Kinde sends the logout response. Leave it blank to use the RelayState from each logout request.
 
@@ -170,13 +189,6 @@ The SP logout callback URL is the third-party application's endpoint, not Kinde'
 </Aside>
 
 Set the **Single logout binding** to match what the service provider expects.
-
-## Test the connection
-
-1. Go to the **IdP metadata** tab.
-2. Select **Test SSO**.
-
-Kinde signs you in and runs a real SAML sign-in to the application, so you can confirm the connection before rolling it out. **Test SSO** appears once both the SP entity ID and the ACS URL are set.
 
 ## Make the application available to your team
 

--- a/src/content/docs/workforce-identity/index.mdx
+++ b/src/content/docs/workforce-identity/index.mdx
@@ -1,0 +1,111 @@
+---
+page_id: 9b92bbc7-f738-48e2-ab36-571cc3b4a57f
+title: Workforce identity in Kinde
+description: "Use Kinde as a SAML identity provider so your team can sign in to third-party tools such as Google Workspace, Microsoft 365, and Slack."
+sidebar:
+  order: 1
+  label: About workforce identity
+prev: false
+relatedArticles:
+  - c00a7687-2d59-427d-b8a4-f2f05d29a7f2
+  - 4a46eba1-598a-4804-b669-dc96f31d2205
+  - fcf28a71-c3a8-4474-9564-ad089d3f2105
+  - f36bce4a-52bb-4785-865b-6b33356f9838
+app_context:
+  - m: settings
+    s: applications
+topics:
+  - workforce-identity
+  - applications
+  - authentication
+sdk: []
+languages: []
+audience:
+  - developers
+  - admins
+complexity: intermediate
+keywords:
+  - workforce identity
+  - SAML identity provider
+  - IdP
+  - single sign-on
+  - SAML applications
+  - application catalog
+  - single logout
+  - self-serve portal
+updated: 2026-09-09
+featured: false
+deprecated: false
+ai_summary: "Workforce identity lets your own team sign in to third-party tools such as Google Workspace, Microsoft 365, Slack, and Salesforce using Kinde as a SAML 2.0 identity provider (IdP). This is the inverse of enterprise connections, where Kinde acts as a service provider consuming a customer's IdP. Settings > Environment > Applications is split into Customer identity (OAuth applications that make up your product) and Workforce identity (SAML applications your team signs in to). Kinde ships a catalog of around 120 pre-configured SAML applications, with Generic SAML available for anything not listed. Sign-in can be service provider initiated, identity provider initiated from the self-serve portal, or triggered by Test SSO in the admin. Access is controlled per application through Enabled, Show on self-serve portal, Limit to organizations, and role-based access control. Single logout ends SAML sessions only and does not sign the person out of Kinde. Available on the Kinde Scale plan."
+---
+
+Workforce identity lets your team sign in to third-party tools using Kinde as the identity provider. Instead of managing a separate login for every tool your business runs on, you manage people once in Kinde and grant them access to the tools they need.
+
+Kinde acts as a SAML 2.0 identity provider (IdP). When someone on your team opens a connected tool, that tool asks Kinde to verify who they are, and Kinde returns a signed SAML assertion containing their identity and any attributes you choose to send.
+
+<Aside type="upgrade">
+
+Workforce identity is available on the [Kinde Scale plan](https://kinde.com/pricing/). Separate plans for workforce identity are coming soon.
+
+</Aside>
+
+## Workforce identity vs enterprise connections
+
+Kinde supports SAML in both directions, and it is important to know which one you need.
+
+|                       | Workforce identity                                  | [Enterprise connections](/authenticate/enterprise-connections/about-enterprise-connections/) |
+| --------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Kinde's role          | Identity provider (IdP)                             | Service provider (SP)                                                                        |
+| Who signs in          | Your own team                                       | Your customers' users                                                                        |
+| Where they sign in to | Third-party tools such as Slack or Google Workspace | Your product                                                                                 |
+| You configure         | The third-party tool to trust Kinde                 | Kinde to trust your customer's IdP                                                           |
+
+If you want your customers to sign in to your product using their own company IdP, you want enterprise connections. If you want your team to sign in to other companies' tools using Kinde, you want workforce identity.
+
+## Customer identity and workforce identity
+
+**Settings > Environment > Applications** is split into two sub-pages.
+
+- **Customer identity** holds your OAuth applications, which are the front-end, back-end and machine to machine apps that make up your own product. See [Applications in Kinde](/build/applications/about-applications/).
+- **Workforce identity** holds your SAML applications, which are the third-party tools your team signs in to.
+
+The two are managed separately and do not share configuration.
+
+## The application catalog
+
+Kinde ships a catalog of around 120 pre-configured SAML applications, so most tools need only a couple of values to connect. The catalog includes Microsoft 365, Google Workspace, Slack and Salesforce, along with many HR, finance and IT tools.
+
+Catalog entries pre-fill what Kinde can know ahead of time, and many include an example SP entity ID, an example ACS URL, and a link to the vendor's own SAML setup guide.
+
+If your tool is not in the catalog, choose **Generic SAML** and enter the values by hand. Any SAML 2.0 service provider will work.
+
+## How people sign in
+
+There are three ways a connected tool can be opened.
+
+- **Service provider initiated** — someone goes to the tool directly, and the tool redirects them to Kinde to sign in. This is the most common path.
+- **Identity provider initiated** — someone opens the tool from a tile in the Kinde self-serve portal. See [Enable self-service portal for users](/build/self-service-portal/self-serve-portal-for-users/).
+- **Test SSO** — you open the tool yourself from the Kinde admin to check a connection before rolling it out.
+
+In every case the person signs in to Kinde using whichever authentication methods you have enabled, and Kinde issues the assertion only after they have authenticated.
+
+## Controlling who gets access
+
+Access to each application is controlled independently, so adding an application does not give it to everyone.
+
+- **Enabled** turns the application on or off. When it is off, nobody can sign in to it.
+- **Show on self-serve portal** controls whether a tile appears for organization members in the portal.
+- **Limit to organizations** restricts portal access to chosen organizations. Leave it unset to allow every organization.
+- **Role-based access control** restricts sign-in to members holding one of the roles you select.
+
+Role-based access control is evaluated within an organization. If it is enabled and Kinde cannot determine which organization the person is signing in from, access is denied.
+
+## Single logout
+
+If you set a logout URL on an application, Kinde supports SAML single logout for it. When a connected tool sends a logout request, Kinde ends the SAML session for that tool and notifies other connected tools that have logout configured.
+
+Single logout ends SAML sessions only. It does not sign the person out of Kinde, and it does not revoke access or refresh tokens for your own applications. Those end only through an explicit Kinde action such as signing out of Kinde, a credential change, or an admin action.
+
+## Next steps
+
+- [Add and configure a SAML application](/workforce-identity/add-saml-application/)

--- a/src/content/docs/workforce-identity/index.mdx
+++ b/src/content/docs/workforce-identity/index.mdx
@@ -39,15 +39,16 @@ deprecated: false
 ai_summary: "Workforce identity lets your own team sign in to third-party tools such as Google Workspace, Microsoft 365, Slack, and Salesforce using Kinde as a SAML 2.0 identity provider (IdP). This is the inverse of enterprise connections, where Kinde acts as a service provider consuming a customer's IdP. Settings > Environment > Applications is split into Customer identity (OAuth applications that make up your product) and Workforce identity (SAML applications your team signs in to). Kinde ships a catalog of around 120 pre-configured SAML applications, with Generic SAML available for anything not listed. Sign-in can be service provider initiated, identity provider initiated from the self-serve portal, or triggered by Test SSO in the admin. Access is controlled per application through Enabled, Show on self-serve portal, Limit to organizations, and role-based access control. Single logout ends SAML sessions only and does not sign the person out of Kinde. Available on the Kinde Scale plan."
 ---
 
-Workforce identity lets your team sign in to third-party tools using Kinde as the identity provider. Instead of managing a separate login for every tool your business runs on, you manage people once in Kinde and grant them access to the tools they need.
-
-Kinde acts as a SAML 2.0 identity provider (IdP). When someone on your team opens a connected tool, that tool asks Kinde to verify who they are, and Kinde returns a signed SAML assertion containing their identity and any attributes you choose to send.
-
 <Aside type="upgrade">
 
 Workforce identity is available on the [Kinde Scale plan](https://kinde.com/pricing/). Separate plans for workforce identity are coming soon.
 
 </Aside>
+
+Workforce identity lets your team sign in to third-party tools using Kinde as the identity provider. Instead of managing a separate login for every tool your business runs on, you manage people once in Kinde and grant them access to the tools they need.
+
+Kinde acts as a SAML 2.0 identity provider (IdP). When someone on your team opens a connected tool, that tool asks Kinde to verify who they are, and Kinde returns a signed SAML assertion containing their identity and any attributes you choose to send.
+
 
 ## Workforce identity vs enterprise connections
 
@@ -67,13 +68,20 @@ If you want your customers to sign in to your product using their own company Id
 **Settings > Environment > Applications** is split into two sub-pages.
 
 - **Customer identity** holds your OAuth applications, which are the front-end, back-end and machine to machine apps that make up your own product. See [Applications in Kinde](/build/applications/about-applications/).
+
+    ![kinde customer identity](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/25c48602-811a-4201-72ce-30ed90d48000/socialsharingimage)
+
 - **Workforce identity** holds your SAML applications, which are the third-party tools your team signs in to.
+
+    ![kinde workforce identity](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/fdf5e9cf-c965-43a6-a5fe-e2c8efce6000/socialsharingimage)
 
 The two are managed separately and do not share configuration.
 
 ## The application catalog
 
 Kinde ships a catalog of around 120 pre-configured SAML applications, so most tools need only a couple of values to connect. The catalog includes Microsoft 365, Google Workspace, Slack and Salesforce, along with many HR, finance and IT tools.
+
+![workforce identity all apps](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/245249d8-6e2b-43f7-f6a9-c3c2b3657000/socialsharingimage)
 
 Catalog entries pre-fill what Kinde can know ahead of time, and many include an example SP entity ID, an example ACS URL, and a link to the vendor's own SAML setup guide.
 
@@ -106,6 +114,6 @@ If you set a logout URL on an application, Kinde supports SAML single logout for
 
 Single logout ends SAML sessions only. It does not sign the person out of Kinde, and it does not revoke access or refresh tokens for your own applications. Those end only through an explicit Kinde action such as signing out of Kinde, a credential change, or an admin action.
 
-## Next steps
+## Get started
 
-- [Add and configure a SAML application](/workforce-identity/add-saml-application/)
+- [Add a SAML application](/workforce-identity/add-saml-application/)

--- a/src/data/sidebarData.ts
+++ b/src/data/sidebarData.ts
@@ -199,6 +199,15 @@ const sidebarData = [
     ]
   },
   {
+    label: "Workforce identity",
+    description:
+      "Use Kinde as a SAML identity provider so your team can sign in to third-party tools",
+    icon: "workforce-identity",
+    collapsed: true,
+    cardLink: "/workforce-identity/",
+    autogenerate: {directory: "workforce-identity"}
+  },
+  {
     label: "Testing",
     description:
       "Test your application's authentication flows, passwordless flows, and backend APIs",

--- a/src/icons/workforce-identity.svg
+++ b/src/icons/workforce-identity.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 10V7C13 5.34315 14.3431 4 16 4C17.6569 4 19 5.34315 19 7V10" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 12V11.5C11 10.6716 11.6716 10 12.5 10H19.5C20.3284 10 21 10.6716 21 11.5V18.5C21 19.3284 20.3284 20 19.5 20H12.5C11.6716 20 11 19.3284 11 18.5V16.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="5" cy="13.5" r="2.5" stroke="black" stroke-width="2"/>
+<path d="M7.5 13.5H16V16.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

Kinde can now act as a SAML 2.0 **identity provider**, so a business's own staff can sign in to third-party tools such as Google Workspace, Microsoft 365, Slack and Salesforce using their Kinde identity. In the admin, **Settings > Environment > Applications** is now split into **Customer identity** (the existing OAuth apps) and **Workforce identity** (the new SAML apps).

This documents that feature. The main editorial risk is confusion with **enterprise connections**, which is the inverse: there Kinde is the *service provider* consuming a customer's IdP, here Kinde *is* the IdP. Every new page states that distinction explicitly, there's a comparison table on the concept page, and both enterprise-connections pages get a disambiguation link pointing the other way.

Workforce identity is documented as available on the **Scale plan**, via the usual `<Aside type="upgrade">` callout.

**New section — Workforce identity**

Added as a new top-level section rather than nested under Build > Applications, since it isn't an OAuth application and readers looking for it won't think to look there. Placed directly after *Auth and access* so the two SAML directions sit next to each other in the nav.

- `/workforce-identity/` — concept page: how it differs from enterprise connections, the app catalog, the three sign-in paths, access control, single logout
- `/workforce-identity/add-saml-application/` — how-to: SP config, IdP metadata, attribute mapping, RBAC, session/assertion lifetimes, signing and encryption, single logout, Test SSO, portal visibility, deletion, troubleshooting

Registered via `sidebarData.ts` (flat `autogenerate`, no `items` key) plus a new `src/icons/workforce-identity.svg`. The homepage card grid picks it up automatically.

**Updated pages**

- *Applications in Kinde* — new section explaining the Customer identity / Workforce identity split
- *Add and manage applications* — notes the split, and step 1 now names the **Customer identity** tab
- *Enable self-service portal for users* — new **Applications** portal module, with the conditions under which a tile appears
- *Manage enterprise connections* and *Custom SAML* — disambiguation links

**Drive-by fixes**

- `Breadcrumb.astro` only walked the sidebar to a fixed `section > group > article` depth, so flat top-level sections rendered an empty breadcrumb. Made the walk recursive. This fixes **13 pages** — the 2 new ones plus MCP Servers (4) and Testing (7), which have been silently missing breadcrumbs and DocSearch `lvl0` hierarchy. I diffed all 462 breadcrumbs site-wide: 13 changed, 449 byte-identical. Worth a closer look from a reviewer since it's a shared component.
- Two redirects: `/build/set-up-options/self-serve-portal-for-users/` has 404'd since the page was deleted in `f022deb4` (Sept 2025), and `/build/self-service-portal/` was the only Build subfolder with no section redirect.

**Verification**

`npm run build` passes; `scripts/validate-links.js` reports all internal links valid; no duplicate `page_id`s.

> ⚠️ Note for whoever runs lint: `npm run lint` globs all of `src/content/docs/**/*` and the tree isn't currently prettier-clean — running it reformats **269 unrelated files**. I formatted only the new files. Probably worth a separate housekeeping pass.

**Before merge**

Two screenshots still to capture (omitted rather than left as placeholder text): the Workforce identity catalog tab, and the IdP metadata tab with Test SSO.

Open questions for product — pages currently ship with the draft's assumptions:
- Catalog size is written as "around 120"; that figure will drift, so consider dropping the number
- Delete control on a SAML app is documented as a **Delete** overlay, but OAuth apps are documented as a three-dots menu — these should be described consistently
- Customer-facing label for the portal module toggle (module key is `user_applications`)
- Wording/timeframe for "separate plans coming soon"
- Whether **Import SP metadata** takes a URL, XML, or both (documented as both)
- Whether to keep the Name ID recommendation (prefer User ID when emails change) — sound SAML practice, but not stated in-product
- Confirmation there's no Management API coverage for SAML apps yet (none found)

The icon was hand-authored from a supplied 24×24 PNG, so if design has the original vector it's a one-file swap.

#### Related issues & labels (optional)

- Suggested label: `New section` (also touches `New doc` and `Update doc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Workforce Identity documentation covering SAML applications, configuration, access controls, sign-in flows, and troubleshooting.
  - Added Workforce Identity to documentation navigation and indexes.
  - Added guidance for launching connected workforce applications from the self-service portal.

- **Improvements**
  - Breadcrumbs now support deeply nested documentation structures.
  - Added redirects for updated self-service portal paths.
  - Clarified customer identity versus workforce identity applications.
  - Added related links, updated screenshots, and improved self-service portal setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->