### PR TITLE
feat: document Kinde default SMS for live environments

### DIFF
--- a/src/content/docs/authenticate/about-auth/authentication-methods.mdx
+++ b/src/content/docs/authenticate/about-auth/authentication-methods.mdx
@@ -36,7 +36,7 @@ keywords:
   - social login
   - enterprise SSO
   - OTP
-updated: 2026-03-26
+updated: 2026-09-10
 ---
 
 Kinde supports the following authentication methods.
@@ -77,17 +77,11 @@ Kinde does not currently support magic links as a passwordless authentication me
 
 ## Phone authentication
 
-<Aside>
-
-You need to have a [Twilio](https://www.twilio.com/en-us) account set up before implementing phone authentication in your production environment. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/) for more information.
-
-</Aside>
-
 You can allow users to authenticate using their phone number as their sign in identity. This is a passwordless method. Once set up, users enter their phone number on the sign in screen and then enter a one-time passcode (sent via SMS) on the next screen.
 
 ### Passwordless via SMS
 
-For users to receive a sign in code via SMS, you need to set up a connection to [Twilio](https://www.twilio.com/en-us), who offer a messaging service for authenticating via SMS. You will need a Twilio account to set up this auth option in Kinde. See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/).
+By default, Kinde sends the sign-in code via its own SMS service. You can use this in live environments. For best deliverability, you can optionally connect your own provider — [Twilio](https://www.twilio.com/en-us) or [Sinch Engage](https://developers.app.sinch.com/). See [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/).
 
 Once set up, users will receive a one time code via SMS that enables them to complete the sign up process to your application or site.
 

--- a/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
+++ b/src/content/docs/authenticate/about-auth/kinde-authentication-faq.mdx
@@ -37,7 +37,7 @@ keywords:
   - auth
   - forgot password
   - password reset
-updated: 2026-03-26
+updated: 2026-09-10
 ---
 
 Here are concise answers to common authentication questions. Select a question to expand the answer.
@@ -124,7 +124,7 @@ No. Kinde does not support the Resource Owner Password Credentials (password) OA
 <details>
 <summary><strong>How do I troubleshoot users not receiving Kinde verification codes?</strong></summary>
 
-Ask users to check their spam folder first, as email filtering is a common cause. For SMS codes, confirm network reception and phone number formatting. Verification codes expire after 2 hours, so users may need to request a new code. If you use SMS authentication, verify that your Twilio configuration is correct.
+Ask users to check their spam folder first, as email filtering is a common cause. For SMS codes, confirm network reception and phone number formatting. Verification codes expire after 2 hours, so users may need to request a new code. If you use your own SMS provider, verify that the provider configuration is correct.
 [Passwordless authentication troubleshooting](/authenticate/authentication-methods/passwordless-authentication/)
 </details>
 
@@ -288,7 +288,7 @@ Keep the experience simple and explicit. Display the code prominently, include t
 <details>
 <summary><strong>What do I need to set up Kinde phone authentication for my users?</strong></summary>
 
-You need a paid Twilio business account because SMS delivery has carrier costs. Before setup, confirm whether 10DLC registration is required in your region and review Twilio A2P messaging requirements. Then add your Twilio configuration in Kinde, choose between a Twilio Messaging Service or a specific phone number, and set your default country.
+Kinde’s default SMS service works in live environments on every plan. On the Free plan it is limited to 10 SMS per month. On paid plans it is not capped — see [Kinde pricing](https://kinde.com/pricing/). Connecting your own provider ([Twilio](https://www.twilio.com/en-us) or [Sinch Engage](https://developers.app.sinch.com/)) is recommended for deliverability and sender control, and is a paid-plan feature. If you use Twilio, confirm whether 10DLC registration is required in your region and review Twilio A2P messaging requirements. Then add your SMS configuration in Kinde and set your default country.
 [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
@@ -364,7 +364,7 @@ Users can hit "forgot password" on the sign-in screen and we'll send them a one-
 <details>
 <summary><strong>How should I help users who are not receiving Kinde SMS auth codes?</strong></summary>
 
-Start with the basics - did they enter their phone number correctly with the right country code? Do they have cell reception? Are they in a country where SMS might be restricted? Then check your end - is your Twilio account funded and configured properly? SMS delivery can be finicky, especially internationally, so having backup contact methods is always smart.
+Start with the basics - did they enter their phone number correctly with the right country code? Do they have cell reception? Are they in a country where SMS might be restricted? If you use Kinde’s default SMS service, check the Free plan limit of 10 SMS per month and review [SMS deliverability](/authenticate/authentication-methods/sms-deliverability/). If you use your own provider, check that the account is funded and configured properly. SMS delivery can be finicky, especially internationally, so having backup contact methods is always smart.
 [Phone authentication setup](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
@@ -399,8 +399,8 @@ Common OAuth errors include `invalid_client` (incorrect client credentials), `in
 <details>
 <summary><strong>What should I check in Kinde when users report authentication is not working on mobile?</strong></summary>
 
-For mobile authentication, confirm deep-link configuration and URL schemes for both iOS and Android. Verify redirect URLs follow the expected custom scheme format, such as `myapp://your_kinde_domain.kinde.com/kinde_callback`. Use browser-based flows, because some providers (including Google) do not support webview-based authentication. If users are not receiving verification codes and Twilio is configured, review Twilio delivery logs.
-[React Native SDK](/developer-tools/sdks/native/react-native-sdk/) and [Set up phone auth with Twilio](/authenticate/authentication-methods/phone-authentication/)
+For mobile authentication, confirm deep-link configuration and URL schemes for both iOS and Android. Verify redirect URLs follow the expected custom scheme format, such as `myapp://your_kinde_domain.kinde.com/kinde_callback`. Use browser-based flows, because some providers (including Google) do not support webview-based authentication. If users are not receiving verification codes and you use your own SMS provider, review that provider’s delivery logs.
+[React Native SDK](/developer-tools/sdks/native/react-native-sdk/) and [Set up phone authentication](/authenticate/authentication-methods/phone-authentication/)
 </details>
 
 <details>

--- a/src/content/docs/authenticate/about-auth/user-communication.mdx
+++ b/src/content/docs/authenticate/about-auth/user-communication.mdx
@@ -28,8 +28,9 @@ keywords:
   - OTP
   - verification
   - Twilio
+  - Sinch Engage
   - webhooks
-updated: 2026-03-03
+updated: 2026-09-10
 ---
 
 Kinde only sends emails or texts to users as part of the authentication experience, for example to send one-time passwords or to verify user identity for self-sign-up.

--- a/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/passwordless-authentication.mdx
@@ -27,7 +27,7 @@ keywords:
   - email code
   - phone code
   - security
-updated: 2025-01-16
+updated: 2026-09-10
 ---
 
 Passwordless authentication is a type of authentication that does not require end-users to set or maintain passwords for access to an application. Instead, they authenticate using a one-time passcode (OTP).
@@ -60,16 +60,16 @@ Passcodes issued from Kinde expire after 2 hours.
    1. Select which applications will use this authentication method.
    2. Select **Save**.
 
+   <Aside>
+
+   Kinde’s default SMS service works in live environments. On the Free plan it is limited to 10 SMS per month. On paid plans it is not capped — see [Kinde pricing](https://kinde.com/pricing/). Connecting your own provider (Twilio or Sinch Engage) is recommended for deliverability and is a paid-plan feature. [Learn more](/authenticate/authentication-methods/phone-authentication/).
+
+   </Aside>
+
 5. If you select the **Username + code** tile:
 
    1. Select which applications will use this authentication method.
    2. Select **Save**.
-
-   <Aside>
-
-   **You can test this feature** but passwordless phone authentication requires that you have a [Twilio](https://www.twilio.com/en-us) account. You need to enter your Twilio account details and [upgrade to Kinde Pro](https://kinde.com/pricing/) if you want your users to authenticate this way. [Learn more](/authenticate/authentication-methods/phone-authentication/).
-
-   </Aside>
 
 ## If a user does not receive a code
 

--- a/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/phone-authentication.mdx
@@ -8,8 +8,9 @@ relatedArticles:
   - 26e55a64-13dd-4c7b-b9ad-e7595903ddc8
   - 90f45d2e-cf59-4b5e-a26b-6dafd772e893
 description: >-
-  Complete setup guide for phone/SMS authentication using Twilio, including
-  configuration, MFA integration, and message formatting.
+  Complete setup guide for phone/SMS authentication using Kinde default SMS,
+  Twilio, or Sinch Engage, including configuration, MFA integration, and
+  message formatting.
 featured: false
 deprecated: false
 topics:
@@ -24,50 +25,64 @@ keywords:
   - phone authentication
   - SMS
   - Twilio
+  - Sinch Engage
   - MFA
   - A2P messaging
   - 10DLC
   - verification code
-updated: 2026-03-03
+updated: 2026-09-10
 ---
 
-You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up. 
+You can allow users to use their phone as a primary method for authentication. This is a passwordless method, where the user is sent a verification code via SMS (or [WhatsApp](/authenticate/authentication-methods/whatsapp-authentication/) when configured). SMS can also be included as a secondary factor if you have [multi-factor authentication](/authenticate/multi-factor-auth/about-multi-factor-authentication/) set up.
 
-<Aside>
+## Kinde default SMS
 
-This feature requires paid third-party services to use. Rates and limitations apply.
+By default, Kinde sends authentication SMS from its own shared service. You can use this in live environments on every plan. You do not need a third-party SMS provider to go live.
+
+- On the **Free** plan, Kinde default SMS is limited to 10 SMS per month.
+- On **paid** plans (Pro, Plus, Scale), Kinde default SMS is not capped. Usage is billed per message — see [Kinde pricing](https://kinde.com/pricing/).
+- SMS sent as a second factor for MFA through Kinde’s default service counts toward the same Free plan limit and paid-plan usage as sign-in SMS.
+
+Free plans cannot connect their own SMS provider.
+
+## Bring your own SMS provider (recommended)
+
+We recommend connecting your own SMS provider for best deliverability, and so you can control the sender ID or from number. Your own provider is uncapped and is not billed by Kinde. This is a recommendation, not a requirement.
+
+Kinde supports:
+
+- [Twilio](https://www.twilio.com/en-us)
+- [Sinch Engage](https://developers.app.sinch.com/)
+
+<Aside type="upgrade">
+
+Connecting your own SMS provider requires a [Kinde paid plan](https://kinde.com/pricing/). Free plans cannot connect Twilio or Sinch Engage.
 
 </Aside>
 
-## (Existing phone auth Twilio users only) Switch on SMS for MFA
+### Benefits of using a third-party SMS service instead of Kinde
+
+- Gives you full control over the SMS delivery nuances, such as SenderID, country registrations, and detailed delivery metrics.
+- You can register dedicated short codes or sender IDs in countries that have strict SMS sending regulations like Ireland, NZ and Canada, which will greatly improve deliverability.
+- Access to delivery logs and other service quality details for troubleshooting.
+
+## Switch on SMS for MFA
+
+If you want phone authentication SMS and MFA SMS to use the same provider:
 
 1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
 2. Scroll to the bottom and switch on the **Use this service for SMS MFA** option.
 3. Select **Save**.
 
-## Benefits of using a third-party SMS service instead of Kinde
+## Set up Twilio
 
-- Gives you full control over the SMS delivery nuances, such as SenderID, country registrations, and detailed delivery metrics. 
-- You can register dedicated short codes or sender IDs in countries that have strict SMS sending regulations like Ireland, NZ and Canada, which will greatly improve deliverability.
-- Access to delivery logs and other service quality details for troubleshooting.
-
-## SMS provider requirements (Twilio)
-
-SMS authentication requires the services of a messaging provider, in this case, [Twilio](https://www.twilio.com/en-us).
-
-You need a [Twilio](https://www.twilio.com/en-us) business account to ensure messaging works for local and overseas phone numbers.
+You need a [Twilio](https://www.twilio.com/en-us) business account to send from your own numbers.
 
 Phone authentication interactions are also known as [A2P (Application to Person)](https://www.twilio.com/docs/glossary/what-a2p-sms-application-person-messaging) messaging. Before you implement A2P, check if you need to register your business for 10DLC (10 Digit Long Code) support to be able to send messages, as this is required in some locations.
 
 We also recommend you check [Twilio’s guidelines for setting up messaging](https://www.twilio.com/en-us/guidelines/sms), and carefully follow procedures for registration, and SMS policies for all relevant countries.
 
-## What you need
-
-<Aside>
-
-If you just want to test this feature first, Kinde allows you to send 10 SMS messages per month without setting up Twilio. If you want the feature to be live for your users, you must implement the full Twilio setup.
-
-</Aside>
+### What you need
 
 You’ll need the following details that are in the dashboard of your [Twilio account](https://www.twilio.com/en-us).
 
@@ -79,17 +94,15 @@ You’ll need the following details that are in the dashboard of your [Twilio ac
 
 Refer to the [Twilio documentation](https://www.twilio.com/docs/messaging/services/tutorials/send-messages-with-messaging-services) for assistance setting up.
 
-## Configure phone SMS auth in Kinde
-
-After you set this up, you can use SMS for both phone authentication and SMS MFA.
+### Configure Twilio
 
 1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
-2. Select the **Default country** that you want to show on the authentication screen when users sign in.
-3. Enter the Twilio details from your Twilio account (see above) in the relevant fields.
+2. Select **Twilio** in the **Provider** field.
+3. Enter the **Account SID** and **Auth token** from your Twilio account.
 
    ![twilio details](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/4c857ff9-ff87-44ea-a488-3e2b511caf00/public)
- 
-4. In the **SMS source** field, select either the **Use** **Messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
+
+4. In the **SMS source** field, select either **Use messaging service** or **Use phone number**. Verification codes will be sent from whichever you choose.
 
    <Aside>
 
@@ -101,15 +114,71 @@ After you set this up, you can use SMS for both phone authentication and SMS MFA
 
    ![Twilio config](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/749a80bc-d6b7-40b0-950a-650c7775b900/public)
 
-6. Select if you want to use a fallback service if the provider service is interrupted.
+6. Select if you want to use a fallback service if the provider service is interrupted. Fallback uses Kinde’s default SMS service.
 
    ![option to use kinde sms as fallback](https://imagedelivery.net/skPPZTHzSlcslvHjesZQcQ/9bdd2ef1-c308-4307-c84e-bc8ffdbfe200/public)
 
 7. Select **Save**.
 
-## Switch on phone authentication for an application
+<Aside>
 
-After you have set up Twilio details, you’re ready to switch on phone or SMS auth for your applications.
+For security, Kinde never displays a stored auth token, so the **Auth token** field is blank when you return to the page. If Twilio is already your selected provider, leave it blank to keep the token you saved earlier. If you are switching to Twilio from another provider, you must enter the auth token.
+
+</Aside>
+
+## Set up Sinch Engage
+
+You need a [Sinch Engage](https://app.sinch.com) account. See the [Sinch Engage API](https://developers.app.sinch.com/) for account and credential details.
+
+### What you need
+
+- An **API key**, created under **Settings > API Settings** in your Sinch Engage account
+- The **API secret** created alongside that key. Sinch only shows the secret once, when the key is created, so store it somewhere safe
+- The region your Sinch Engage account is hosted in — **APAC** or **EU**
+- Optionally, a **source number** and **source number type** if you want to send from a specific sender
+
+<Aside>
+
+**Account region** is where your Sinch Engage account is hosted — it selects the API endpoint Kinde calls. It is not a restriction on where you can send messages.
+
+</Aside>
+
+### Configure Sinch Engage
+
+1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
+2. Select **Sinch Engage** in the **Provider** field.
+3. Enter your **API key**.
+4. Enter your **API secret**.
+5. Select your **Account region** — **APAC** or **EU**. This must match the region your Sinch Engage account is hosted in.
+6. Optionally enter a **Source number**. Leave it blank to use your account default.
+7. If you entered a source number, select the **Source number type**.
+8. Select if you want to use a fallback service if the provider service is interrupted. Fallback uses Kinde’s default SMS service.
+9. Select **Save**.
+
+<Aside>
+
+For security, Kinde never displays a stored API secret, so the **API secret** field is blank when you return to the page. If Sinch Engage is already your selected provider, leave **API secret** blank to keep the secret you saved earlier. If you are switching to Sinch Engage from another provider, you must enter the **API secret**.
+
+</Aside>
+
+## Configure phone SMS auth in Kinde
+
+After you set this up, you can use SMS for both phone authentication and SMS MFA.
+
+1. In Kinde, go to **Settings > Environment > Messaging > SMS**.
+2. Select the **Default country** that you want to show on the authentication screen when users sign in.
+3. Select a **Provider**:
+
+   - **Kinde default** — uses Kinde’s own SMS service. No credentials are needed. This works in live environments.
+   - **Twilio** — your own Twilio account. See [Set up Twilio](#set-up-twilio).
+   - **Sinch Engage** — your own Sinch Engage account. See [Set up Sinch Engage](#set-up-sinch-engage).
+
+   The fields below the selector change to match the provider you choose.
+
+4. If you selected your own provider, enter the credentials and choose whether to use a fallback service if the provider is interrupted.
+5. Select **Save**.
+
+## Switch on phone authentication for an application
 
 1. Go to **Settings > Environment > Authentication**.
 2. In the **Passwordless** section, select **Configure** on the **Phone** tile.
@@ -118,7 +187,7 @@ After you have set up Twilio details, you’re ready to switch on phone or SMS a
 
 ## Switch on SMS as a factor in MFA
 
-If MFA is required or optional for your users, you may want to use the Twilio service for SMS MFA.
+If MFA is required or optional for your users, you may want to use Kinde default SMS or your own SMS provider for SMS MFA.
 
 1. Go to **Settings > Environment > Multi-factor auth**.
 2. Under **Additional authentication methods**, switch on **SMS**.

--- a/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
+++ b/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
@@ -87,7 +87,7 @@ The content of the SMS is not editable due to strict one-time passcode requireme
 An example of the SMS content is below.
 
 ```
-123456 is your one-time code to sign in to {Business Name} 
+123456 is your one-time code to sign in to {Business Name}
 
 @business.kinde.com #123456
 ```

--- a/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
+++ b/src/content/docs/authenticate/authentication-methods/sms-deliverability.mdx
@@ -23,11 +23,12 @@ complexity: intermediate
 keywords:
   - SMS deliverability
   - Twilio
+  - Sinch Engage
   - sender ID
   - regional delivery
   - 10DLC
   - A2P messaging
-updated: 2026-03-03
+updated: 2026-09-10
 ---
 
 Kinde encourages customers to configure their own SMS sender, so that verification, country registrations, sender IDs, and deliverability metrics are controlled and managed by you.
@@ -40,7 +41,7 @@ This topic describes SMS delivery via Kinde, deliverability factors, and some co
 
 By default, when you first start using Kinde, all SMS messages are sent from Kinde's shared service provider. We recommend configuring your own SMS sender so that users receive authentication messages branded with your business.
 
-Configure this before your production environment goes live. Add your SMS details under **Settings > Environment > Messaging > SMS**. See [Set up phone or SMS authentication](/authenticate/authentication-methods/phone-authentication/) for step-by-step instructions.
+We recommend configuring your own provider for production traffic, so you control deliverability and the sender ID. Add your SMS details under **Settings > Environment > Messaging > SMS**. See [Set up phone or SMS authentication](/authenticate/authentication-methods/phone-authentication/) for step-by-step instructions.
 
 ## Deliverability factors when using Kinde's default SMS shared service provider
 

--- a/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
@@ -28,7 +28,7 @@ keywords:
   - Meta
   - WhatsApp Business
   - messaging
-updated: 2026-03-03
+updated: 2026-09-10
 ---
 
 You can send one-time passcodes (OTP) and multi-factor authentication (MFA) codes via **WhatsApp** in addition to SMS. When WhatsApp is set up and enabled, Kinde prefers WhatsApp for delivering codes and falls back to SMS if WhatsApp delivery fails and SMS is configured.
@@ -55,7 +55,7 @@ After saving, Kinde sends OTP and MFA codes through WhatsApp when available, and
 
 ### Do I need a paid Kinde plan to use WhatsApp authentication?
 
-WhatsApp authentication is free to use in Kinde, but the number of messages you can send is subject to the same monthly limit as SMS (10 messages per month). WhatsApp is a bring-your-own-provider integration, and Meta charges separately for each message sent. See [WhatsApp pricing](https://developers.facebook.com/docs/whatsapp/pricing) for details.
+WhatsApp authentication is free to use in Kinde, but is subject to the Free plan limit of 10 messages per month. WhatsApp is a bring-your-own-provider integration, and Meta charges separately for each message sent. See [WhatsApp pricing](https://developers.facebook.com/docs/whatsapp/pricing) for details.
 
 ### Can I change the language of the WhatsApp messages?
 

--- a/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
+++ b/src/content/docs/authenticate/authentication-methods/whatsapp-authentication.mdx
@@ -61,7 +61,6 @@ WhatsApp authentication is free to use in Kinde, but is subject to the Free plan
 
 Yes, you can change the language by going to **Kinde > Settings > Environment > Languages**. After changing languages, run **Sync WhatsApp** again so template languages are updated. If a configured language is not supported by WhatsApp, Kinde falls back to **en-US**.
 
-
 ## Troubleshooting
 
 ### Templates fail to create or sync

--- a/src/content/docs/authenticate/multi-factor-auth/about-multi-factor-authentication.mdx
+++ b/src/content/docs/authenticate/multi-factor-auth/about-multi-factor-authentication.mdx
@@ -37,7 +37,7 @@ keywords:
   - email
   - recovery codes
   - security
-updated: 2025-01-16
+updated: 2026-09-10
 ---
 
 To increase security for your product, you can enable multi-factor authentication (MFA). This means that your users sign in using at least two authentication methods, for example, password _plus_ verification code.
@@ -74,6 +74,7 @@ We suggest you advise users ahead of time if you are changing your sign-in requi
 ### MFA **using SMS verification**
 
 - A code is sent via SMS that the user must enter into the verification code field on the sign up / sign in screen.
+- SMS sent through Kinde’s default service counts toward the same [phone authentication](/authenticate/authentication-methods/phone-authentication/) SMS allowance as sign-in SMS.
 
 ## **Recovery codes**
 

--- a/src/content/docs/build/environments/production-to-live.mdx
+++ b/src/content/docs/build/environments/production-to-live.mdx
@@ -33,13 +33,13 @@ keywords:
   - multi-factor authentication
   - terms of use and privacy policy
   - default roles
-  - twilio sms authentication
+  - SMS authentication
   - custom email sender
   - google analytics
-updated: 2026-05-27
+updated: 2026-09-10
 featured: false
 deprecated: false
-ai_summary: "This guide helps you prepare a Kinde production environment before marking it as Live. It covers required setup for third-party authentication credentials and Twilio SMS configuration, then walks through recommended business readiness steps in priority order. These include adding terms and privacy policy URLs, enabling multi-factor authentication, setting default roles, connecting a custom domain, configuring a branded email sender, adding tracking scripts, and creating additional development environments. The page also clarifies that the Live switch is a status indicator only and does not publish or change app behavior."
+ai_summary: "This guide helps you prepare a Kinde production environment before marking it as Live. It covers required setup for third-party authentication credentials, then walks through recommended business readiness steps in priority order. These include adding terms and privacy policy URLs, enabling multi-factor authentication, setting default roles, connecting a custom domain, configuring a branded email sender, optionally connecting your own SMS provider for deliverability, adding tracking scripts, and creating additional development environments. The page also clarifies that the Live switch is a status indicator only and does not publish or change app behavior."
 ---
 
 Use this checklist to prepare your Kinde production environment before you mark it as `Live`.
@@ -74,19 +74,22 @@ Enter a `Client ID` and `Client secret` in all your third-party authentication c
 
 Check out the specific connection page for steps for each provider in the [third-party authentication](/authenticate/authentication-methods/set-up-user-authentication/) section.
 
+## Recommended steps
 
-### Add Twilio details
+### Configure your own SMS provider (recommended)
 
-If you are using phone or SMS authentication, configure your Twilio details. Kinde provides 10 SMS messages per month for free to test this feature. To use the full feature set, enter your Twilio credentials:
+Kinde’s default SMS service works in live environments. You do not need a third-party provider to go live.
+
+On the Free plan, default SMS is limited to 10 messages per month. On paid plans, default SMS is not capped — see [Kinde pricing](https://kinde.com/pricing/).
+
+If you use phone or SMS authentication, we recommend connecting your own provider ([Twilio](https://www.twilio.com/en-us) or [Sinch Engage](https://developers.app.sinch.com/)) for best deliverability and so you can control the sender ID or from number. Connecting your own provider is a paid-plan feature.
 
 1. Go to **Settings > Environment > Messaging > SMS**.
 2. Select the **Default country** that you want to show on the authentication screen when users sign in.
-3. Enter the Twilio details from your Twilio account in the relevant fields.
+3. Select **Twilio** or **Sinch Engage** in the **Provider** field and enter your credentials.
 4. Select **Save**.
 
 Learn more about [phone or SMS authentication](/authenticate/authentication-methods/phone-authentication/).
-
-## Recommended steps
 
 ### Add terms and policy URLs
 

--- a/src/content/docs/get-started/guides/error-codes.mdx
+++ b/src/content/docs/get-started/guides/error-codes.mdx
@@ -23,7 +23,7 @@ keywords:
   - oauth errors
   - verification codes
   - token errors
-updated: 2026-05-29
+updated: 2026-09-10
 featured: false
 deprecated: false
 ai_summary: Comprehensive troubleshooting guide for common Kinde error codes including authentication, SAML, OAuth, and verification issues.
@@ -74,7 +74,7 @@ Verification codes are sent almost immediately when triggered. If a code is not 
 - Full storage preventing new messages from being received
 - Phone numbers in certain countries do sometimes experience issues. Contact us if you think this might be the case. 
 
-We recommend using [Twilio](/authenticate/authentication-methods/phone-authentication/), a third-party SMS provider instead of Kinde's default service. This makes troubleshooting issues and accessing logs much easier.
+We recommend [connecting your own SMS provider](/authenticate/authentication-methods/phone-authentication/) — Twilio or Sinch Engage — for better deliverability and so you can access delivery logs. This is a recommendation, not a requirement; Kinde’s default SMS service works in live environments.
 
 ## Email verification error code 123f11e6453744da8069f1a6d65247ba
 


### PR DESCRIPTION
#### Description (required)

Kinde default SMS now works in live environments on every plan. The docs still said a Twilio account was required to go live, and they did not mention Sinch Engage.

This update is for anyone setting up phone, SMS, or SMS MFA auth — especially teams on Free or going to production without a third-party provider.

How:

- Document Kinde default SMS as live-ready: Free plan 10 SMS per month; paid plans uncapped, billed per the [Kinde pricing](https://kinde.com/pricing/) page
- Document optional BYO (Twilio or Sinch Engage) as a paid-plan recommendation for deliverability and sender ID control, not a go-live requirement
- Add Sinch Engage setup (API key, API secret, APAC or EU region, optional source number and type)
- Note that MFA SMS through Kinde default counts toward the same allowance as sign-in SMS
- Align go-live, passwordless, FAQ, error codes, WhatsApp, and deliverability pages with the same rules

#### Related issues & labels (optional)

- Suggested label: Update doc

Related: #807 also adds Sinch Engage, but still treats a third-party provider as required to go live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance to support Kinde’s default SMS service, Twilio, and Sinch Engage.
  * Documented Free plan SMS limits, paid-plan allowances, provider configuration, and deliverability recommendations.
  * Expanded phone authentication and SMS MFA setup instructions across supported providers.
  * Updated troubleshooting guidance, FAQs, production setup instructions, and related metadata.
  * Clarified WhatsApp authentication limits and SMS allowance usage for MFA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->