### PR TITLE
fix(react): clarify ProtectedRoute requires all specified roles

### DIFF
--- a/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
+++ b/src/content/docs/developer-tools/sdks/frontend/react-sdk.mdx
@@ -508,7 +508,7 @@ import { ProtectedRoute } from '@kinde-oss/kinde-auth-react/react-router';
   <AdminDashboard />
 </ProtectedRoute>
 
-// Protect with multiple roles (user must have at least one)
+// Protect with multiple roles (user must have all specified roles)
 <ProtectedRoute has={{ roles: ['admin', 'moderator'] }} fallbackPath="/">
   <ModeratorPanel />
 </ProtectedRoute>


### PR DESCRIPTION
<!-- Thank you for opening a PR -->

#### Description (required)

This PR corrects the comment in the React SDK `<ProtectedRoute>` example. 

The example previously stated "user must have at least one" for multiple roles in the array, but has() / hasRoles evaluates roles with .every(), requiring the user to have all specified roles.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that users must have all specified roles to access a protected route when multiple roles are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->