### PR TITLE
docs: document Sinch Engage as a second SMS provider

### DIFF
--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -36,7 +36,7 @@ keywords:
   - social login
   - enterprise SSO
   - OTP
-updated: 2026-03-26
+updated: 2026-09-09
 ---
 
 Kinde supports the following authentication methods.
@@ -79,7 +79,7 @@ Kinde does not currently support magic links as a passwordless authentication me
 
 <Aside>
 
-You need to have a [Twilio](https://www.twilio.com/en-us) account set up before implementing phone authentication in your production environment. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/) for more information.
+You need to have an account with a supported SMS provider — [Twilio](https://www.twilio.com/en-us) or Sinch Engage — set up before implementing phone authentication in your production environment. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/) for more information.
 
 </Aside>
 
@@ -87,7 +87,7 @@ You can allow users to authenticate using their phone number as their sign in id
 
 ### Passwordless via SMS
 
-For users to receive a sign in code via SMS, you need to set up a connection to [Twilio](https://www.twilio.com/en-us), who offer a messaging service for authenticating via SMS. You will need a Twilio account to set up this auth option in Kinde. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/).
+For users to receive a sign in code via SMS, you need to set up a connection to a messaging provider. Kinde supports [Twilio](https://www.twilio.com/en-us) and Sinch Engage, and you will need an account with one of them to set up this auth option in Kinde. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/).
 
 Once set up, users will receive a one time code via SMS that enables them to complete the sign up process to your application or site.
 

--- a/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
+++ b/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
@@ -37,7 +37,7 @@ keywords:
   - auth
   - forgot password
   - password reset
-updated: 2026-03-26
+updated: 2026-09-09
 ---
 
 Here are concise answers to common authentication questions. Select a question to expand the answer.
@@ -124,7 +124,7 @@ No. Kinde does not support the Resource Owner Password Credentials (password) OA
 <details>
 <summary><strong>How do I troubleshoot users not receiving Kinde verification codes?</strong></summary>
 
-Ask users to check their spam folder first, as email filtering is a common cause. For SMS codes, confirm network reception and phone number formatting. Verification codes expire after 2 hours, so users may need to request a new code. If you use SMS authentication, verify that your Twilio configuration is correct.
+Ask users to check their spam folder first, as email filtering is a common cause. For SMS codes, confirm network reception and phone number formatting. Verification codes expire after 2 hours, so users may need to request a new code. If you use SMS authentication, verify that your SMS provider configuration is correct.
 [Passwordless authentication troubleshooting](/authenticate/authentication-methods/passwordless-authentication/)
 </details>
 
@@ -288,7 +288,7 @@ Keep the experience simple and explicit. Display the code prominently, include t
 <details>
 <summary><strong>What do I need to set up Kinde phone authentication for my users?</strong></summary>
 
-You need a paid Twilio business account because SMS delivery has carrier costs. Before setup, confirm whether 10DLC registration is required in your region and review Twilio A2P messaging requirements. Then add your Twilio configuration in Kinde, choose between a Twilio Messaging Service or a specific phone number, and set your default country.
+You need a paid account with a supported SMS provider — Twilio or Sinch Engage — because SMS delivery has carrier costs. Before setup, confirm whether 10DLC registration is required in your region and review your provider's A2P messaging requirements. Then select your provider in Kinde and add its credentials. For Twilio, choose between a Messaging Service or a specific phone number. For Sinch Engage, select your account region. Either way, set your default country.
 [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
@@ -364,7 +364,7 @@ Users can hit "forgot password" on the sign-in screen and we'll send them a one-
 <details>
 <summary><strong>How should I help users who are not receiving Kinde SMS auth codes?</strong></summary>
 
-Start with the basics - did they enter their phone number correctly with the right country code? Do they have cell reception? Are they in a country where SMS might be restricted? Then check your end - is your Twilio account funded and configured properly? SMS delivery can be finicky, especially internationally, so having backup contact methods is always smart.
+Start with the basics - did they enter their phone number correctly with the right country code? Do they have cell reception? Are they in a country where SMS might be restricted? Then check your end - is your SMS provider account funded and configured properly? SMS delivery can be finicky, especially internationally, so having backup contact methods is always smart.
 [Phone authentication setup](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
@@ -399,8 +399,8 @@ Common OAuth errors include `invalid_client` (incorrect client credentials), `in
 <details>
 <summary><strong>What should I check in Kinde when users report authentication is not working on mobile?</strong></summary>
 
-For mobile authentication, confirm deep-link configuration and URL schemes for both iOS and Android. Verify redirect URLs follow the expected custom scheme format, such as `myapp://your_kinde_domain.kinde.com/kinde_callback`. Use browser-based flows, because some providers (including Google) do not support webview-based authentication. If users are not receiving verification codes and Twilio is configured, review Twilio delivery logs.
-[React Native SDK](/developer-tools/sdks/native/react-native-sdk/) and [Set up phone auth with Twilio](/authenticate/authentication-methods/phone-authentication/)
+For mobile authentication, confirm deep-link configuration and URL schemes for both iOS and Android. Verify redirect URLs follow the expected custom scheme format, such as `myapp://your_kinde_domain.kinde.com/kinde_callback`. Use browser-based flows, because some providers (including Google) do not support webview-based authentication. If users are not receiving verification codes and you have configured your own SMS provider, review that provider's delivery logs.
+[React Native SDK](/developer-tools/sdks/native/react-native-sdk/) and [Set up phone auth](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
 <details>

--- a/src/content/docs/authenticate/about-auth/user-communication.mdx
+++ b/src/content/docs/authenticate/about-auth/user-communication.mdx
@@ -28,6 +28,7 @@ keywords:
   - OTP
   - verification
   - Twilio
+  - Sinch Engage
   - webhooks
 updated: 2026-03-03
 ---

--- a/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
@@ -27,7 +27,7 @@ keywords:
   - email code
   - phone code
   - security
-updated: 2025-01-16
+updated: 2026-09-09
 ---
 
 Passwordless authentication is a type of authentication that does not require end-users to set or maintain passwords for access to an application. Instead, they authenticate using a one-time passcode (OTP).
@@ -67,7 +67,7 @@ Passcodes issued from Kinde expire after 2 hours.
 
    <Aside>
 
-   **You can test this feature** but passwordless phone authentication requires that you have a [Twilio](https://www.twilio.com/en-us) account. You need to enter your Twilio account details and [upgrade to Kinde Pro](https://kinde.com/pricing/) if you want your users to authenticate this way. [Learn more](/authenticate/authentication-methods/phone-authentication/).
+   **You can test this feature** but passwordless phone authentication requires that you have an account with a supported SMS provider — [Twilio](https://www.twilio.com/en-us) or Sinch Engage. You need to enter your provider account details and [upgrade to Kinde Pro](https://kinde.com/pricing/) if you want your users to authenticate this way. [Learn more](/authenticate/authentication-methods/phone-authentication/).
 
    </Aside>
 

--- a/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
@@ -3,6 +3,8 @@ page_id: 8b9376c4-308c-4eaa-a990-606fb8bbf770
 title: Phone authentication
 sidebar:
   order: 6
+tableOfContents:
+  maxHeadingLevel: 3
 relatedArticles:
   - f18a5a74-23b3-43d8-8db9-440ee485e4d4
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
@@ -33,25 +35,223 @@ keywords:
 updated: 2026-09-09
 ---
 
-You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up. 
+<Aside type="upgrade">
 
-<Aside>
-
-This feature requires paid third-party services to use. Rates and limitations apply.
+Connecting your own third-party SMS provider requires the [Kinde Pro plan or higher](https://kinde.com/pricing/).
 
 </Aside>
 
-## (Existing phone auth Twilio users only) Switch on SMS for MFA
+You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up. 
 
-1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Scroll to the bottom and switch on the **Use this service for SMS MFA** option.
-3. Select **Save**.
+## What you need
 
-## Benefits of using a third-party SMS service instead of Kinde
+- A [Kinde](https://kinde.com/) account (Pro plan or higher, [see pricing](https://kinde.com/pricing/))
+- A paid third-party SMS provider account ([Twilio](https://www.twilio.com/en-us/messaging/channels/sms) and [Sinch Engage](https://sinch.com/engage/) are currently supported)
 
-- Gives you full control over the SMS delivery nuances, such as SenderID, country registrations, and detailed delivery metrics. 
-- You can register dedicated short codes or sender IDs in countries that have strict SMS sending regulations like Ireland, NZ and Canada, which will greatly improve deliverability.
-- Access to delivery logs and other service quality details for troubleshooting.
+## Configuration
+
+After you set this up, you can use SMS for both phone authentication and SMS MFA.
+
+### 1. Select SMS provider
+
+1. Sign in to your Kinde dashboard, go to **Settings > Environment > Messaging > SMS**.
+
+    ![setup sms provider in kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/b0e10ef0-26c5-4ca0-1954-05333d42ff00/socialsharingimage)
+
+2. Select the **Default country** that you want to show on the authentication screen when users sign in.
+3. Select a **Provider**:
+
+    - **Kinde default** – uses Kinde’s own SMS service. No credentials are needed, but you can’t take an environment live on this option.
+    - **Twilio** – your own Twilio account.
+    - **Sinch Engage** – your own Sinch Engage account.
+
+    The fields below the selector change to match the provider you choose.
+
+4. Enter the credentials for your chosen provider. See the configuration steps for each provider in the following sections.
+
+### Option 1: Twilio
+
+You need a [Twilio](https://www.twilio.com/en-us) business account to ensure messaging works for local and overseas phone numbers.
+
+We also recommend you check [Twilio’s guidelines for setting up messaging](https://www.twilio.com/en-us/guidelines/sms).
+
+#### 1. Get Twilio credentials
+
+1. Sign in to your Twilio dashboard and get the following credentials from your Console:
+
+    - The `Account SID`
+    - The `Auth Token`
+    - Your Twilio `phone number` or the `Messaging Service SID` (if you set one up)
+
+        ![Twilio account info](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1da93a0a-9fd3-437f-5357-be90f3f3c200/public)
+
+Refer to the [Twilio documentation](https://www.twilio.com/docs/messaging/quickstart) for assistance setting up.
+
+#### 2. Enable Twilio in Kinde
+
+1. Select **Twilio** in the **Provider** dropdown. Twilio settings will be displayed.
+2. Enter the **Account SID** and **Auth token** from your Twilio account.
+
+   ![configure twilio sms provider](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/3df95365-0da0-43e1-7f9d-f53ff2272e00/socialsharingimage)
+
+3. In the **SMS source** field, select either **Use messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
+
+   <Aside>
+
+   Note that the Twilio messaging service is more suitable for global applications as it detects where the sign in comes from and sends from an appropriate number.
+
+   </Aside>
+
+4. Depending on your selection in the previous step, enter either the **Messaging service SID** or Twilio **Phone number** in the relevant field.
+5. Select **Save**.
+
+#### Updating your Twilio credentials
+
+For security, Kinde never displays a stored API secret, so the **Auth token** field is blank when you return to the page.
+
+- If Twilio is already your selected provider, leave **Auth token** blank to keep the token you saved earlier. Enter a value only when you want to replace it.
+- If you are switching to Twilio from another provider, you must enter the **Auth token**. It can’t be left blank.
+
+### Option 2: Sinch Engage
+
+#### 1. Get Sinch Engage credentials
+
+1. Sign in to your [Sinch Engage](https://app.sinch.com) (formerly MessageMedia) dashboard.
+2. Go to **Settings > API Settings** and create a new **API key**.
+3. Copy both the `API key` and `API secret`
+
+    <Aside type="warning">
+
+    Sinch only shows the secret once, when the key is created, so copy and store it somewhere safe.
+
+    </Aside>
+
+4. Copy the region your Sinch Engage account is hosted in — `Asia Pacific` or `Europe`.
+
+    <Aside>
+
+    **Account region** is where your Sinch Engage account is hosted — it selects the API endpoint Kinde calls. It is not a restriction on where you can send messages. From either region you can send to phone numbers in any country, subject to your provider's registration requirements for those countries.
+
+    </Aside>
+
+#### 2. Enable Sinch Engage in Kinde
+
+1. Select **Sinch Engage** in the **Provider** dropdown. Sinch Engage settings will be displayed.
+
+    ![setup sms provider in kinde](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/b0e10ef0-26c5-4ca0-1954-05333d42ff00/socialsharingimage)
+
+2. Enter the **API key** and **API secret** from your Sinch Engage account.
+
+    ![configure sinch engage sms provider](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/2bc20701-40ba-4d80-0f09-d36d98d57900/socialsharingimage)
+
+3. Select your **Account region** — either **Asia Pacific (au.app.api.sinch.com)** or **Europe (eu.app.api.sinch.com)**. Messages are sent through this region’s API endpoint, so it must match the region your Sinch Engage account is hosted in.
+4. Optionally enter a **Source number**. Leave it blank to use your account default. Include the country code, with no spaces.
+5. If you entered a source number, select the **Source number type** to one of the following:
+
+    ![sinch engage source number type](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1208d264-bc2b-425e-9059-8aec9b067400/socialsharingimage)
+
+    - Detect automatically 
+    - International
+    - Alphanumeric
+    - Short code
+    
+    <Aside>
+
+    Leave it on **Detect automatically** to let Sinch Engage work it out.
+
+    </Aside>
+
+6. Select **Save**.
+
+<Aside type="warning">
+
+Dedicated source numbers are not enabled by default on Sinch Engage accounts and must be registered with Sinch first. If you enter a source number that is not registered to your account, messages will fail to send.
+
+</Aside>
+
+<Aside>
+
+Sinch Engage’s automatic detection of the source number type can be inaccurate for alphanumeric and short code sources. If your messages are not arriving and you use one of those source types, set the **Source number type** explicitly instead of leaving it on automatic.
+
+</Aside>
+
+#### Updating your Sinch Engage credentials
+
+For security, Kinde never displays a stored API secret, so the **API secret** field is blank when you return to the page.
+
+- If Sinch Engage is already your selected provider, leave **API secret** blank to keep the secret you saved earlier. Enter a value only when you want to replace it.
+- If you are switching to Sinch Engage from another provider, you must enter the **API secret**. It can’t be left blank.
+
+<Aside type="warning">
+
+SMS sent through your own Twilio or Sinch Engage credentials is not billed by Kinde. The fallback service uses Kinde’s own SMS provider, so any message it sends is billed to your Kinde account at standard rates. Leave the fallback switched off if you do not want that.
+
+</Aside>
+
+<Aside>
+
+Switching provider does not delete the credentials you saved for the previous provider — Kinde keeps the retired connection so that SMS messages already queued against it can still be delivered. The settings page only ever shows the fields for the provider that is currently selected.
+
+</Aside>
+
+### 3. Set Kinde as fallback SMS provider
+
+With a third-party SMS provider configured, you can set Kinde as a fallback service.
+
+1. Scroll down to the end of the page and enable **Allow Kinde to use fallback SMS provider**.
+
+    ![allow kinde to use fallback sms provider](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/5b912b9f-3fb2-4698-78e4-fb6bf5b01c00/socialsharingimage)
+
+    <Aside>
+
+    If the primary provider is experiencing issues, Kinde may switch to a fallback provider. Delivery cannot be guaranteed.
+
+    </Aside>
+
+2. Select **Save**.
+
+### 4. Switch on phone authentication for an application
+
+1. Go to your Kinde dashboard, and select **View details** on your prefered application tile.
+2. Select **Authentication** from the left menu.
+3. Enable **Code** from the **Phone connections** section.
+
+    ![enable phone authentication](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/227ebc3c-766d-4787-4da8-fd35de309900/socialsharingimage)
+
+4. Select **Save**.
+
+You can also enable the connection for multiple applications at once:
+
+1. Go to **Settings > Environment > Authentication**.
+2. In the **Phone connections** section, select **Configure** on the **Code** tile.
+
+    ![enable phone connections tile](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/cdd4976f-6461-4dff-196b-dddde03e5700/socialsharingimage)
+
+3. Check each of the applications you want to enable phone authentication for.
+
+    ![enable phone connections for multiple applications](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/e316d930-1cce-419f-c032-81692e48f900/socialsharingimage)
+
+4. Select **Save**.
+
+You can also find the `connection ID` in this popup. Connection ID is useful when building a [custom authentication experience](/authenticate/custom-configurations/custom-authentication-pages/), you’ll need the ID to trigger the phone authentication workflow.
+
+![get connection id popup](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/fc3d269b-5e40-42ba-16e0-c36a4e621a00/socialsharingimage)
+
+### Optional: Enable SMS as a factor in MFA
+
+You can use the same third-party SMS service as a factor in multi-factor authentication.
+
+1. Go to **Settings > Environment > Multi-factor auth**.
+2. Under **Require multi-factor authentication**, select **Yes** or **Optional**.
+    More settings appear.
+
+    ![kinde enable mfa setting page](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/a4292026-d483-469b-859b-878de853ce00/socialsharingimage)
+
+3. Under **Additional authentication methods**, switch on **SMS**.
+
+    ![enable sms as mfa factor](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/40515cfc-2d2a-4f40-287a-fb9e80713f00/socialsharingimage)
+
+4. Select **Save**.
 
 ## SMS provider requirements
 
@@ -61,12 +261,6 @@ SMS authentication requires the services of a messaging provider. Kinde supports
 - **Sinch Engage** (formerly MessageMedia)
 
 You need an account with one of these providers to use phone authentication in a live environment.
-
-<Aside type="upgrade">
-
-Connecting your own SMS provider requires the [Kinde Pro plan or higher](https://kinde.com/pricing/). On the Free plan you can test phone authentication with the **Kinde default** provider, but you can’t connect your own Twilio or Sinch Engage credentials.
-
-</Aside>
 
 <Aside>
 
@@ -82,168 +276,34 @@ Phone authentication interactions are also known as [A2P (Application to Person)
 
 Whichever provider you choose, carefully follow their procedures for registration, and their SMS policies for all relevant countries.
 
-## Set up Twilio
+## Glossary
 
-You need a [Twilio](https://www.twilio.com/en-us) business account to ensure messaging works for local and overseas phone numbers.
+### Using Kinde as an SMS provider
 
-We also recommend you check [Twilio’s guidelines for setting up messaging](https://www.twilio.com/en-us/guidelines/sms).
+If you just want to test this feature first, select **Kinde default** as the provider — no credentials are needed. On the free plan, Kinde allows 10 phone OTP messages per month. Paid plans have no monthly cap, and SMS is charged per message — see [pricing](https://kinde.com/pricing/).
 
-### What you need
+The monthly allowance counts phone OTP used as a first factor. SMS sent as a second factor for MFA is not counted against it.
 
-You’ll need the following details that are in the dashboard of your [Twilio account](https://www.twilio.com/en-us).
+### Benefits of using a third-party SMS service instead of Kinde
 
-- The SID of your Twilio account
-- The Auth Token for your Twilio account
-- Your Twilio phone number or the Messaging Service SID (if you set one up)
+- Gives you full control over the SMS delivery nuances, such as SenderID, country registrations, and detailed delivery metrics. 
+- You can register dedicated short codes or sender IDs in countries that have strict SMS sending regulations like Ireland, NZ and Canada, which will greatly improve deliverability.
+- Access to delivery logs and other service quality details for troubleshooting.
 
-![Twilio account info](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/1da93a0a-9fd3-437f-5357-be90f3f3c200/public)
+### SMS message format
 
-Refer to the [Twilio documentation](https://www.twilio.com/docs/messaging/services/tutorials/send-messages-with-messaging-services) for assistance setting up.
+We use a standard format as follows, to allow for easier translation.
 
-### Configure Twilio
-
-1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Select **Twilio** in the **Provider** field.
-3. Enter the **Account SID** and **Auth token** from your Twilio account.
-
-   ![twilio details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4c857ff9-ff87-44ea-a488-3e2b511caf00/public)
-
-4. In the **SMS source** field, select either **Use messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
-
-   <Aside>
-
-   Note that the Twilio messaging service is more suitable for global applications as it detects where the sign in comes from and sends from an appropriate number.
-
-   </Aside>
-
-5. Depending on your selection in the previous step, enter either the **Messaging service SID** or Twilio **Phone number** in the relevant field.
-
-   ![Twilio config](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/749a80bc-d6b7-40b0-950a-650c7775b900/public)
-
-6. Select **Save**.
-
-<Aside>
-
-For security, Kinde never displays a stored auth token, so the **Auth token** field is blank when you return to the page. If Twilio is already your selected provider, leave it blank to keep the token you saved earlier. If you are switching to Twilio from another provider, you must enter the auth token.
-
-</Aside>
-
-## Set up Sinch Engage
-
-Sinch Engage (formerly MessageMedia) is an alternative to Twilio. You need a Sinch Engage account at [app.sinch.com](https://app.sinch.com).
-
-### What you need
-
-- An **API key**, created under **Settings > API Settings** in your Sinch Engage account.
-- The **API secret** created alongside that key. Sinch only shows the secret once, when the key is created, so store it somewhere safe.
-- The region your Sinch Engage account is hosted in — Asia Pacific or Europe.
-
-<Aside>
-
-**Account region** is where your Sinch Engage account is hosted — it selects the API endpoint Kinde calls. It is not a restriction on where you can send messages. From either region you can send to phone numbers in any country, subject to your provider's registration requirements for those countries.
-
-</Aside>
-
-### Configure Sinch Engage
-
-1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Select **Sinch Engage** in the **Provider** field.
-3. Enter your **API key**.
-4. Enter your **API secret**.
-5. Select your **Account region** — either **Asia Pacific (au.app.api.sinch.com)** or **Europe (eu.app.api.sinch.com)**. Messages are sent through this region’s API endpoint, so it must match the region your Sinch Engage account is hosted in.
-6. Optionally enter a **Source number**. Leave it blank to use your account default. Include the country code, with no spaces.
-7. If you entered a source number, select the **Source number type** — **International**, **Alphanumeric**, or **Short code**. Leave it on **Detect automatically** to let Sinch Engage work it out.
-8. Select **Save**.
-
-<Aside type="danger" title="Screenshot needed before publishing">
-
-Add a screenshot of the SMS settings page with **Sinch Engage** selected, showing the **API key**, **API secret**, **Account region**, **Source number**, and **Source number type** fields. Upload it to Cloudflare Images, then replace this callout with the image.
-
-</Aside>
+    ```text title="SMS message format"
+    Your verification code is XXXXXX
+    ```
 
 <Aside type="warning">
 
-Dedicated source numbers are not enabled by default on Sinch Engage accounts and must be registered with Sinch first. If you enter a source number that is not registered to your account, messages will fail to send.
+You can’t customize the code message that user’s receive. 
 
 </Aside>
 
-<Aside>
+### Taking the environment live
 
-Sinch Engage’s automatic detection of the source number type can be inaccurate for alphanumeric and short code sources. If your messages are not arriving and you use one of those source types, set the **Source number type** explicitly instead of leaving it on automatic.
-
-</Aside>
-
-### Updating your Sinch Engage credentials
-
-For security, Kinde never displays a stored API secret, so the **API secret** field is blank when you return to the page.
-
-- If Sinch Engage is already your selected provider, leave **API secret** blank to keep the secret you saved earlier. Enter a value only when you want to replace it.
-- If you are switching to Sinch Engage from another provider, you must enter the **API secret**. It can’t be left blank.
-
-## Configure phone SMS auth in Kinde
-
-After you set this up, you can use SMS for both phone authentication and SMS MFA.
-
-1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Select the **Default country** that you want to show on the authentication screen when users sign in.
-3. Select a **Provider**:
-
-   - **Kinde default** – uses Kinde’s own SMS service. No credentials are needed, but you can’t take an environment live on this option.
-   - **Twilio** – your own Twilio account.
-   - **Sinch Engage** – your own Sinch Engage account.
-
-   The fields below the selector change to match the provider you choose.
-
-   <Aside type="danger" title="Screenshot needed before publishing">
-
-   Add a screenshot of the SMS settings page with the **Provider** dropdown expanded, showing the **Kinde default**, **Twilio**, and **Sinch Engage** options. Upload it to Cloudflare Images, then replace this callout with the image.
-
-   </Aside>
-
-4. Enter the credentials for your chosen provider. See [Set up Twilio](#set-up-twilio) or [Set up Sinch Engage](#set-up-sinch-engage) above.
-5. Select if you want to use a fallback service if the provider service is interrupted. Delivery can’t be guaranteed when a fallback is used.
-
-   ![option to use kinde sms as fallback](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/9bdd2ef1-c308-4307-c84e-bc8ffdbfe200/public)
-
-6. Select **Save**.
-
-<Aside type="warning">
-
-SMS sent through your own Twilio or Sinch Engage credentials is not billed by Kinde. The fallback service uses Kinde’s own SMS provider, so any message it sends is billed to your Kinde account at standard rates. Leave the fallback switched off if you do not want that.
-
-</Aside>
-
-<Aside>
-
-Switching provider does not delete the credentials you saved for the previous provider — Kinde keeps the retired connection so that SMS messages already queued against it can still be delivered. The settings page only ever shows the fields for the provider that is currently selected.
-
-</Aside>
-
-## Switch on phone authentication for an application
-
-After you have set up your SMS provider, you’re ready to switch on phone or SMS auth for your applications.
-
-1. Go to **Settings > Environment > Authentication**.
-2. In the **Passwordless** section, select **Configure** on the **Phone** tile.
-3. Switch on the auth method for the applications you want.
-4. Select **Save**.
-
-## Switch on SMS as a factor in MFA
-
-If MFA is required or optional for your users, you may want to use your SMS provider for SMS MFA.
-
-1. Go to **Settings > Environment > Multi-factor auth**.
-2. Under **Additional authentication methods**, switch on **SMS**.
-3. Select **Save**.
-
-## SMS message format
-
-You can’t customize the code message that user’s receive. We use a standard format as follows, to allow for easier translation.
-
-      ```
-      Your verification code is [xxxxxx]
-      ```
-
-## Connection ID
-
-When you configure phone authentication, you’ll see that a Connection ID is automatically assigned. If you’re building a [custom authentication experience](/authenticate/custom-configurations/custom-authentication-pages/), you’ll need the ID to trigger the phone authentication workflow.
+You need to switch to a third-party SMS provider to take the environment live. See the [Go live checklist](/build/environments/production-to-live/)

--- a/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
@@ -8,8 +8,8 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
 description: >-
-  Complete setup guide for phone/SMS authentication using Twilio, including
-  configuration, MFA integration, and message formatting.
+  Complete setup guide for phone/SMS authentication using Twilio or Sinch
+  Engage, including configuration, MFA integration, and message formatting.
 featured: false
 deprecated: false
 topics:
@@ -24,11 +24,13 @@ keywords:
   - phone authentication
   - SMS
   - Twilio
+  - Sinch Engage
+  - MessageMedia
   - MFA
   - A2P messaging
   - 10DLC
   - verification code
-updated: 2026-03-03
+updated: 2026-09-09
 ---
 
 You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up. 
@@ -51,23 +53,42 @@ This feature requires paid third-party services to use. Rates and limitations ap
 - You can register dedicated short codes or sender IDs in countries that have strict SMS sending regulations like Ireland, NZ and Canada, which will greatly improve deliverability.
 - Access to delivery logs and other service quality details for troubleshooting.
 
-## SMS provider requirements (Twilio)
+## SMS provider requirements
 
-SMS authentication requires the services of a messaging provider, in this case, [Twilio](https://www.twilio.com/en-us).
+SMS authentication requires the services of a messaging provider. Kinde supports two:
 
-You need a [Twilio](https://www.twilio.com/en-us) business account to ensure messaging works for local and overseas phone numbers.
+- **Twilio**
+- **Sinch Engage** (formerly MessageMedia)
 
-Phone authentication interactions are also known as [A2P (Application to Person)](https://www.twilio.com/docs/glossary/what-a2p-sms-application-person-messaging) messaging. Before you implement A2P, check if you need to register your business for 10DLC (10 Digit Long Code) support to be able to send messages, as this is required in some locations.
+You need an account with one of these providers to use phone authentication in a live environment.
 
-We also recommend you check [Twilio’s guidelines for setting up messaging](https://www.twilio.com/en-us/guidelines/sms), and carefully follow procedures for registration, and SMS policies for all relevant countries.
+<Aside type="upgrade">
 
-## What you need
+Connecting your own SMS provider requires the [Kinde Pro plan or higher](https://kinde.com/pricing/). On the Free plan you can test phone authentication with the **Kinde default** provider, but you can’t connect your own Twilio or Sinch Engage credentials.
+
+</Aside>
 
 <Aside>
 
-If you just want to test this feature first, Kinde allows you to send 10 SMS messages per month without setting up Twilio. If you want the feature to be live for your users, you must implement the full Twilio setup.
+If you just want to test this feature first, select **Kinde default** as the provider — no credentials are needed. On the free plan, Kinde allows 10 phone OTP messages per month. Paid plans have no monthly cap, and SMS is charged per message — see [pricing](https://kinde.com/pricing/).
+
+The monthly allowance counts phone OTP used as a first factor. SMS sent as a second factor for MFA is not counted against it.
+
+You can’t take an environment live on **Kinde default** — to go live, you must switch to Twilio or Sinch Engage.
 
 </Aside>
+
+Phone authentication interactions are also known as [A2P (Application to Person)](https://www.twilio.com/docs/glossary/what-a2p-sms-application-person-messaging) messaging. Before you implement A2P, check if you need to register your business for 10DLC (10 Digit Long Code) support to be able to send messages, as this is required in some locations.
+
+Whichever provider you choose, carefully follow their procedures for registration, and their SMS policies for all relevant countries.
+
+## Set up Twilio
+
+You need a [Twilio](https://www.twilio.com/en-us) business account to ensure messaging works for local and overseas phone numbers.
+
+We also recommend you check [Twilio’s guidelines for setting up messaging](https://www.twilio.com/en-us/guidelines/sms).
+
+### What you need
 
 You’ll need the following details that are in the dashboard of your [Twilio account](https://www.twilio.com/en-us).
 
@@ -79,17 +100,15 @@ You’ll need the following details that are in the dashboard of your [Twilio ac
 
 Refer to the [Twilio documentation](https://www.twilio.com/docs/messaging/services/tutorials/send-messages-with-messaging-services) for assistance setting up.
 
-## Configure phone SMS auth in Kinde
-
-After you set this up, you can use SMS for both phone authentication and SMS MFA.
+### Configure Twilio
 
 1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Select the **Default country** that you want to show on the authentication screen when users sign in.
-3. Enter the Twilio details from your Twilio account (see above) in the relevant fields.
+2. Select **Twilio** in the **Provider** field.
+3. Enter the **Account SID** and **Auth token** from your Twilio account.
 
    ![twilio details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4c857ff9-ff87-44ea-a488-3e2b511caf00/public)
- 
-4. In the **SMS source** field, select either the **Use** **Messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
+
+4. In the **SMS source** field, select either **Use messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
 
    <Aside>
 
@@ -101,15 +120,108 @@ After you set this up, you can use SMS for both phone authentication and SMS MFA
 
    ![Twilio config](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/749a80bc-d6b7-40b0-950a-650c7775b900/public)
 
-6. Select if you want to use a fallback service if the provider service is interrupted.
+6. Select **Save**.
+
+<Aside>
+
+For security, Kinde never displays a stored auth token, so the **Auth token** field is blank when you return to the page. If Twilio is already your selected provider, leave it blank to keep the token you saved earlier. If you are switching to Twilio from another provider, you must enter the auth token.
+
+</Aside>
+
+## Set up Sinch Engage
+
+Sinch Engage (formerly MessageMedia) is an alternative to Twilio. You need a Sinch Engage account at [app.sinch.com](https://app.sinch.com).
+
+### What you need
+
+- An **API key**, created under **Settings > API Settings** in your Sinch Engage account.
+- The **API secret** created alongside that key. Sinch only shows the secret once, when the key is created, so store it somewhere safe.
+- The region your Sinch Engage account is hosted in — Asia Pacific or Europe.
+
+<Aside>
+
+**Account region** is where your Sinch Engage account is hosted — it selects the API endpoint Kinde calls. It is not a restriction on where you can send messages. From either region you can send to phone numbers in any country, subject to your provider's registration requirements for those countries.
+
+</Aside>
+
+### Configure Sinch Engage
+
+1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
+2. Select **Sinch Engage** in the **Provider** field.
+3. Enter your **API key**.
+4. Enter your **API secret**.
+5. Select your **Account region** — either **Asia Pacific (au.app.api.sinch.com)** or **Europe (eu.app.api.sinch.com)**. Messages are sent through this region’s API endpoint, so it must match the region your Sinch Engage account is hosted in.
+6. Optionally enter a **Source number**. Leave it blank to use your account default. Include the country code, with no spaces.
+7. If you entered a source number, select the **Source number type** — **International**, **Alphanumeric**, or **Short code**. Leave it on **Detect automatically** to let Sinch Engage work it out.
+8. Select **Save**.
+
+<Aside type="danger" title="Screenshot needed before publishing">
+
+Add a screenshot of the SMS settings page with **Sinch Engage** selected, showing the **API key**, **API secret**, **Account region**, **Source number**, and **Source number type** fields. Upload it to Cloudflare Images, then replace this callout with the image.
+
+</Aside>
+
+<Aside type="warning">
+
+Dedicated source numbers are not enabled by default on Sinch Engage accounts and must be registered with Sinch first. If you enter a source number that is not registered to your account, messages will fail to send.
+
+</Aside>
+
+<Aside>
+
+Sinch Engage’s automatic detection of the source number type can be inaccurate for alphanumeric and short code sources. If your messages are not arriving and you use one of those source types, set the **Source number type** explicitly instead of leaving it on automatic.
+
+</Aside>
+
+### Updating your Sinch Engage credentials
+
+For security, Kinde never displays a stored API secret, so the **API secret** field is blank when you return to the page.
+
+- If Sinch Engage is already your selected provider, leave **API secret** blank to keep the secret you saved earlier. Enter a value only when you want to replace it.
+- If you are switching to Sinch Engage from another provider, you must enter the **API secret**. It can’t be left blank.
+
+## Configure phone SMS auth in Kinde
+
+After you set this up, you can use SMS for both phone authentication and SMS MFA.
+
+1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
+2. Select the **Default country** that you want to show on the authentication screen when users sign in.
+3. Select a **Provider**:
+
+   - **Kinde default** – uses Kinde’s own SMS service. No credentials are needed, but you can’t take an environment live on this option.
+   - **Twilio** – your own Twilio account.
+   - **Sinch Engage** – your own Sinch Engage account.
+
+   The fields below the selector change to match the provider you choose.
+
+   <Aside type="danger" title="Screenshot needed before publishing">
+
+   Add a screenshot of the SMS settings page with the **Provider** dropdown expanded, showing the **Kinde default**, **Twilio**, and **Sinch Engage** options. Upload it to Cloudflare Images, then replace this callout with the image.
+
+   </Aside>
+
+4. Enter the credentials for your chosen provider. See [Set up Twilio](#set-up-twilio) or [Set up Sinch Engage](#set-up-sinch-engage) above.
+5. Select if you want to use a fallback service if the provider service is interrupted. Delivery can’t be guaranteed when a fallback is used.
 
    ![option to use kinde sms as fallback](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/9bdd2ef1-c308-4307-c84e-bc8ffdbfe200/public)
 
-7. Select **Save**.
+6. Select **Save**.
+
+<Aside type="warning">
+
+SMS sent through your own Twilio or Sinch Engage credentials is not billed by Kinde. The fallback service uses Kinde’s own SMS provider, so any message it sends is billed to your Kinde account at standard rates. Leave the fallback switched off if you do not want that.
+
+</Aside>
+
+<Aside>
+
+Switching provider does not delete the credentials you saved for the previous provider — Kinde keeps the retired connection so that SMS messages already queued against it can still be delivered. The settings page only ever shows the fields for the provider that is currently selected.
+
+</Aside>
 
 ## Switch on phone authentication for an application
 
-After you have set up Twilio details, you’re ready to switch on phone or SMS auth for your applications.
+After you have set up your SMS provider, you’re ready to switch on phone or SMS auth for your applications.
 
 1. Go to **Settings > Environment > Authentication**.
 2. In the **Passwordless** section, select **Configure** on the **Phone** tile.
@@ -118,7 +230,7 @@ After you have set up Twilio details, you’re ready to switch on phone or SMS a
 
 ## Switch on SMS as a factor in MFA
 
-If MFA is required or optional for your users, you may want to use the Twilio service for SMS MFA.
+If MFA is required or optional for your users, you may want to use your SMS provider for SMS MFA.
 
 1. Go to **Settings > Environment > Multi-factor auth**.
 2. Under **Additional authentication methods**, switch on **SMS**.

--- a/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
+++ b/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
@@ -23,6 +23,7 @@ complexity: intermediate
 keywords:
   - SMS deliverability
   - Twilio
+  - Sinch Engage
   - sender ID
   - regional delivery
   - 10DLC

--- a/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
@@ -8,13 +8,14 @@ relatedArticles:
   - 90134c89-16e4-4981-b988-b0cb4f1722c5
 tableOfContents:
   maxHeadingLevel: 3
-description: >-
-  Configure WhatsApp in Kinde to send OTP and MFA codes via WhatsApp, with
-  fallback to SMS. Uses your Meta/WhatsApp Business account.
+description: "Send OTP and MFA codes via WhatsApp in Kinde, use your Meta Business account with automatic SMS fallback"
 featured: false
 deprecated: false
 topics:
   - authenticate
+  - authentication-methods
+  - whatsapp
+  - mfa
 sdk: []
 languages: []
 audience:
@@ -22,26 +23,32 @@ audience:
   - product-manager
 complexity: intermediate
 keywords:
-  - WhatsApp
-  - OTP
+  - whatsapp otp
   - MFA
-  - Meta
-  - WhatsApp Business
-  - messaging
-updated: 2026-03-03
+  - SMS fallback
+  - whatsapp business
+  - meta
+  - message templates
+  - passwordless
+  - phone authentication
+ai_summary: "Guide to configuring WhatsApp in Kinde so OTP and MFA codes can be delivered over WhatsApp when available. Covers prerequisites: a verified WhatsApp Business account in Meta, a WhatsApp API token, a WhatsApp Business Account ID, and an optional SMS provider in Kinde for fallback. Walks through dashboard setup under Settings, Environment, Messaging, WhatsApp: enable WhatsApp, enter token and Business Account ID, optionally set a template name, run Sync WhatsApp, choose a sending phone number, and save. Explains that Kinde prefers WhatsApp and falls back to SMS if delivery fails and SMS is configured. FAQ covers Kinde plan and message limits (same 10-message monthly cap as SMS), Meta per-message charges, and changing WhatsApp message language via environment languages then re-syncing, with en-US fallback for unsupported languages. Troubleshooting covers template create or sync failures from Meta account or credential issues, and undelivered messages due to phone format, regional WhatsApp availability, or missing SMS fallback. Intended for developers and product managers."
+updated: 2026-09-11
 ---
 
 You can send one-time passcodes (OTP) and multi-factor authentication (MFA) codes via **WhatsApp** in addition to SMS. When WhatsApp is set up and enabled, Kinde prefers WhatsApp for delivering codes and falls back to SMS if WhatsApp delivery fails and SMS is configured.
 
-### What you need
+## What you need
 
 - A verified **WhatsApp Business account** in Meta
 - **WhatsApp API token** (access token) and **WhatsApp Business Account ID**
-- A configured [SMS provider in Kinde](/authenticate/authentication-methods/phone-authentication/#configure-phone-sms-auth-in-kinde) if you want fallback delivery
+- A configured [SMS provider in Kinde](/authenticate/authentication-methods/phone-authentication/) if you want fallback delivery
 
-## Configure WhatsApp in Kinde
+## Configuration
 
 1. In Kinde, go to **Settings > Environment > Messaging > WhatsApp**
+
+    ![whatsapp sms authentication settings](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/79a917d1-0299-440e-293c-4903c8af6400/socialsharingimage)
+
 2. Turn on **Enable WhatsApp**
 3. Enter your **WhatsApp token** (from Meta)
 4. Enter your **WhatsApp Business Account ID**
@@ -52,6 +59,8 @@ You can send one-time passcodes (OTP) and multi-factor authentication (MFA) code
 9. Select **Save**
 
 After saving, Kinde sends OTP and MFA codes through WhatsApp when available, and falls back to SMS if delivery fails and SMS is configured.
+
+## FAQ
 
 ### Do I need a paid Kinde plan to use WhatsApp authentication?
 

--- a/src/content/docs/build/environments/production-to-live.mdx
+++ b/src/content/docs/build/environments/production-to-live.mdx
@@ -33,13 +33,14 @@ keywords:
   - multi-factor authentication
   - terms of use and privacy policy
   - default roles
-  - twilio sms authentication
+  - sms authentication
+  - sinch engage
   - custom email sender
   - google analytics
-updated: 2026-05-27
+updated: 2026-09-09
 featured: false
 deprecated: false
-ai_summary: "This guide helps you prepare a Kinde production environment before marking it as Live. It covers required setup for third-party authentication credentials and Twilio SMS configuration, then walks through recommended business readiness steps in priority order. These include adding terms and privacy policy URLs, enabling multi-factor authentication, setting default roles, connecting a custom domain, configuring a branded email sender, adding tracking scripts, and creating additional development environments. The page also clarifies that the Live switch is a status indicator only and does not publish or change app behavior."
+ai_summary: "This guide helps you prepare a Kinde production environment before marking it as Live. It covers required setup for third-party authentication credentials and SMS provider configuration (Twilio or Sinch Engage), then walks through recommended business readiness steps in priority order. These include adding terms and privacy policy URLs, enabling multi-factor authentication, setting default roles, connecting a custom domain, configuring a branded email sender, adding tracking scripts, and creating additional development environments. The page also clarifies that the Live switch is a status indicator only and does not publish or change app behavior."
 ---
 
 Use this checklist to prepare your Kinde production environment before you mark it as `Live`.
@@ -75,14 +76,23 @@ Enter a `Client ID` and `Client secret` in all your third-party authentication c
 Check out the specific connection page for steps for each provider in the [third-party authentication](/authenticate/authentication-methods/set-up-user-authentication/) section.
 
 
-### Add Twilio details
+### Add SMS provider details
 
-If you are using phone or SMS authentication, configure your Twilio details. Kinde provides 10 SMS messages per month for free to test this feature. To use the full feature set, enter your Twilio credentials:
+If the **Phone** authentication method is switched on for any application in this environment, you must select **Twilio** or **Sinch Engage** as your SMS provider before the environment can go live. Either provider satisfies the requirement.
+
+The **Kinde default** provider is for testing only — on the free plan it allows 10 phone OTP messages per month — and Kinde blocks the switch to `Live` while phone authentication is in use and the provider is still set to **Kinde default**.
+
+<Aside type="upgrade">
+
+Connecting your own SMS provider requires the [Kinde Pro plan or higher](https://kinde.com/pricing/). If you use phone authentication, you will need a paid plan to take this environment live.
+
+</Aside>
 
 1. Go to **Settings > Environment > Messaging > SMS**.
 2. Select the **Default country** that you want to show on the authentication screen when users sign in.
-3. Enter the Twilio details from your Twilio account in the relevant fields.
-4. Select **Save**.
+3. Select either **Twilio** or **Sinch Engage** in the **Provider** field.
+4. Enter the credentials from your provider account in the relevant fields.
+5. Select **Save**.
 
 Learn more about [phone or SMS authentication](/authenticate/authentication-methods/phone-authentication/).
 

--- a/src/content/docs/get-started/guides/error-codes.mdx
+++ b/src/content/docs/get-started/guides/error-codes.mdx
@@ -23,7 +23,7 @@ keywords:
   - oauth errors
   - verification codes
   - token errors
-updated: 2026-05-29
+updated: 2026-09-09
 featured: false
 deprecated: false
 ai_summary: Comprehensive troubleshooting guide for common Kinde error codes including authentication, SAML, OAuth, and verification issues.
@@ -74,7 +74,7 @@ Verification codes are sent almost immediately when triggered. If a code is not 
 - Full storage preventing new messages from being received
 - Phone numbers in certain countries do sometimes experience issues. Contact us if you think this might be the case. 
 
-We recommend using [Twilio](/authenticate/authentication-methods/phone-authentication/), a third-party SMS provider instead of Kinde's default service. This makes troubleshooting issues and accessing logs much easier.
+We recommend [configuring your own SMS provider](/authenticate/authentication-methods/phone-authentication/) — Twilio or Sinch Engage — instead of using Kinde's default service. This makes troubleshooting issues and accessing logs much easier.
 
 ## Email verification error code 123f11e6453744da8069f1a6d65247ba
 


### PR DESCRIPTION
#### Description (required)

Kinde now supports **Sinch Engage** (formerly MessageMedia) alongside Twilio as a bring-your-own-credentials SMS provider, selected through a new `Provider` dropdown on **Settings > Environment > Messaging > SMS**.

This is not a purely additive change. The SMS settings page was previously a Twilio-only form where the provider was inferred from whichever credential fields were filled in. Every existing customer who opens the page now sees the provider selector, so the current Twilio instructions were incomplete rather than merely missing a provider. Selecting Sinch Engage also satisfies the "configure your SMS provider" requirement for taking an environment live, which previously only Twilio did.

Changes include:

- Restructure [Phone authentication](https://docs.kinde.com/authenticate/authentication-methods/phone-authentication/) into symmetrical `Set up Twilio` and `Set up Sinch Engage` sections, and rewrite `Configure phone SMS auth in Kinde` as a provider-agnostic entry point covering the new selector.
- Document the Sinch Engage fields: API key, API secret, account region (`au.app.api.sinch.com` / `eu.app.api.sinch.com`), optional source number, and source number type, plus the blank-secret behaviour when updating credentials.
- Clarify that `Account region` is where your Sinch Engage account is hosted and selects the API endpoint Kinde calls. It is not a restriction on destination countries, which the two-region list could otherwise imply.
- Make the SMS provider requirements provider-neutral, and note that connecting your own provider requires the Kinde Pro plan or higher.
- Correct the free-plan SMS allowance, which was documented as a flat "10 SMS per month". It is a Free-plan entitlement covering phone OTP as a first factor; SMS sent as a second factor for MFA is not counted against it.
- Document that the fallback SMS toggle routes through Kinde's own provider and is therefore billed, whereas sends through your own Twilio or Sinch Engage credentials are not.
- Rename `Add Twilio details` to `Add SMS provider details` on the [go live checklist](https://docs.kinde.com/build/environments/production-to-live/) and state the condition that blocks go-live, rather than quoting the product error string.
- Correct Twilio-only claims that this change makes untrue on `authentication-methods.mdx`, `passwordless-authentication.mdx`, `kinde-authentication-faq.mdx`, and `error-codes.mdx`, and add `Sinch Engage` keywords to `sms-deliverability.mdx` and `user-communication.mdx`.

Two screenshots are still required and are marked in the MDX with visible `<Aside type="danger">` callouts so they cannot be merged unnoticed. Both should be captured on a paid plan, since the Free plan renders an upgrade banner above the form:

- The `Provider` dropdown expanded, showing `Kinde default`, `Twilio`, and `Sinch Engage`.
- The Sinch Engage panel, showing all five fields.

Notes on scope:

- The Management and Frontend API references are intentionally unchanged, as that content is generated from the OpenAPI specifications.
- `sub-processors.mdx` and `sub-processors-interactive.mdx` were reviewed and left untouched. Both already refer to "your own custom SMS provider" and are provider-neutral.
- The `#add-twilio-details` anchor has no references anywhere in the repo. Astro's `redirects` map is path-only and cannot redirect a fragment, so no redirect entry was added.
- No third-party Sinch documentation link is included. `developers.sinch.com` documents the Conversation and Verification APIs rather than Engage, and `developers.messagemedia.com` now redirects to a Zendesk support category. Neither is a confident customer-facing target, so the page links `app.sinch.com` (matching the in-product helper text) and the link decision is left open.

Validation completed:

- `npm run build`
- `node scripts/validate-links.js` — all internal links valid
- `node scripts/check-for-duplicate-page-ids.js` — no duplicates
- Rendered HTML checked for `#set-up-twilio` / `#set-up-sinch-engage` anchor generation, all `<Aside>` blocks rendering as callouts rather than raw JSX, and the `#configure-phone-sms-auth-in-kinde` deep link from `whatsapp-authentication.mdx` still resolving
- `prettier --check` reports the same 5 files as non-compliant both before and after this change, so no new formatting issues are introduced. They are left unformatted to avoid a large unrelated reformatting diff.

Open questions for product:

- Whether Sinch provisions North America-hosted Engage accounts, which would need a third region, and what US customers should be told.
- Kinde's marketing pricing page lists SMS at 7c per message. Worth confirming nothing still published states 5c.

#### Related issues & labels (optional)

- Suggested labels: `Update doc`, `New section`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated phone and passwordless authentication guides to support Twilio and Sinch Engage SMS providers.
  * Added guidance for provider setup, credentials, regional settings, source numbers, fallback behavior, provider switching, plan requirements, and testing with Kinde’s default provider.
  * Clarified that phone authentication can be tested on the Free plan, while third-party SMS providers require Kinde Pro or higher and a paid provider account for production.
  * Refreshed production, troubleshooting, error-code, and FAQ guidance with provider-neutral instructions.
  * Improved WhatsApp authentication documentation structure, metadata, configuration guidance, and FAQ navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->